### PR TITLE
Polish UI, Rename Sessions, Markdown Output Support, Queued Messages

### DIFF
--- a/AutoPilot.App.csproj
+++ b/AutoPilot.App.csproj
@@ -68,6 +68,7 @@
 
     <ItemGroup>
         <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.22" />
+        <PackageReference Include="Markdig" Version="0.40.0" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />

--- a/Components/Layout/SessionSidebar.razor
+++ b/Components/Layout/SessionSidebar.razor
@@ -2,16 +2,17 @@
 @using AutoPilot.App.Models
 @inject CopilotService CopilotService
 @inject IJSRuntime JS
+@inject NavigationManager Nav
 
 <div class="sidebar-content">
     <div class="sidebar-header">
-        <h3>🤖 AutoPilot</h3>
+        <h3><svg style="vertical-align:middle" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect x="2" y="8" width="20" height="8" rx="2"/><path d="M6 16v4"/><path d="M18 16v4"/><circle cx="9" cy="12" r="1" fill="currentColor"/><circle cx="15" cy="12" r="1" fill="currentColor"/></svg> AutoPilot</h3>
         <p class="status @(CopilotService.IsInitialized ? "connected" : "disconnected")">
             @(CopilotService.IsInitialized ? "● Connected" : "○ Disconnected")
         </p>
         <div class="nav-tabs">
-            <a href="/" class="nav-tab" @onclick='() => CopilotService.SaveUiState("/")'>💬 Chat</a>
-            <a href="/dashboard" class="nav-tab" @onclick='() => CopilotService.SaveUiState("/dashboard")'>🎛️ Dashboard</a>
+            <a href="/" class="nav-tab @(currentPage == "/" ? "active" : "")" @onclick='() => { CopilotService.SaveUiState("/"); currentPage = "/"; }'><svg style="vertical-align:middle" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg> Chat</a>
+            <a href="/dashboard" class="nav-tab @(currentPage == "/dashboard" ? "active" : "")" @onclick='() => { CopilotService.SaveUiState("/dashboard"); currentPage = "/dashboard"; }'><svg style="vertical-align:middle" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg> Dashboard</a>
         </div>
     </div>
 
@@ -25,7 +26,7 @@
                     <option value="@model">@model</option>
                 }
             </select>
-            <button class="dir-toggle-btn" @onclick="ToggleDirectoryInput" title="Set working directory">📂</button>
+            <button class="dir-toggle-btn" @onclick="ToggleDirectoryInput" title="Set working directory"><svg style="vertical-align:middle" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg></button>
             <button @onclick="CreateSession" disabled="@isCreating">
                 @(isCreating ? "..." : "+")
             </button>
@@ -36,13 +37,15 @@
                 <input type="text" id="sessionDirInput"
                        placeholder="Working directory (default: AutoPilot.App)" 
                        class="dir-input" />
-                <button class="dir-browse-btn" @onclick="BrowseDirectory" title="Browse folders">📁</button>
+                <button class="dir-browse-btn" @onclick="BrowseDirectory" title="Browse folders"><svg style="vertical-align:middle" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/><line x1="12" y1="11" x2="12" y2="17"/><line x1="9" y1="14" x2="15" y2="14"/></svg></button>
             </div>
         }
     </div>
 
+    <div class="sidebar-divider"></div>
+
     <div class="session-list">
-        <div class="section-header">Active Sessions</div>
+        <div class="section-header"><span class="section-header-label"><svg style="vertical-align:middle" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg> Active Sessions</span></div>
         @if (!sessions.Any())
         {
             <p class="no-sessions">No active sessions.<br/>Create one above or resume below.</p>
@@ -60,9 +63,20 @@
                         <span class="session-name">
                             @if (completedSessions.Contains(session.Name))
                             {
-                                <span class="done-badge">✓</span>
+                                <span class="done-badge"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span>
                             }
-                            @session.Name
+                            @if (renamingSession == session.Name)
+                            {
+                                <input type="text" class="rename-input" id="renameInput"
+                                       value="@session.Name"
+                                       @onclick:stopPropagation="true"
+                                       @onblur="CommitRename"
+                                       @onkeydown="HandleRenameKeyDown" />
+                            }
+                            else
+                            {
+                                <span @ondblclick="() => StartRename(session.Name)" @ondblclick:stopPropagation="true">@session.Name</span>
+                            }
                             @if (session.IsResumed)
                             {
                                 <span class="resumed-badge">resumed</span>
@@ -81,6 +95,8 @@
                         {
                             <span class="processing">●</span>
                         }
+                        <button class="rename-btn" @onclick:stopPropagation="true"
+                                @onclick="() => StartRename(session.Name)" title="Rename session"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></button>
                         <button class="close-btn" @onclick:stopPropagation="true" 
                                 @onclick="() => CloseSession(session.Name)">×</button>
                     </div>
@@ -90,8 +106,9 @@
 
         @if (persistedSessions.Any())
         {
+            <div class="sidebar-divider"></div>
             <div class="section-header" @onclick="TogglePersistedSessions" style="cursor: pointer;">
-                📁 Saved Sessions (@filteredPersistedSessions.Count())
+                <span class="section-header-label"><svg style="vertical-align:middle" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg> Saved Sessions (@filteredPersistedSessions.Count())</span>
                 <span class="toggle-icon">@(showPersistedSessions ? "▼" : "▶")</span>
             </div>
             
@@ -99,7 +116,7 @@
             {
                 <div class="filter-box">
                     <input type="text" @bind="sessionFilter" @bind:event="oninput" 
-                           placeholder="🔍 Filter sessions..." class="filter-input" />
+                           placeholder="Filter sessions..." class="filter-input" />
                 </div>
                 
                 @foreach (var persisted in filteredPersistedSessions.Take(30))
@@ -117,7 +134,7 @@
                                 }
                             </span>
                         </div>
-                        <span class="resume-icon">↻ Resume</span>
+                        <span class="resume-icon"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg> Resume</span>
                     </div>
                 }
             }
@@ -132,6 +149,8 @@
     private bool isCreating = false;
     private bool showPersistedSessions = false;
     private bool showDirectoryInput = false;
+    private string? renamingSession = null;
+    private string currentPage = "/";
     private List<AgentSessionInfo> sessions = new();
     private List<PersistedSessionInfo> persistedSessions = new();
 
@@ -159,6 +178,8 @@
 
     protected override void OnInitialized()
     {
+        currentPage = new Uri(Nav.Uri).AbsolutePath;
+        Nav.LocationChanged += (_, e) => { currentPage = new Uri(e.Location).AbsolutePath; InvokeAsync(StateHasChanged); };
         CopilotService.OnStateChanged += RefreshSessions;
         CopilotService.OnSessionComplete += HandleSessionComplete;
         RefreshSessions();
@@ -293,6 +314,43 @@
         finally
         {
             isCreating = false;
+        }
+    }
+
+    private async Task StartRename(string sessionName)
+    {
+        renamingSession = sessionName;
+        StateHasChanged();
+        // Focus the input after render
+        await Task.Yield();
+        await JS.InvokeVoidAsync("eval", @"
+            var el = document.getElementById('renameInput');
+            if (el) { el.focus(); el.select(); }
+        ");
+    }
+
+    private async Task CommitRename()
+    {
+        if (renamingSession == null) return;
+        var oldName = renamingSession;
+        renamingSession = null;
+
+        var newName = await JS.InvokeAsync<string>("eval", "document.getElementById('renameInput')?.value || ''");
+        if (!string.IsNullOrWhiteSpace(newName) && newName.Trim() != oldName)
+        {
+            CopilotService.RenameSession(oldName, newName.Trim());
+        }
+    }
+
+    private async Task HandleRenameKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+        {
+            await CommitRename();
+        }
+        else if (e.Key == "Escape")
+        {
+            renamingSession = null;
         }
     }
 

--- a/Components/Layout/SessionSidebar.razor.css
+++ b/Components/Layout/SessionSidebar.razor.css
@@ -11,6 +11,18 @@
     border-bottom: 1px solid rgba(255,255,255,0.1);
 }
 
+.sidebar-divider {
+    min-height: 1px;
+    height: 1px;
+    background: rgba(255,255,255,0.15);
+    margin: 0;
+    flex-shrink: 0;
+}
+
+.session-list > .sidebar-divider {
+    margin: 0.5rem -0.5rem;
+}
+
 .sidebar-header h3 {
     margin: 0 0 0.5rem 0;
     font-size: 1.4rem;
@@ -33,7 +45,6 @@
     display: flex;
     gap: 0.5rem;
     padding: 1rem;
-    border-bottom: 1px solid rgba(255,255,255,0.1);
     flex-wrap: wrap;
 }
 
@@ -147,13 +158,20 @@
 
 .section-header {
     padding: 0.5rem 0.75rem;
-    font-size: 1rem;
+    font-size: 0.8rem;
     font-weight: 600;
     text-transform: uppercase;
+    letter-spacing: 0.03em;
     color: rgba(255,255,255,0.5);
     display: flex;
     justify-content: space-between;
     align-items: center;
+}
+
+.section-header-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
 }
 
 .toggle-icon {
@@ -250,7 +268,7 @@
     50% { opacity: 0.5; }
 }
 
-.close-btn, .resume-btn {
+.close-btn, .resume-btn, .rename-btn {
     width: 1.5rem;
     height: 1.5rem;
     border: none;
@@ -265,13 +283,23 @@
 }
 
 .session-item:hover .close-btn,
-.session-item:hover .resume-btn {
+.session-item:hover .resume-btn,
+.session-item:hover .rename-btn {
     opacity: 1;
 }
 
 .close-btn:hover {
     background: rgba(239, 68, 68, 0.3);
     color: #ef4444;
+}
+
+.rename-btn:hover {
+    background: rgba(59, 130, 246, 0.3);
+    color: #60a5fa;
+}
+
+.rename-btn {
+    font-size: 0.8rem;
 }
 
 .resume-btn:hover {
@@ -339,6 +367,8 @@
     display: flex;
     gap: 0.5rem;
     margin-top: 0.75rem;
+    --bs-nav-tabs-border-color: transparent;
+    border-bottom: none;
 }
 
 .nav-tab {
@@ -346,7 +376,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 0.4rem;
     padding: 0.5rem;
+    border: 1px solid transparent;
     border-radius: 6px;
     background: rgba(255,255,255,0.08);
     color: rgba(255,255,255,0.7);
@@ -359,4 +391,23 @@
 .nav-tab:hover {
     background: rgba(255,255,255,0.15);
     color: white;
+}
+
+.nav-tab.active {
+    background: rgba(59, 130, 246, 0.25);
+    color: #60a5fa;
+    border: 1px solid rgba(59, 130, 246, 0.4);
+}
+
+.rename-input {
+    width: 100%;
+    padding: 0.2rem 0.4rem;
+    border: 1px solid #60a5fa;
+    border-radius: 4px;
+    background: rgba(255,255,255,0.15);
+    color: white;
+    font-size: 1rem;
+    font-weight: 500;
+    font-family: inherit;
+    outline: none;
 }

--- a/Components/Pages/Dashboard.razor
+++ b/Components/Pages/Dashboard.razor
@@ -7,7 +7,7 @@
 
 <div class="dashboard">
     <div class="dashboard-header">
-        <h2>🎛️ Session Orchestrator</h2>
+        <h2><svg style="vertical-align:middle" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg> Session Orchestrator</h2>
         <span class="session-count">@sessions.Count active sessions</span>
     </div>
 
@@ -30,8 +30,8 @@
                             <span class="card-status-dot @cardClass"></span>
                             <h3>@session.Name</h3>
                         </div>
-                        <button class="card-close" @onclick="() => CloseSession(session.Name)" title="Close session">✕</button>
                         <span class="card-model">@session.Model</span>
+                        <button class="card-close" @onclick="() => CloseSession(session.Name)" title="Close session">✕</button>
                     </div>
 
                     <div class="card-messages">
@@ -46,10 +46,39 @@
                         {
                             @foreach (var msg in lastMessages)
                             {
-                                <div class="card-msg @(msg.IsUser ? "user" : "assistant")">
-                                    <span class="card-msg-role">@(msg.IsUser ? "You" : "AI")</span>
-                                    <span class="card-msg-text">@msg.Content</span>
-                                </div>
+                                @switch (msg.MessageType)
+                                {
+                                    case ChatMessageType.User:
+                                        <div class="card-msg user">
+                                            <span class="card-msg-role">You</span>
+                                            <span class="card-msg-text">@Truncate(msg.Content, 120)</span>
+                                        </div>
+                                        break;
+                                    case ChatMessageType.Assistant:
+                                        <div class="card-msg assistant">
+                                            <span class="card-msg-role">AI</span>
+                                            <span class="card-msg-text">@Truncate(msg.Content, 120)</span>
+                                        </div>
+                                        break;
+                                    case ChatMessageType.ToolCall:
+                                        <div class="card-msg tool">
+                                            <span class="card-msg-role"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg></span>
+                                            <span class="card-msg-text">@(msg.ToolName ?? "tool") @(msg.IsComplete ? (msg.IsSuccess ? "✓" : "✗") : "…")</span>
+                                        </div>
+                                        break;
+                                    case ChatMessageType.Reasoning:
+                                        <div class="card-msg reasoning">
+                                            <span class="card-msg-role"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a8 8 0 0 0-8 8c0 3.4 2.1 6.3 5 7.4V20a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1v-2.6c2.9-1.1 5-4 5-7.4a8 8 0 0 0-8-8z"/><line x1="10" y1="22" x2="14" y2="22"/></svg></span>
+                                            <span class="card-msg-text">@(msg.IsComplete ? "Thought" : "Thinking...")</span>
+                                        </div>
+                                        break;
+                                    case ChatMessageType.Error:
+                                        <div class="card-msg error">
+                                            <span class="card-msg-role"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>
+                                            <span class="card-msg-text">@Truncate(msg.Content, 80)</span>
+                                        </div>
+                                        break;
+                                }
                             }
                         }
                         @if (session.IsProcessing)
@@ -74,7 +103,7 @@
                                disabled="@session.IsProcessing" />
                         <button @onclick="() => SendFromCard(session.Name)"
                                 disabled="@session.IsProcessing">
-                            @(session.IsProcessing ? "⏳" : "➤")
+                            @(session.IsProcessing ? "…" : "➤")
                         </button>
                     </div>
                 </div>
@@ -82,7 +111,7 @@
         </div>
 
         <div class="broadcast-section">
-            <h3>📢 Broadcast to All</h3>
+            <h3><svg style="vertical-align:middle" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5.5 8.5L9 12l-3.5 3.5"/><path d="M2 12h7"/><path d="M14 4.5A7.5 7.5 0 0 1 14 19.5"/><path d="M17.5 2a11 11 0 0 1 0 20"/></svg> Broadcast to All</h3>
             <div class="broadcast-input">
                 <input type="text" id="broadcastInput"
                        placeholder="Send same message to all sessions..." />

--- a/Components/Pages/Dashboard.razor.css
+++ b/Components/Pages/Dashboard.razor.css
@@ -42,6 +42,7 @@
 }
 
 .session-card {
+    position: relative;
     background: rgba(255,255,255,0.05);
     border: 1px solid rgba(255,255,255,0.1);
     border-radius: 12px;
@@ -74,32 +75,27 @@
 
 .card-header {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    flex-wrap: wrap;
-    gap: 0.25rem;
+    gap: 0.5rem;
 }
 
 .card-close {
     background: none;
-    border: 1px solid rgba(255,255,255,0.15);
+    border: none;
     color: rgba(255,255,255,0.4);
     font-size: 0.85rem;
-    width: 24px;
-    height: 24px;
-    border-radius: 6px;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
     cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
     line-height: 1;
+    flex-shrink: 0;
     transition: all 0.15s ease;
 }
 
+.session-card:hover .card-close { }
+
 .card-close:hover {
     background: rgba(239, 68, 68, 0.2);
-    border-color: rgba(239, 68, 68, 0.5);
     color: #ef4444;
 }
 
@@ -107,6 +103,8 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    flex: 1;
+    min-width: 0;
 }
 
 .card-title h3 {

--- a/Components/Pages/Home.razor
+++ b/Components/Pages/Home.razor
@@ -1,6 +1,7 @@
 @page "/"
 @using AutoPilot.App.Services
 @using AutoPilot.App.Models
+@using Markdig
 @inject CopilotService CopilotService
 @inject IJSRuntime JS
 @inject NavigationManager Nav
@@ -22,7 +23,7 @@
     else if (activeSession == null)
     {
         <div class="no-session">
-            <h2>👋 Welcome to AutoPilot</h2>
+            <h2>Welcome to AutoPilot</h2>
             <p>Create a new session from the sidebar to start chatting with Copilot.</p>
         </div>
     }
@@ -33,7 +34,7 @@
             <span class="model-badge">@activeSession.Model</span>
             @if (activeSession.SessionId != null)
             {
-                <span class="session-id-badge" title="@activeSession.SessionId">📎 @activeSession.SessionId[..8]</span>
+                <span class="session-id-badge" title="@activeSession.SessionId"><svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg> @activeSession.SessionId[..8]</span>
             }
             @if (activeSession.IsProcessing)
             {
@@ -42,7 +43,7 @@
         </div>
 
         <div class="messages" @ref="messagesContainer">
-            @if (!activeSession.History.Any())
+            @if (!activeSession.History.Any() && string.IsNullOrEmpty(streamingContent))
             {
                 <div class="empty-chat">
                     <p>Start a conversation with Copilot!</p>
@@ -50,41 +51,123 @@
             }
             else
             {
-                @foreach (var message in activeSession.History)
+                @foreach (var message in activeSession.History.ToList())
                 {
-                    <div class="message @(message.IsUser ? "user" : "assistant")">
-                        <div class="message-avatar">
-                            @(message.IsUser ? "👤" : "🤖")
-                        </div>
-                        <div class="message-content">
-                            <div class="message-text">@((MarkupString)FormatMessage(message.Content))</div>
-                            <div class="message-time">@message.Timestamp.ToString("HH:mm")</div>
-                        </div>
-                    </div>
+                    @switch (message.MessageType)
+                    {
+                        case ChatMessageType.User:
+                            <div class="message user">
+                                <div class="message-avatar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></div>
+                                <div class="message-content">
+                                    <div class="message-text">@((MarkupString)FormatUserMessage(message.Content))</div>
+                                    <div class="message-time">@message.Timestamp.ToString("HH:mm")</div>
+                                </div>
+                            </div>
+                            break;
+
+                        case ChatMessageType.Assistant:
+                            <div class="message assistant">
+                                <div class="message-avatar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect x="2" y="8" width="20" height="8" rx="2"/><path d="M6 16v4"/><path d="M18 16v4"/><circle cx="9" cy="12" r="1" fill="currentColor"/><circle cx="15" cy="12" r="1" fill="currentColor"/></svg></div>
+                                <div class="message-content">
+                                    <div class="message-text markdown-body">@((MarkupString)RenderMarkdown(message.Content))</div>
+                                    <div class="message-time">@message.Timestamp.ToString("HH:mm")</div>
+                                </div>
+                            </div>
+                            break;
+
+                        case ChatMessageType.Reasoning:
+                            <div class="reasoning-block @(message.IsCollapsed && LineCount(message.Content) > 5 ? "collapsed" : "")">
+                                <button class="reasoning-header" @onclick="() => message.IsCollapsed = !message.IsCollapsed">
+                                    <span class="reasoning-title"><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a8 8 0 0 0-8 8c0 3.4 2.1 6.3 5 7.4V20a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1v-2.6c2.9-1.1 5-4 5-7.4a8 8 0 0 0-8-8z"/><line x1="10" y1="22" x2="14" y2="22"/></svg> @(message.IsComplete ? "Thought" : "Thinking...")</span>
+                                    @if (LineCount(message.Content) > 5)
+                                    {
+                                        <span class="collapse-icon">@(message.IsCollapsed ? "▶" : "▼")</span>
+                                    }
+                                </button>
+                                @if (!message.IsCollapsed || LineCount(message.Content) <= 5)
+                                {
+                                    <div class="reasoning-content">@message.Content</div>
+                                }
+                                else
+                                {
+                                    <div class="reasoning-content preview">@FirstLines(message.Content, 3)</div>
+                                }
+                            </div>
+                            break;
+
+                        case ChatMessageType.ToolCall:
+                            @if (message.ToolName == "task_complete")
+                            {
+                                <div class="task-complete-card">
+                                    <svg class="icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#4ade80" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+                                    <span class="task-complete-text">@(string.IsNullOrEmpty(message.Content) || IsUnusableResult(message.Content) ? "Task complete" : message.Content)</span>
+                                </div>
+                            }
+                            else
+                            {
+                            <div class="tool-card @(message.IsComplete ? (message.IsSuccess ? "success" : "error") : "running")">
+                                <div class="tool-header">
+                                    <span class="tool-info"><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg> @FormatToolName(message.ToolName ?? "")</span>
+                                    <span class="tool-status">
+                                        @if (!message.IsComplete)
+                                        {
+                                            <svg class="icon spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.22-8.56"/></svg> <text>Running</text>
+                                        }
+                                        else if (message.IsSuccess)
+                                        {
+                                            <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#4ade80" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg> <text>Done</text>
+                                        }
+                                        else
+                                        {
+                                            <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg> <text>Failed</text>
+                                        }
+                                    </span>
+                                </div>
+                                @if (message.IsComplete && !string.IsNullOrEmpty(message.Content) && !IsUnusableResult(message.Content))
+                                {
+                                    @if (LineCount(message.Content) <= 5)
+                                    {
+                                        <div class="tool-result-section">
+                                            <pre class="tool-result-content">@TruncateResult(message.Content)</pre>
+                                        </div>
+                                    }
+                                    else
+                                    {
+                                        <div class="tool-result-section">
+                                            <button class="tool-result-toggle" @onclick="() => message.IsCollapsed = !message.IsCollapsed">
+                                                @(message.IsCollapsed ? "Show Full Result ▶" : "Collapse ▼")
+                                            </button>
+                                            @if (!message.IsCollapsed)
+                                            {
+                                                <pre class="tool-result-content">@TruncateResult(message.Content)</pre>
+                                            }
+                                            else
+                                            {
+                                                <pre class="tool-result-content preview">@FirstLines(message.Content, 3)</pre>
+                                            }
+                                        </div>
+                                    }
+                                }
+                            </div>
+                            }
+                            break;
+
+                        case ChatMessageType.Error:
+                            <div class="error-card">
+                                <span class="error-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>
+                                <span class="error-text">@message.Content</span>
+                            </div>
+                            break;
+                    }
                 }
+
                 @if (!string.IsNullOrEmpty(streamingContent))
                 {
                     <div class="message assistant streaming">
-                        <div class="message-avatar">🤖</div>
+                        <div class="message-avatar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect x="2" y="8" width="20" height="8" rx="2"/><path d="M6 16v4"/><path d="M18 16v4"/><circle cx="9" cy="12" r="1" fill="currentColor"/><circle cx="15" cy="12" r="1" fill="currentColor"/></svg></div>
                         <div class="message-content">
-                            <div class="message-text">@((MarkupString)FormatMessage(streamingContent))</div>
+                            <div class="message-text markdown-body">@((MarkupString)RenderMarkdown(streamingContent))</div>
                         </div>
-                    </div>
-                }
-                @if (activeSession.IsProcessing)
-                {
-                    <div class="activity-log">
-                        @foreach (var activity in activityLog)
-                        {
-                            <div class="activity-entry">@activity</div>
-                        }
-                        @if (!string.IsNullOrEmpty(currentActivity))
-                        {
-                            <div class="activity-entry current">
-                                <span class="activity-spinner">●</span>
-                                @currentActivity
-                            </div>
-                        }
                     </div>
                 }
             }
@@ -93,21 +176,75 @@
         @if (!string.IsNullOrEmpty(lastError))
         {
             <div class="error-bar">
-                <span>⚠️ @lastError</span>
+                <span><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg> @lastError</span>
                 <button @onclick="() => lastError = null">×</button>
             </div>
         }
 
         <div class="input-area">
-            <textarea @bind="userInput" @bind:event="oninput" 
-                      @onkeydown="HandleKeyDown"
-                      placeholder="Type a message... (Enter to send, Shift+Enter for new line)"
-                      disabled="@activeSession.IsProcessing"
-                      rows="1"></textarea>
-            <button @onclick="SendMessage" 
-                    disabled="@(string.IsNullOrWhiteSpace(userInput) || activeSession.IsProcessing)">
-                @(activeSession.IsProcessing ? "..." : "Send")
-            </button>
+            @if (!string.IsNullOrEmpty(currentIntent))
+            {
+                <div class="intent-pill"><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg> @currentIntent</div>
+            }
+            @if (activeSession.MessageQueue.Any())
+            {
+                <div class="message-queue">
+                    <div class="queue-header">
+                        <span><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg> Queued (@activeSession.MessageQueue.Count)</span>
+                        <button class="queue-clear-btn" @onclick="ClearQueue">Clear</button>
+                    </div>
+                    @for (var i = 0; i < activeSession.MessageQueue.Count; i++)
+                    {
+                        var index = i;
+                        var msg = activeSession.MessageQueue[i];
+                        <div class="queue-item">
+                            <span class="queue-index">@(index + 1)</span>
+                            <span class="queue-text">@Truncate(msg, 80)</span>
+                            <button class="queue-remove-btn" @onclick="() => RemoveQueuedMessage(index)">×</button>
+                        </div>
+                    }
+                </div>
+            }
+            <div class="input-row">
+                <textarea @bind="userInput" @bind:event="oninput" 
+                          @onkeydown="HandleKeyDown" @onkeydown:preventDefault="shouldPreventDefault"
+                          placeholder="@GetInputPlaceholder()"
+                          rows="1"></textarea>
+                <button @onclick="SendMessage" 
+                        disabled="@(string.IsNullOrWhiteSpace(userInput))">
+                    @if (activeSession.IsProcessing)
+                    {
+                        <text>Queue</text>
+                    }
+                    else
+                    {
+                        <text>Send</text>
+                    }
+                </button>
+            </div>
+            <div class="input-status-bar">
+                <button class="plan-icon-toggle @(isPlanMode ? "active" : "")" @onclick="() => isPlanMode = !isPlanMode" title="Toggle planning mode — prefixes messages with [[PLAN]]">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="1.5" width="12" height="13" rx="1.5"/><line x1="5" y1="5" x2="5.01" y2="5"/><line x1="7.5" y1="5" x2="11" y2="5"/><line x1="5" y1="8" x2="5.01" y2="8"/><line x1="7.5" y1="8" x2="11" y2="8"/><line x1="5" y1="11" x2="5.01" y2="11"/><line x1="7.5" y1="11" x2="11" y2="11"/></svg>
+                    <span>Planning</span>
+                </button>
+                <span class="status-sep">·</span>
+                <span class="status-model">@(currentUsage?.Model ?? activeSession.Model)</span>
+                @if (currentUsage != null)
+                {
+                    @if (currentUsage.InputTokens.HasValue || currentUsage.OutputTokens.HasValue)
+                    {
+                        <span class="status-sep">·</span>
+                        <span class="status-tokens">↑@FormatTokenCount(currentUsage.InputTokens ?? 0) ↓@FormatTokenCount(currentUsage.OutputTokens ?? 0)</span>
+                    }
+                    @if (currentUsage.CurrentTokens.HasValue && currentUsage.TokenLimit.HasValue)
+                    {
+                        <span class="status-sep">·</span>
+                        <span class="status-ctx" title="@currentUsage.CurrentTokens.Value / @currentUsage.TokenLimit.Value tokens">@FormatTokenCount(currentUsage.CurrentTokens.Value)/@FormatTokenCount(currentUsage.TokenLimit.Value) ctx</span>
+                    }
+                }
+                <span class="status-sep">·</span>
+                <span class="status-msgs">@activeSession.History.Count msgs</span>
+            </div>
         </div>
     }
     
@@ -121,17 +258,24 @@
 </div>
 
 @code {
+    private static readonly MarkdownPipeline MdPipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .Build();
+
     private AgentSessionInfo? activeSession;
     private string userInput = "";
+    private bool isPlanMode = false;
     private string streamingContent = "";
-    private string currentActivity = "";
-    private List<string> activityLog = new();
+    private string currentIntent = "";
+    private SessionUsageInfo? currentUsage;
     private string? initError;
     private string? lastError;
     private string debugLog = "";
     private ElementReference messagesContainer;
     private bool _needsRedirect;
     private string? _redirectTo;
+    private bool _needsScroll = true;
+    private bool shouldPreventDefault;
 
     protected override async Task OnInitializedAsync()
     {
@@ -140,35 +284,142 @@
         CopilotService.OnSessionComplete += HandleSessionComplete;
         CopilotService.OnError += HandleError;
         CopilotService.OnDebug += HandleDebug;
-        CopilotService.OnActivity += HandleActivity;
+        CopilotService.OnToolStarted += HandleToolStarted;
+        CopilotService.OnToolCompleted += HandleToolCompleted;
+        CopilotService.OnReasoningReceived += HandleReasoningReceived;
+        CopilotService.OnReasoningComplete += HandleReasoningComplete;
+        CopilotService.OnIntentChanged += HandleIntentChanged;
+        CopilotService.OnUsageInfoChanged += HandleUsageInfoChanged;
+        CopilotService.OnTurnStart += HandleTurnStart;
+        CopilotService.OnTurnEnd += HandleTurnEnd;
 
         await Initialize();
     }
 
-    protected override void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (_needsRedirect && _redirectTo != null)
         {
             _needsRedirect = false;
             Nav.NavigateTo(_redirectTo);
         }
+        if (firstRender || _needsScroll)
+        {
+            _needsScroll = false;
+            await ForceScrollToBottom();
+        }
     }
 
-    private void HandleActivity(string sessionName, string activity)
+    private void HandleToolStarted(string sessionName, string toolName, string callId)
     {
-        if (sessionName == CopilotService.ActiveSessionName)
+        if (sessionName != CopilotService.ActiveSessionName) return;
+        var msg = ChatMessage.ToolCallMessage(toolName, callId);
+        activeSession?.History.Add(msg);
+        InvokeAsync(async () => { StateHasChanged(); await ScrollToBottom(); });
+    }
+
+    private void HandleToolCompleted(string sessionName, string callId, string result, bool success)
+    {
+        if (sessionName != CopilotService.ActiveSessionName || activeSession == null) return;
+        var msg = activeSession.History.LastOrDefault(m =>
+            m.MessageType == ChatMessageType.ToolCall && !m.IsComplete &&
+            (!string.IsNullOrEmpty(callId) ? m.ToolCallId == callId : true));
+        if (msg == null)
+            msg = activeSession.History.LastOrDefault(m => m.MessageType == ChatMessageType.ToolCall && !m.IsComplete);
+        if (msg != null)
         {
-            currentActivity = activity;
-            if (!string.IsNullOrEmpty(activity))
-            {
-                activityLog.Add(activity);
-            }
-            InvokeAsync(async () =>
-            {
-                StateHasChanged();
-                await ScrollToBottom();
-            });
+            msg.IsComplete = true;
+            msg.IsSuccess = success;
+            msg.Content = result;
+            msg.IsCollapsed = true;
         }
+        InvokeAsync(async () => { StateHasChanged(); await ScrollToBottom(); });
+    }
+
+    private void HandleReasoningReceived(string sessionName, string reasoningId, string content)
+    {
+        if (sessionName != CopilotService.ActiveSessionName || activeSession == null) return;
+        var msg = activeSession.History.LastOrDefault(m =>
+            m.MessageType == ChatMessageType.Reasoning && m.ReasoningId == reasoningId);
+        if (msg == null)
+        {
+            msg = activeSession.History.LastOrDefault(m => m.MessageType == ChatMessageType.Reasoning && !m.IsComplete);
+        }
+        if (msg == null)
+        {
+            msg = ChatMessage.ReasoningMessage(reasoningId);
+            activeSession.History.Add(msg);
+        }
+        msg.Content += content;
+        InvokeAsync(async () => { StateHasChanged(); await ScrollToBottom(); });
+    }
+
+    private void HandleReasoningComplete(string sessionName, string reasoningId)
+    {
+        if (sessionName != CopilotService.ActiveSessionName || activeSession == null) return;
+        var msg = activeSession.History.LastOrDefault(m =>
+            m.MessageType == ChatMessageType.Reasoning &&
+            (m.ReasoningId == reasoningId || !m.IsComplete));
+        if (msg != null)
+        {
+            msg.IsComplete = true;
+            msg.IsCollapsed = true;
+        }
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleIntentChanged(string sessionName, string intent)
+    {
+        if (sessionName != CopilotService.ActiveSessionName) return;
+        currentIntent = intent;
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleUsageInfoChanged(string sessionName, SessionUsageInfo info)
+    {
+        if (sessionName != CopilotService.ActiveSessionName) return;
+        if (currentUsage == null)
+        {
+            currentUsage = info;
+        }
+        else
+        {
+            currentUsage = new SessionUsageInfo(
+                info.Model ?? currentUsage.Model,
+                info.CurrentTokens ?? currentUsage.CurrentTokens,
+                info.TokenLimit ?? currentUsage.TokenLimit,
+                info.InputTokens ?? currentUsage.InputTokens,
+                info.OutputTokens ?? currentUsage.OutputTokens);
+        }
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleTurnStart(string sessionName)
+    {
+        if (sessionName != CopilotService.ActiveSessionName || activeSession == null) return;
+        // Complete any open reasoning blocks from prior turn
+        foreach (var m in activeSession.History.Where(m => m.MessageType == ChatMessageType.Reasoning && !m.IsComplete))
+        {
+            m.IsComplete = true;
+            m.IsCollapsed = true;
+        }
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleTurnEnd(string sessionName)
+    {
+        if (sessionName != CopilotService.ActiveSessionName) return;
+        currentIntent = "";
+        // Complete any open reasoning blocks
+        if (activeSession != null)
+        {
+            foreach (var m in activeSession.History.Where(m => m.MessageType == ChatMessageType.Reasoning && !m.IsComplete))
+            {
+                m.IsComplete = true;
+                m.IsCollapsed = true;
+            }
+        }
+        InvokeAsync(StateHasChanged);
     }
 
     private void HandleDebug(string message)
@@ -184,16 +435,12 @@
         try
         {
             await CopilotService.InitializeAsync();
-            // Restore previously active sessions
             await CopilotService.RestorePreviousSessionsAsync();
-
-            // Restore UI state (active session and page)
             var uiState = CopilotService.LoadUiState();
             if (uiState != null)
             {
                 if (!string.IsNullOrEmpty(uiState.ActiveSession))
                     CopilotService.SetActiveSession(uiState.ActiveSession);
-
                 if (uiState.CurrentPage is "/dashboard")
                 {
                     _needsRedirect = true;
@@ -219,7 +466,10 @@
 
     private void RefreshState()
     {
+        var prev = activeSession?.Name;
         activeSession = CopilotService.GetActiveSession();
+        if (activeSession?.Name != prev)
+            _needsScroll = true;
         InvokeAsync(async () =>
         {
             StateHasChanged();
@@ -244,15 +494,12 @@
     {
         if (sessionName == CopilotService.ActiveSessionName)
         {
-            currentActivity = "";
+            currentIntent = "";
         }
         InvokeAsync(async () =>
         {
-            try
-            {
-                await JS.InvokeVoidAsync("showNotification", sessionName, summary);
-            }
-            catch { /* JS might not be ready */ }
+            try { await JS.InvokeVoidAsync("showNotification", sessionName, summary); }
+            catch { }
         });
     }
 
@@ -260,20 +507,33 @@
     {
         if (e.Key == "Enter" && !e.ShiftKey)
         {
+            shouldPreventDefault = true;
             await SendMessage();
+        }
+        else
+        {
+            shouldPreventDefault = false;
         }
     }
 
     private async Task SendMessage()
     {
-        if (string.IsNullOrWhiteSpace(userInput) || activeSession == null || activeSession.IsProcessing)
+        if (string.IsNullOrWhiteSpace(userInput) || activeSession == null)
             return;
 
         var prompt = userInput.Trim();
+        if (isPlanMode)
+            prompt = $"[[PLAN]] {prompt}";
         userInput = "";
+
+        if (activeSession.IsProcessing)
+        {
+            CopilotService.EnqueueMessage(activeSession.Name, prompt);
+            return;
+        }
+
         streamingContent = "";
-        currentActivity = "";
-        activityLog.Clear();
+        currentIntent = "";
         lastError = null;
 
         try
@@ -284,45 +544,102 @@
         catch (Exception ex)
         {
             lastError = $"Error: {ex.Message}";
-            Console.WriteLine($"Error: {ex.Message}");
         }
+        await ForceScrollToBottom();
     }
 
-    private string FormatMessage(string content)
+    private void RemoveQueuedMessage(int index)
+    {
+        if (activeSession != null) CopilotService.RemoveQueuedMessage(activeSession.Name, index);
+    }
+
+    private void ClearQueue()
+    {
+        if (activeSession != null) CopilotService.ClearQueue(activeSession.Name);
+    }
+
+    private string GetInputPlaceholder()
+    {
+        if (isPlanMode) return "Plan mode: describe what you want planned...";
+        if (activeSession?.IsProcessing == true) return "Type to queue next message... (sent when idle)";
+        return "Type a message... (Enter to send, Shift+Enter for new line)";
+    }
+
+    private string Truncate(string text, int maxLen)
+    {
+        text = text.Replace("\n", " ").Replace("\r", "");
+        return text.Length > maxLen ? text[..maxLen] + "…" : text;
+    }
+
+    private static string RenderMarkdown(string content)
+    {
+        if (string.IsNullOrEmpty(content)) return "";
+        try { return Markdig.Markdown.ToHtml(content, MdPipeline); }
+        catch { return System.Net.WebUtility.HtmlEncode(content).Replace("\n", "<br/>"); }
+    }
+
+    private static string FormatUserMessage(string content)
     {
         var escaped = System.Net.WebUtility.HtmlEncode(content);
-        
-        // Code blocks
-        escaped = System.Text.RegularExpressions.Regex.Replace(
-            escaped, 
-            @"```(\w*)\n?([\s\S]*?)```",
-            "<pre><code>$2</code></pre>");
-        
-        // Inline code
-        escaped = System.Text.RegularExpressions.Regex.Replace(
-            escaped,
-            @"`([^`]+)`",
-            "<code>$1</code>");
-        
-        // Bold
-        escaped = System.Text.RegularExpressions.Regex.Replace(
-            escaped,
-            @"\*\*([^*]+)\*\*",
-            "<strong>$1</strong>");
-        
-        // Line breaks
-        escaped = escaped.Replace("\n", "<br/>");
-        
-        return escaped;
+        return escaped.Replace("\n", "<br/>");
     }
+
+    private static int LineCount(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return 0;
+        var count = 1;
+        foreach (var c in text) { if (c == '\n') count++; }
+        return count;
+    }
+
+    private static string FirstLines(string? text, int lines)
+    {
+        if (string.IsNullOrEmpty(text)) return "";
+        var idx = 0;
+        for (var i = 0; i < lines && idx < text.Length; i++)
+        {
+            var next = text.IndexOf('\n', idx);
+            if (next < 0) break;
+            idx = next + 1;
+        }
+        if (idx <= 0 || idx >= text.Length) return text;
+        return text[..idx] + "…";
+    }
+
+    private static string FormatToolName(string toolName)
+    {
+        if (string.IsNullOrEmpty(toolName)) return "";
+        return string.Join(" ", toolName.Split('_').Select(w =>
+            w.Length > 0 ? char.ToUpperInvariant(w[0]) + w[1..].ToLowerInvariant() : w));
+    }
+
+    private static string TruncateResult(string result, int maxLength = 1500)
+    {
+        if (string.IsNullOrEmpty(result) || result.Length <= maxLength) return result ?? "";
+        return result[..maxLength] + "\n… (truncated)";
+    }
+
+    private static bool IsUnusableResult(string? content)
+    {
+        if (string.IsNullOrEmpty(content)) return true;
+        if (content.StartsWith("GitHub.Copilot.SDK.")) return true;
+        if (content is "(no result)" or "Intent logged") return true;
+        return false;
+    }
+
+    private static string FormatTokenCount(int count) =>
+        count >= 1000 ? $"{count / 1000}k" : count.ToString();
 
     private async Task ScrollToBottom()
     {
-        try
-        {
-            await JS.InvokeVoidAsync("scrollToBottom", messagesContainer);
-        }
-        catch { /* JS might not be ready */ }
+        try { await JS.InvokeVoidAsync("smartScrollToBottom", messagesContainer); }
+        catch { }
+    }
+
+    private async Task ForceScrollToBottom()
+    {
+        try { await JS.InvokeVoidAsync("scrollToBottom", messagesContainer); }
+        catch { }
     }
 
     public void Dispose()
@@ -332,6 +649,13 @@
         CopilotService.OnSessionComplete -= HandleSessionComplete;
         CopilotService.OnError -= HandleError;
         CopilotService.OnDebug -= HandleDebug;
-        CopilotService.OnActivity -= HandleActivity;
+        CopilotService.OnToolStarted -= HandleToolStarted;
+        CopilotService.OnToolCompleted -= HandleToolCompleted;
+        CopilotService.OnReasoningReceived -= HandleReasoningReceived;
+        CopilotService.OnReasoningComplete -= HandleReasoningComplete;
+        CopilotService.OnIntentChanged -= HandleIntentChanged;
+        CopilotService.OnUsageInfoChanged -= HandleUsageInfoChanged;
+        CopilotService.OnTurnStart -= HandleTurnStart;
+        CopilotService.OnTurnEnd -= HandleTurnEnd;
     }
 }

--- a/Components/Pages/Home.razor.css
+++ b/Components/Pages/Home.razor.css
@@ -18,9 +18,7 @@
     font-size: 18px;
 }
 
-.initializing .error {
-    color: #ef4444;
-}
+.initializing .error { color: #ef4444; }
 
 .initializing button {
     padding: 0.5rem 1rem;
@@ -40,18 +38,14 @@
     animation: spin 1s linear infinite;
 }
 
-@keyframes spin {
-    to { transform: rotate(360deg); }
-}
+@keyframes spin { to { transform: rotate(360deg); } }
 
-.no-session h2 {
-    margin: 0;
-}
+.no-session h2 { margin: 0; }
+.no-session p { margin: 0; color: rgba(255,255,255,0.5); }
 
-.no-session p {
-    margin: 0;
-    color: rgba(255,255,255,0.5);
-}
+/* === Inline icons === */
+.icon { vertical-align: middle; flex-shrink: 0; }
+.icon.spin { animation: spin 1s linear infinite; }
 
 .chat-header {
     display: flex;
@@ -62,10 +56,7 @@
     border-bottom: 1px solid rgba(255,255,255,0.1);
 }
 
-.chat-header h2 {
-    margin: 0;
-    font-size: 1.6rem;
-}
+.chat-header h2 { margin: 0; font-size: 1.6rem; }
 
 .model-badge {
     padding: 0.25rem 0.5rem;
@@ -83,10 +74,7 @@
     animation: pulse 1.5s infinite;
 }
 
-@keyframes pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.5; }
-}
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
 
 .messages {
     flex: 1;
@@ -94,7 +82,7 @@
     padding: 1rem;
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.75rem;
 }
 
 .empty-chat {
@@ -105,6 +93,7 @@
     color: rgba(255,255,255,0.5);
 }
 
+/* === Messages === */
 .message {
     display: flex;
     gap: 0.75rem;
@@ -117,22 +106,18 @@
 }
 
 .message-avatar {
-    width: 40px;
-    height: 40px;
+    width: 36px;
+    height: 36px;
     display: flex;
     align-items: center;
     justify-content: center;
     background: rgba(255,255,255,0.1);
     border-radius: 50%;
-    font-size: 1.3rem;
+    font-size: 1.2rem;
     flex-shrink: 0;
-    line-height: 1;
-    text-align: center;
 }
 
-.message.user .message-avatar {
-    background: rgba(59, 130, 246, 0.3);
-}
+.message.user .message-avatar { background: rgba(59, 130, 246, 0.3); }
 
 .message-content {
     display: flex;
@@ -143,9 +128,10 @@
 .message-text {
     padding: 0.75rem 1rem;
     border-radius: 12px;
-    line-height: 1.7;
-    font-size: 1.1rem;
+    line-height: 1.6;
+    font-size: 1.05rem;
     word-break: break-word;
+    min-height: 1.6em;
 }
 
 .message.user .message-text {
@@ -163,47 +149,294 @@
     animation: blink 1s infinite;
 }
 
-@keyframes blink {
-    0%, 50% { opacity: 1; }
-    51%, 100% { opacity: 0; }
+@keyframes blink { 0%, 50% { opacity: 1; } 51%, 100% { opacity: 0; } }
+
+.message-time {
+    font-size: 0.75rem;
+    color: rgba(255,255,255,0.35);
+    padding: 0 0.5rem;
 }
 
-.message-text pre {
-    background: rgba(0,0,0,0.3);
+.message.user .message-time { text-align: right; }
+
+/* === Markdown body (::deep for MarkupString inner content) === */
+::deep .markdown-body p { margin: 0 0 0.5rem 0; }
+::deep .markdown-body p:last-child { margin-bottom: 0; }
+
+::deep .markdown-body pre {
+    background: rgba(0,0,0,0.4);
     padding: 0.75rem;
     border-radius: 6px;
     overflow-x: auto;
     margin: 0.5rem 0;
 }
 
-.message-text code {
+::deep .markdown-body code {
     font-family: 'SF Mono', Monaco, Consolas, monospace;
-    font-size: 0.95rem;
+    font-size: 0.9rem;
 }
 
-.message-text :not(pre) > code {
-    background: rgba(0,0,0,0.3);
-    padding: 0.15rem 0.3rem;
+::deep .markdown-body :not(pre) > code {
+    background: rgba(0,0,0,0.35);
+    padding: 0.15rem 0.35rem;
     border-radius: 3px;
 }
 
-.message-time {
-    font-size: 0.8rem;
+::deep .markdown-body ul, ::deep .markdown-body ol {
+    margin: 0.4rem 0;
+    padding-left: 1.5rem;
+}
+
+::deep .markdown-body li { margin: 0.15rem 0; }
+
+::deep .markdown-body h1, ::deep .markdown-body h2, ::deep .markdown-body h3 {
+    margin: 0.75rem 0 0.4rem 0;
+}
+::deep .markdown-body h1 { font-size: 1.25em; }
+::deep .markdown-body h2 { font-size: 1.15em; }
+::deep .markdown-body h3 { font-size: 1.05em; }
+
+::deep .markdown-body blockquote {
+    border-left: 3px solid #60a5fa;
+    margin: 0.5rem 0;
+    padding: 0.4rem 0.75rem;
+    background: rgba(59, 130, 246, 0.08);
+    border-radius: 0 6px 6px 0;
+}
+
+::deep .markdown-body a { color: #60a5fa; text-decoration: none; }
+::deep .markdown-body a:hover { text-decoration: underline; }
+
+::deep .markdown-body table {
+    border-collapse: collapse;
+    margin: 0.5rem 0;
+    width: 100%;
+    font-size: 0.9rem;
+}
+
+::deep .markdown-body th, ::deep .markdown-body td {
+    border: 1px solid rgba(255,255,255,0.15);
+    padding: 0.4rem 0.6rem;
+}
+
+::deep .markdown-body th {
+    background: rgba(255,255,255,0.08);
+    font-weight: 600;
+}
+
+/* === Reasoning blocks === */
+.reasoning-block {
+    background: rgba(139, 92, 246, 0.08);
+    border: 1px solid rgba(139, 92, 246, 0.25);
+    border-radius: 8px;
+    max-width: 90%;
+    overflow: hidden;
+}
+
+.reasoning-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: white;
+    font-size: 0.85rem;
+}
+
+.reasoning-header:hover { background: rgba(139, 92, 246, 0.12); }
+
+.reasoning-title {
+    font-weight: 600;
+    color: #a78bfa;
+}
+
+.collapse-icon {
+    font-size: 0.7rem;
     color: rgba(255,255,255,0.4);
-    padding: 0 0.5rem;
 }
 
-.message.user .message-time {
-    text-align: right;
+.reasoning-content {
+    padding: 0 0.75rem 0.75rem 0.75rem;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    color: rgba(255,255,255,0.6);
+    font-style: italic;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 200px;
+    overflow-y: auto;
 }
 
+.reasoning-content.preview {
+    max-height: none;
+    overflow: hidden;
+    position: relative;
+    mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
+    -webkit-mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
+}
+
+.reasoning-block.collapsed .reasoning-content:not(.preview) { display: none; }
+
+/* === Tool cards === */
+.tool-card {
+    border-radius: 8px;
+    border: 1px solid rgba(255,255,255,0.15);
+    max-width: 90%;
+    overflow: hidden;
+    background: rgba(255,255,255,0.04);
+}
+
+.tool-card.running { border-color: rgba(59, 130, 246, 0.4); }
+.tool-card.success { border-color: rgba(34, 197, 94, 0.35); }
+.tool-card.error { border-color: rgba(239, 68, 68, 0.35); }
+
+.tool-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.45rem 0.75rem;
+    font-size: 0.85rem;
+}
+
+.tool-info {
+    font-weight: 600;
+    color: rgba(255,255,255,0.8);
+}
+
+.tool-status { font-size: 0.8rem; color: rgba(255,255,255,0.5); }
+.tool-card.running .tool-status { color: #60a5fa; }
+.tool-card.success .tool-status { color: #4ade80; }
+.tool-card.error .tool-status { color: #f87171; }
+
+.tool-result-section { border-top: 1px solid rgba(255,255,255,0.08); }
+
+.tool-result-toggle {
+    width: 100%;
+    padding: 0.35rem 0.75rem;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-size: 0.75rem;
+    color: rgba(255,255,255,0.4);
+    text-align: left;
+}
+
+.tool-result-toggle:hover { background: rgba(255,255,255,0.05); }
+
+.tool-result-content {
+    margin: 0;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.8rem;
+    background: rgba(0,0,0,0.2);
+    color: rgba(255,255,255,0.6);
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 200px;
+    overflow-y: auto;
+    font-family: 'SF Mono', Monaco, Consolas, monospace;
+}
+
+.tool-result-content.preview {
+    max-height: none;
+    overflow: hidden;
+    mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
+    -webkit-mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
+}
+
+/* === Task complete card === */
+.task-complete-card {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.7rem;
+    background: rgba(34, 197, 94, 0.08);
+    border: 1px solid rgba(34, 197, 94, 0.25);
+    border-radius: 6px;
+    max-width: 90%;
+    font-size: 0.85rem;
+}
+
+.task-complete-text {
+    color: #86efac;
+    line-height: 1.4;
+}
+
+/* === Error cards === */
+.error-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    background: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 8px;
+    max-width: 90%;
+    font-size: 0.9rem;
+}
+
+.error-icon { flex-shrink: 0; }
+.error-text { color: #fca5a5; line-height: 1.4; }
+
+/* === Intent pill === */
+.intent-pill {
+    padding: 0.3rem 0.65rem;
+    background: rgba(139, 92, 246, 0.12);
+    border: 1px solid rgba(139, 92, 246, 0.25);
+    border-radius: 6px;
+    font-size: 0.8rem;
+    color: #a78bfa;
+    align-self: flex-start;
+}
+
+/* === Input status bar === */
+.input-status-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0 0.25rem;
+    font-size: 0.75rem;
+    color: rgba(255,255,255,0.35);
+}
+
+.plan-icon-toggle {
+    all: unset;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    color: rgba(255,255,255,0.35);
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: color 0.15s ease;
+}
+
+.plan-icon-toggle:hover {
+    color: rgba(255,255,255,0.55);
+}
+
+.plan-icon-toggle.active {
+    color: #60a5fa;
+}
+
+.status-model { color: rgba(59, 130, 246, 0.6); }
+.status-tokens { }
+.status-ctx { }
+.status-msgs { }
+.status-sep { color: rgba(255,255,255,0.15); user-select: none; }
+
+/* === Input area === */
 .input-area {
     display: flex;
-    gap: 0.75rem;
-    padding: 1rem 1.5rem;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
     background: rgba(255,255,255,0.05);
     border-top: 1px solid rgba(255,255,255,0.1);
 }
+
+.input-row { display: flex; gap: 0.75rem; }
 
 .input-area textarea {
     flex: 1;
@@ -219,20 +452,11 @@
     max-height: 150px;
 }
 
-.input-area textarea::placeholder {
-    color: rgba(255,255,255,0.4);
-}
+.input-area textarea::placeholder { color: rgba(255,255,255,0.4); }
+.input-area textarea:focus { outline: none; border-color: #3b82f6; }
+.input-area textarea:disabled { opacity: 0.6; }
 
-.input-area textarea:focus {
-    outline: none;
-    border-color: #3b82f6;
-}
-
-.input-area textarea:disabled {
-    opacity: 0.6;
-}
-
-.input-area button {
+.input-area .input-row button {
     padding: 0.75rem 1.5rem;
     border: none;
     border-radius: 8px;
@@ -244,15 +468,10 @@
     transition: background 0.15s ease;
 }
 
-.input-area button:hover:not(:disabled) {
-    background: #2563eb;
-}
+.input-area .input-row button:hover:not(:disabled) { background: #2563eb; }
+.input-area .input-row button:disabled { opacity: 0.5; cursor: not-allowed; }
 
-.input-area button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-}
-
+/* === Error bar === */
 .error-bar {
     display: flex;
     align-items: center;
@@ -273,27 +492,9 @@
     padding: 0 0.5rem;
 }
 
-.error-bar button:hover {
-    color: white;
-}
+.error-bar button:hover { color: white; }
 
-.message-text.thinking {
-    color: rgba(255,255,255,0.6);
-    font-style: italic;
-}
-
-.message-text.thinking::after {
-    content: "";
-    animation: dots 1.5s infinite;
-}
-
-@keyframes dots {
-    0%, 20% { content: ""; }
-    40% { content: "."; }
-    60% { content: ".."; }
-    80%, 100% { content: "..."; }
-}
-
+/* === Badges === */
 .session-id-badge {
     padding: 0.25rem 0.5rem;
     background: rgba(251, 191, 36, 0.2);
@@ -304,6 +505,7 @@
     font-family: monospace;
 }
 
+/* === Debug panel === */
 .debug-panel {
     position: fixed;
     bottom: 80px;
@@ -348,32 +550,73 @@
     word-break: break-all;
 }
 
-.activity-log {
-    padding: 0.5rem 1rem;
-    color: rgba(255,255,255,0.5);
+/* === Message queue === */
+.message-queue {
+    border: 1px solid rgba(59, 130, 246, 0.25);
+    border-radius: 8px;
+    background: rgba(59, 130, 246, 0.08);
+    overflow: hidden;
+}
+
+.queue-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.4rem 0.75rem;
     font-size: 0.85rem;
-    border-left: 2px solid rgba(255,255,255,0.1);
-    margin-left: 3rem;
-    margin-bottom: 0.5rem;
+    color: rgba(255,255,255,0.6);
+    border-bottom: 1px solid rgba(59, 130, 246, 0.15);
 }
 
-.activity-entry {
-    padding: 0.15rem 0;
-    opacity: 0.5;
+.queue-clear-btn {
+    padding: 0.15rem 0.5rem !important;
+    font-size: 0.75rem !important;
+    background: rgba(239, 68, 68, 0.2) !important;
+    border: 1px solid rgba(239, 68, 68, 0.3) !important;
+    border-radius: 4px !important;
+    color: #fca5a5 !important;
+    cursor: pointer;
 }
 
-.activity-entry.current {
-    opacity: 1;
+.queue-clear-btn:hover { background: rgba(239, 68, 68, 0.35) !important; }
+
+.queue-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.9rem;
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+
+.queue-item:last-child { border-bottom: none; }
+
+.queue-index {
+    color: rgba(59, 130, 246, 0.7);
+    font-weight: 600;
+    font-size: 0.8rem;
+    min-width: 1.2rem;
+}
+
+.queue-text {
+    flex: 1;
     color: rgba(255,255,255,0.7);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-.activity-spinner {
-    color: #fbbf24;
-    animation: pulse-activity 1s infinite;
-    margin-right: 0.4rem;
+.queue-remove-btn {
+    padding: 0.1rem 0.4rem !important;
+    font-size: 0.85rem !important;
+    background: transparent !important;
+    border: none !important;
+    color: rgba(255,255,255,0.3) !important;
+    cursor: pointer;
+    border-radius: 3px !important;
 }
 
-@keyframes pulse-activity {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.3; }
+.queue-remove-btn:hover {
+    background: rgba(239, 68, 68, 0.2) !important;
+    color: #ef4444 !important;
 }

--- a/Models/AgentSessionInfo.cs
+++ b/Models/AgentSessionInfo.cs
@@ -2,12 +2,13 @@ namespace AutoPilot.App.Models;
 
 public class AgentSessionInfo
 {
-    public required string Name { get; init; }
+    public required string Name { get; set; }
     public required string Model { get; init; }
     public DateTime CreatedAt { get; init; }
     public int MessageCount { get; set; }
     public bool IsProcessing { get; set; }
     public List<ChatMessage> History { get; } = new();
+    public List<string> MessageQueue { get; } = new();
     
     public string? WorkingDirectory { get; set; }
     

--- a/Models/ChatMessage.cs
+++ b/Models/ChatMessage.cs
@@ -1,8 +1,59 @@
 namespace AutoPilot.App.Models;
 
-public record ChatMessage(string Role, string Content, DateTime Timestamp)
+public enum ChatMessageType
 {
+    User,
+    Assistant,
+    Reasoning,
+    ToolCall,
+    Error
+}
+
+public class ChatMessage
+{
+    public ChatMessage(string role, string content, DateTime timestamp, ChatMessageType messageType = ChatMessageType.User)
+    {
+        Role = role;
+        Content = content;
+        Timestamp = timestamp;
+        MessageType = messageType;
+
+        if (role == "user") MessageType = ChatMessageType.User;
+        else if (messageType == ChatMessageType.User) MessageType = ChatMessageType.Assistant;
+    }
+
+    public string Role { get; set; }
+    public string Content { get; set; }
+    public DateTime Timestamp { get; set; }
+    public ChatMessageType MessageType { get; set; }
+
+    // Tool call fields
+    public string? ToolName { get; set; }
+    public string? ToolCallId { get; set; }
+    public bool IsComplete { get; set; } = true;
+    public bool IsCollapsed { get; set; }
+    public bool IsSuccess { get; set; }
+
+    // Reasoning fields
+    public string? ReasoningId { get; set; }
+
+    // Convenience properties
     public bool IsUser => Role == "user";
     public bool IsAssistant => Role == "assistant";
-    public bool IsSystem => Role == "system";
+
+    // Factory methods
+    public static ChatMessage UserMessage(string content) =>
+        new("user", content, DateTime.Now, ChatMessageType.User) { IsComplete = true };
+
+    public static ChatMessage AssistantMessage(string content) =>
+        new("assistant", content, DateTime.Now, ChatMessageType.Assistant) { IsComplete = true };
+
+    public static ChatMessage ReasoningMessage(string reasoningId) =>
+        new("assistant", "", DateTime.Now, ChatMessageType.Reasoning) { ReasoningId = reasoningId, IsComplete = false, IsCollapsed = false };
+
+    public static ChatMessage ToolCallMessage(string toolName, string? toolCallId = null) =>
+        new("assistant", "", DateTime.Now, ChatMessageType.ToolCall) { ToolName = toolName, ToolCallId = toolCallId, IsComplete = false };
+
+    public static ChatMessage ErrorMessage(string content, string? toolName = null) =>
+        new("assistant", content, DateTime.Now, ChatMessageType.Error) { ToolName = toolName, IsComplete = true };
 }

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -36,6 +36,20 @@
             }
         };
 
+        window.smartScrollToBottom = function(element) {
+            if (!element) return;
+            var threshold = 150;
+            var isAtBottom = (element.scrollHeight - element.scrollTop - element.clientHeight) < threshold;
+            if (isAtBottom) {
+                element.scrollTop = element.scrollHeight;
+            }
+        };
+
+        window.isScrolledToBottom = function(element) {
+            if (!element) return true;
+            return (element.scrollHeight - element.scrollTop - element.clientHeight) < 150;
+        };
+
         window.showNotification = function(sessionName, summary) {
             // Play a sound
             try {


### PR DESCRIPTION
UX polish and feature additions across the chat/dashboard UI: add Markdig package for markdown rendering; replace many emoji labels with inline SVG icons; implement inline session renaming (JS focus/blur handling) and visual active-nav state in the sidebar; improve persisted/session lists and filters; add message queuing and a planning mode for input; enhance dashboard cards to render different ChatMessage types (tool calls, reasoning, errors) and truncate/preview long results; track intent and usage info with new event handlers and UI indicators; add smart scrolling JS interop and minor CSS tweaks for better layout and hover states. Also includes small model/service updates to support new message types and events.