### PR TITLE
Persistent sessions, streaming fixes, stop button

### DIFF
--- a/Components/Layout/SessionSidebar.razor
+++ b/Components/Layout/SessionSidebar.razor
@@ -8,11 +8,19 @@
     <div class="sidebar-header">
         <h3><svg style="vertical-align:middle" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect x="2" y="8" width="20" height="8" rx="2"/><path d="M6 16v4"/><path d="M18 16v4"/><circle cx="9" cy="12" r="1" fill="currentColor"/><circle cx="15" cy="12" r="1" fill="currentColor"/></svg> AutoPilot</h3>
         <p class="status @(CopilotService.IsInitialized ? "connected" : "disconnected")">
-            @(CopilotService.IsInitialized ? "● Connected" : "○ Disconnected")
+            @if (CopilotService.IsInitialized)
+            {
+                <text>● @(CopilotService.CurrentMode == ConnectionMode.Persistent ? "Persistent" : "Embedded")</text>
+            }
+            else
+            {
+                <text>○ Disconnected</text>
+            }
         </p>
         <div class="nav-tabs">
             <a href="/" class="nav-tab @(currentPage == "/" ? "active" : "")" @onclick='() => { CopilotService.SaveUiState("/"); currentPage = "/"; }'><svg style="vertical-align:middle" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg> Chat</a>
             <a href="/dashboard" class="nav-tab @(currentPage == "/dashboard" ? "active" : "")" @onclick='() => { CopilotService.SaveUiState("/dashboard"); currentPage = "/dashboard"; }'><svg style="vertical-align:middle" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg> Dashboard</a>
+            <a href="/settings" class="nav-tab @(currentPage == "/settings" ? "active" : "")" @onclick='() => { CopilotService.SaveUiState("/settings"); currentPage = "/settings"; }'>⚙️</a>
         </div>
     </div>
 

--- a/Components/Pages/Dashboard.razor
+++ b/Components/Pages/Dashboard.razor
@@ -36,7 +36,7 @@
 
                     <div class="card-messages">
                         @{
-                            var lastMessages = session.History.TakeLast(6).ToList();
+                            var lastMessages = session.History.ToList().TakeLast(6).ToList();
                         }
                         @if (!lastMessages.Any())
                         {
@@ -206,7 +206,16 @@
 
         try
         {
-            _ = CopilotService.SendPromptAsync(sessionName, prompt.Trim());
+            _ = CopilotService.SendPromptAsync(sessionName, prompt.Trim()).ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    InvokeAsync(() =>
+                    {
+                        Console.WriteLine($"Error sending to {sessionName}: {t.Exception?.InnerException?.Message}");
+                    });
+                }
+            });
         }
         catch (Exception ex)
         {

--- a/Components/Pages/Home.razor
+++ b/Components/Pages/Home.razor
@@ -51,16 +51,16 @@
             }
             else
             {
-                @foreach (var message in activeSession.History.ToList())
+                @foreach (var msg in activeSession.History.ToList())
                 {
-                    @switch (message.MessageType)
+                    @switch (msg.MessageType)
                     {
                         case ChatMessageType.User:
                             <div class="message user">
                                 <div class="message-avatar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></div>
                                 <div class="message-content">
-                                    <div class="message-text">@((MarkupString)FormatUserMessage(message.Content))</div>
-                                    <div class="message-time">@message.Timestamp.ToString("HH:mm")</div>
+                                    <div class="message-text">@((MarkupString)FormatUserMessage(msg.Content))</div>
+                                    <div class="message-time">@msg.Timestamp.ToString("HH:mm")</div>
                                 </div>
                             </div>
                             break;
@@ -69,96 +69,36 @@
                             <div class="message assistant">
                                 <div class="message-avatar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect x="2" y="8" width="20" height="8" rx="2"/><path d="M6 16v4"/><path d="M18 16v4"/><circle cx="9" cy="12" r="1" fill="currentColor"/><circle cx="15" cy="12" r="1" fill="currentColor"/></svg></div>
                                 <div class="message-content">
-                                    <div class="message-text markdown-body">@((MarkupString)RenderMarkdown(message.Content))</div>
-                                    <div class="message-time">@message.Timestamp.ToString("HH:mm")</div>
+                                    <div class="message-text markdown-body">@((MarkupString)RenderMarkdown(msg.Content))</div>
+                                    <div class="message-time">@msg.Timestamp.ToString("HH:mm")</div>
                                 </div>
                             </div>
-                            break;
-
-                        case ChatMessageType.Reasoning:
-                            <div class="reasoning-block @(message.IsCollapsed && LineCount(message.Content) > 5 ? "collapsed" : "")">
-                                <button class="reasoning-header" @onclick="() => message.IsCollapsed = !message.IsCollapsed">
-                                    <span class="reasoning-title"><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a8 8 0 0 0-8 8c0 3.4 2.1 6.3 5 7.4V20a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1v-2.6c2.9-1.1 5-4 5-7.4a8 8 0 0 0-8-8z"/><line x1="10" y1="22" x2="14" y2="22"/></svg> @(message.IsComplete ? "Thought" : "Thinking...")</span>
-                                    @if (LineCount(message.Content) > 5)
-                                    {
-                                        <span class="collapse-icon">@(message.IsCollapsed ? "▶" : "▼")</span>
-                                    }
-                                </button>
-                                @if (!message.IsCollapsed || LineCount(message.Content) <= 5)
-                                {
-                                    <div class="reasoning-content">@message.Content</div>
-                                }
-                                else
-                                {
-                                    <div class="reasoning-content preview">@FirstLines(message.Content, 3)</div>
-                                }
-                            </div>
-                            break;
-
-                        case ChatMessageType.ToolCall:
-                            @if (message.ToolName == "task_complete")
-                            {
-                                <div class="task-complete-card">
-                                    <svg class="icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#4ade80" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-                                    <span class="task-complete-text">@(string.IsNullOrEmpty(message.Content) || IsUnusableResult(message.Content) ? "Task complete" : message.Content)</span>
-                                </div>
-                            }
-                            else
-                            {
-                            <div class="tool-card @(message.IsComplete ? (message.IsSuccess ? "success" : "error") : "running")">
-                                <div class="tool-header">
-                                    <span class="tool-info"><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg> @FormatToolName(message.ToolName ?? "")</span>
-                                    <span class="tool-status">
-                                        @if (!message.IsComplete)
-                                        {
-                                            <svg class="icon spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.22-8.56"/></svg> <text>Running</text>
-                                        }
-                                        else if (message.IsSuccess)
-                                        {
-                                            <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#4ade80" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg> <text>Done</text>
-                                        }
-                                        else
-                                        {
-                                            <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg> <text>Failed</text>
-                                        }
-                                    </span>
-                                </div>
-                                @if (message.IsComplete && !string.IsNullOrEmpty(message.Content) && !IsUnusableResult(message.Content))
-                                {
-                                    @if (LineCount(message.Content) <= 5)
-                                    {
-                                        <div class="tool-result-section">
-                                            <pre class="tool-result-content">@TruncateResult(message.Content)</pre>
-                                        </div>
-                                    }
-                                    else
-                                    {
-                                        <div class="tool-result-section">
-                                            <button class="tool-result-toggle" @onclick="() => message.IsCollapsed = !message.IsCollapsed">
-                                                @(message.IsCollapsed ? "Show Full Result ▶" : "Collapse ▼")
-                                            </button>
-                                            @if (!message.IsCollapsed)
-                                            {
-                                                <pre class="tool-result-content">@TruncateResult(message.Content)</pre>
-                                            }
-                                            else
-                                            {
-                                                <pre class="tool-result-content preview">@FirstLines(message.Content, 3)</pre>
-                                            }
-                                        </div>
-                                    }
-                                }
-                            </div>
-                            }
                             break;
 
                         case ChatMessageType.Error:
                             <div class="error-card">
                                 <span class="error-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>
-                                <span class="error-text">@message.Content</span>
+                                <span class="error-text">@msg.Content</span>
+                            </div>
+                            break;
+
+                        case ChatMessageType.System:
+                            <div class="message system">
+                                <div class="system-text">@msg.Content</div>
                             </div>
                             break;
                     }
+                }
+
+                @* Show current tool activity inline *@
+                @if (!string.IsNullOrEmpty(currentToolName))
+                {
+                    <div class="tool-card running">
+                        <div class="tool-header">
+                            <span class="tool-info"><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg> @FormatToolName(currentToolName)</span>
+                            <span class="tool-status"><svg class="icon spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.22-8.56"/></svg> @currentTurnToolCount tool@(currentTurnToolCount != 1 ? "s" : "")</span>
+                        </div>
+                    </div>
                 }
 
                 @if (!string.IsNullOrEmpty(streamingContent))
@@ -206,10 +146,16 @@
                 </div>
             }
             <div class="input-row">
-                <textarea @bind="userInput" @bind:event="oninput" 
-                          @onkeydown="HandleKeyDown" @onkeydown:preventDefault="shouldPreventDefault"
+                <textarea @ref="textareaRef" @bind="userInput" @bind:event="oninput" 
+                          @onkeydown="HandleKeyDown"
                           placeholder="@GetInputPlaceholder()"
                           rows="1"></textarea>
+                @if (activeSession.IsProcessing)
+                {
+                    <button class="stop-btn" @onclick="StopResponse" title="Stop response">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="1"/></svg>
+                    </button>
+                }
                 <button @onclick="SendMessage" 
                         disabled="@(string.IsNullOrWhiteSpace(userInput))">
                     @if (activeSession.IsProcessing)
@@ -272,10 +218,10 @@
     private string? lastError;
     private string debugLog = "";
     private ElementReference messagesContainer;
+    private ElementReference textareaRef;
     private bool _needsRedirect;
     private string? _redirectTo;
     private bool _needsScroll = true;
-    private bool shouldPreventDefault;
 
     protected override async Task OnInitializedAsync()
     {
@@ -308,64 +254,37 @@
             _needsScroll = false;
             await ForceScrollToBottom();
         }
+        try { await JS.InvokeVoidAsync("setupTextareaEnterHandler", textareaRef); } catch { }
     }
+
+    private string currentToolName = "";
+    private int currentTurnToolCount;
 
     private void HandleToolStarted(string sessionName, string toolName, string callId)
     {
         if (sessionName != CopilotService.ActiveSessionName) return;
-        var msg = ChatMessage.ToolCallMessage(toolName, callId);
-        activeSession?.History.Add(msg);
-        InvokeAsync(async () => { StateHasChanged(); await ScrollToBottom(); });
+        currentToolName = toolName;
+        currentTurnToolCount++;
+        InvokeAsync(StateHasChanged);
     }
 
     private void HandleToolCompleted(string sessionName, string callId, string result, bool success)
     {
         if (sessionName != CopilotService.ActiveSessionName || activeSession == null) return;
-        var msg = activeSession.History.LastOrDefault(m =>
-            m.MessageType == ChatMessageType.ToolCall && !m.IsComplete &&
-            (!string.IsNullOrEmpty(callId) ? m.ToolCallId == callId : true));
-        if (msg == null)
-            msg = activeSession.History.LastOrDefault(m => m.MessageType == ChatMessageType.ToolCall && !m.IsComplete);
-        if (msg != null)
-        {
-            msg.IsComplete = true;
-            msg.IsSuccess = success;
-            msg.Content = result;
-            msg.IsCollapsed = true;
-        }
-        InvokeAsync(async () => { StateHasChanged(); await ScrollToBottom(); });
+        // Don't add to history — just clear current tool indicator
+        currentToolName = "";
+        InvokeAsync(StateHasChanged);
     }
 
     private void HandleReasoningReceived(string sessionName, string reasoningId, string content)
     {
-        if (sessionName != CopilotService.ActiveSessionName || activeSession == null) return;
-        var msg = activeSession.History.LastOrDefault(m =>
-            m.MessageType == ChatMessageType.Reasoning && m.ReasoningId == reasoningId);
-        if (msg == null)
-        {
-            msg = activeSession.History.LastOrDefault(m => m.MessageType == ChatMessageType.Reasoning && !m.IsComplete);
-        }
-        if (msg == null)
-        {
-            msg = ChatMessage.ReasoningMessage(reasoningId);
-            activeSession.History.Add(msg);
-        }
-        msg.Content += content;
-        InvokeAsync(async () => { StateHasChanged(); await ScrollToBottom(); });
+        // Don't add reasoning to history — it clutters the view
+        // The intent indicator already shows thinking state
     }
 
     private void HandleReasoningComplete(string sessionName, string reasoningId)
     {
-        if (sessionName != CopilotService.ActiveSessionName || activeSession == null) return;
-        var msg = activeSession.History.LastOrDefault(m =>
-            m.MessageType == ChatMessageType.Reasoning &&
-            (m.ReasoningId == reasoningId || !m.IsComplete));
-        if (msg != null)
-        {
-            msg.IsComplete = true;
-            msg.IsCollapsed = true;
-        }
-        InvokeAsync(StateHasChanged);
+        // No-op — reasoning not tracked in history
     }
 
     private void HandleIntentChanged(string sessionName, string intent)
@@ -397,12 +316,12 @@
     private void HandleTurnStart(string sessionName)
     {
         if (sessionName != CopilotService.ActiveSessionName || activeSession == null) return;
-        // Complete any open reasoning blocks from prior turn
-        foreach (var m in activeSession.History.Where(m => m.MessageType == ChatMessageType.Reasoning && !m.IsComplete))
-        {
-            m.IsComplete = true;
-            m.IsCollapsed = true;
-        }
+        // Don't clear streamingContent — let it accumulate across turns
+        // so messages don't vanish between tool-call-driven turns.
+        // CompleteResponse will add the full response to History and 
+        // SendPromptAsync clears streamingContent when done.
+        currentTurnToolCount = 0;
+        currentToolName = "";
         InvokeAsync(StateHasChanged);
     }
 
@@ -410,15 +329,10 @@
     {
         if (sessionName != CopilotService.ActiveSessionName) return;
         currentIntent = "";
-        // Complete any open reasoning blocks
-        if (activeSession != null)
-        {
-            foreach (var m in activeSession.History.Where(m => m.MessageType == ChatMessageType.Reasoning && !m.IsComplete))
-            {
-                m.IsComplete = true;
-                m.IsCollapsed = true;
-            }
-        }
+        currentToolName = "";
+        currentTurnToolCount = 0;
+        // Don't clear streamingContent here — CompleteResponse hasn't added it to History yet.
+        // It gets cleared in HandleTurnStart when the next turn begins.
         InvokeAsync(StateHasChanged);
     }
 
@@ -435,16 +349,16 @@
         try
         {
             await CopilotService.InitializeAsync();
-            await CopilotService.RestorePreviousSessionsAsync();
+            // RestorePreviousSessionsAsync is already called inside InitializeAsync
             var uiState = CopilotService.LoadUiState();
             if (uiState != null)
             {
                 if (!string.IsNullOrEmpty(uiState.ActiveSession))
                     CopilotService.SetActiveSession(uiState.ActiveSession);
-                if (uiState.CurrentPage is "/dashboard")
+                if (uiState.CurrentPage is "/dashboard" or "/settings")
                 {
                     _needsRedirect = true;
-                    _redirectTo = "/dashboard";
+                    _redirectTo = uiState.CurrentPage;
                 }
             }
         }
@@ -469,7 +383,12 @@
         var prev = activeSession?.Name;
         activeSession = CopilotService.GetActiveSession();
         if (activeSession?.Name != prev)
+        {
             _needsScroll = true;
+            // Clean up any stale tool/reasoning entries from history
+            activeSession?.History.RemoveAll(m =>
+                m.MessageType is ChatMessageType.ToolCall or ChatMessageType.Reasoning);
+        }
         InvokeAsync(async () =>
         {
             StateHasChanged();
@@ -479,7 +398,7 @@
 
     private void HandleContentReceived(string sessionName, string content)
     {
-        if (sessionName == CopilotService.ActiveSessionName)
+        if (sessionName == CopilotService.ActiveSessionName && activeSession?.IsProcessing == true)
         {
             streamingContent += content;
             InvokeAsync(async () =>
@@ -507,13 +426,16 @@
     {
         if (e.Key == "Enter" && !e.ShiftKey)
         {
-            shouldPreventDefault = true;
             await SendMessage();
         }
-        else
-        {
-            shouldPreventDefault = false;
-        }
+    }
+
+    private async Task StopResponse()
+    {
+        if (activeSession == null) return;
+        await CopilotService.AbortSessionAsync(activeSession.Name);
+        streamingContent = "";
+        StateHasChanged();
     }
 
     private async Task SendMessage()

--- a/Components/Pages/Home.razor.css
+++ b/Components/Pages/Home.razor.css
@@ -105,6 +105,19 @@
     flex-direction: row-reverse;
 }
 
+.message.system {
+    align-self: center;
+    max-width: 100%;
+    justify-content: center;
+}
+
+.system-text {
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.4);
+    text-align: center;
+    padding: 0.25rem 0;
+}
+
 .message-avatar {
     width: 36px;
     height: 36px;
@@ -142,6 +155,7 @@
 .message.assistant .message-text {
     background: rgba(255,255,255,0.1);
     border-bottom-left-radius: 4px;
+    color: white;
 }
 
 .message.streaming .message-text::after {
@@ -160,6 +174,7 @@
 .message.user .message-time { text-align: right; }
 
 /* === Markdown body (::deep for MarkupString inner content) === */
+::deep .markdown-body { color: white; }
 ::deep .markdown-body p { margin: 0 0 0.5rem 0; }
 ::deep .markdown-body p:last-child { margin-bottom: 0; }
 
@@ -279,6 +294,19 @@
 }
 
 .reasoning-block.collapsed .reasoning-content:not(.preview) { display: none; }
+
+/* === Tool summary (grouped completed tools) === */
+.tool-summary {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.8rem;
+    color: rgba(255,255,255,0.4);
+    max-width: 90%;
+}
+
+.tool-summary.has-error { color: rgba(248, 113, 113, 0.6); }
 
 /* === Tool cards === */
 .tool-card {
@@ -470,6 +498,14 @@
 
 .input-area .input-row button:hover:not(:disabled) { background: #2563eb; }
 .input-area .input-row button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.input-area .input-row .stop-btn {
+    padding: 0.75rem;
+    background: #ef4444;
+    border-radius: 8px;
+    min-width: auto;
+}
+.input-area .input-row .stop-btn:hover { background: #dc2626; }
 
 /* === Error bar === */
 .error-bar {

--- a/Components/Pages/Settings.razor
+++ b/Components/Pages/Settings.razor
@@ -1,0 +1,162 @@
+@page "/settings"
+@using AutoPilot.App.Services
+@using AutoPilot.App.Models
+@inject CopilotService CopilotService
+@inject ServerManager ServerManager
+@inject NavigationManager Nav
+
+<div class="settings-page">
+    <div class="settings-header">
+        <h2>⚙️ Connection Settings</h2>
+    </div>
+
+    <div class="settings-section">
+        <h3>Transport Mode</h3>
+        <div class="mode-cards">
+            <div class="mode-card @(settings.Mode == ConnectionMode.Embedded ? "selected" : "")"
+                 @onclick="() => SetMode(ConnectionMode.Embedded)">
+                <div class="mode-icon">🔌</div>
+                <div class="mode-title">Embedded</div>
+                <div class="mode-desc">Default. Copilot process dies when app closes.</div>
+            </div>
+            <div class="mode-card @(settings.Mode == ConnectionMode.Persistent ? "selected" : "")"
+                 @onclick="() => SetMode(ConnectionMode.Persistent)">
+                <div class="mode-icon">🏗️</div>
+                <div class="mode-title">Persistent</div>
+                <div class="mode-desc">Copilot server survives app restarts. Sessions persist.</div>
+            </div>
+        </div>
+    </div>
+
+    @if (settings.Mode == ConnectionMode.Persistent)
+    {
+        <div class="settings-section">
+            <h3>Persistent Server</h3>
+            <div class="server-controls">
+                <div class="server-status">
+                    <span class="status-dot @(serverAlive ? "alive" : "dead")"></span>
+                    <span>@(serverAlive ? $"Running on port {settings.Port}" : "Not running")</span>
+                    @if (ServerManager.ServerPid != null && serverAlive)
+                    {
+                        <span class="pid-label">PID @ServerManager.ServerPid</span>
+                    }
+                </div>
+                <div class="port-input">
+                    <label>Port:</label>
+                    <input type="number" @bind="settings.Port" min="1024" max="65535" />
+                </div>
+                <div class="server-buttons">
+                    @if (!serverAlive)
+                    {
+                        <button class="start-btn" @onclick="StartServer" disabled="@starting">
+                            @(starting ? "⏳ Starting..." : "▶️ Start Server")
+                        </button>
+                    }
+                    else
+                    {
+                        <button class="stop-btn" @onclick="StopServer">⏹️ Stop Server</button>
+                    }
+                </div>
+            </div>
+        </div>
+    }
+
+    <div class="settings-section">
+        <div class="save-row">
+            <button class="save-btn" @onclick="SaveAndApply">
+                💾 Save & Reconnect
+            </button>
+            @if (!string.IsNullOrEmpty(statusMessage))
+            {
+                <span class="save-status @statusClass">@statusMessage</span>
+            }
+        </div>
+    </div>
+
+    <div class="settings-section info">
+        <h3>Current Connection</h3>
+        <p><strong>Mode:</strong> @CopilotService.CurrentMode</p>
+        <p><strong>Status:</strong> @(CopilotService.IsInitialized ? "✅ Connected" : "❌ Disconnected")</p>
+
+        <h3>About Transport Modes</h3>
+        <ul>
+            <li><strong>Embedded</strong> — Simple, default. Copilot process dies when app closes. All sessions are lost.</li>
+            <li><strong>Persistent</strong> — App spawns a detached Copilot server on a port. Survives app restarts — sessions reconnect after relaunching.</li>
+        </ul>
+    </div>
+</div>
+
+@code {
+    private ConnectionSettings settings = new();
+    private string? statusMessage;
+    private string statusClass = "";
+    private bool serverAlive;
+    private bool starting;
+
+    protected override void OnInitialized()
+    {
+        settings = ConnectionSettings.Load();
+        serverAlive = ServerManager.CheckServerRunning("localhost", settings.Port);
+    }
+
+    private void SetMode(ConnectionMode mode)
+    {
+        settings.Mode = mode;
+    }
+
+    private async Task StartServer()
+    {
+        starting = true;
+        StateHasChanged();
+
+        var success = await ServerManager.StartServerAsync(settings.Port);
+        serverAlive = success;
+        starting = false;
+
+        if (success)
+            statusMessage = $"✅ Server started on port {settings.Port}";
+        else
+            statusMessage = "❌ Failed to start server";
+        statusClass = success ? "success" : "error";
+        StateHasChanged();
+    }
+
+    private void StopServer()
+    {
+        ServerManager.StopServer();
+        serverAlive = false;
+        statusMessage = "Server stopped";
+        statusClass = "";
+        StateHasChanged();
+    }
+
+    private async Task SaveAndApply()
+    {
+        // If switching to Persistent mode, ensure server is running
+        if (settings.Mode == ConnectionMode.Persistent && !serverAlive)
+        {
+            statusMessage = "⚠️ Start the persistent server first";
+            statusClass = "error";
+            StateHasChanged();
+            return;
+        }
+
+        settings.Save();
+        statusMessage = "Settings saved. Reconnecting...";
+        statusClass = "";
+        StateHasChanged();
+
+        try
+        {
+            await CopilotService.ReconnectAsync(settings);
+            statusMessage = "✅ Connected!";
+            statusClass = "success";
+        }
+        catch (Exception ex)
+        {
+            statusMessage = $"❌ Connection failed: {ex.Message}";
+            statusClass = "error";
+        }
+        StateHasChanged();
+    }
+}

--- a/Components/Pages/Settings.razor.css
+++ b/Components/Pages/Settings.razor.css
@@ -1,0 +1,332 @@
+.settings-page {
+    padding: 1.5rem;
+    color: white;
+    background: #0f0f23;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.settings-header h2 {
+    margin: 0 0 1.5rem 0;
+    font-size: 1.6rem;
+}
+
+.settings-section {
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 12px;
+    padding: 1.25rem;
+    margin-bottom: 1rem;
+}
+
+.settings-section h3 {
+    margin: 0 0 1rem 0;
+    font-size: 1.15rem;
+    color: rgba(255,255,255,0.9);
+}
+
+.settings-section.info {
+    background: rgba(59, 130, 246, 0.08);
+    border-color: rgba(59, 130, 246, 0.2);
+}
+
+.settings-section.info p {
+    color: rgba(255,255,255,0.6);
+    margin: 0.5rem 0;
+}
+
+.settings-section.info code {
+    display: block;
+    background: rgba(0,0,0,0.3);
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    font-family: monospace;
+    color: #60a5fa;
+    margin: 0.5rem 0;
+}
+
+.settings-section.info ul {
+    color: rgba(255,255,255,0.6);
+    padding-left: 1.25rem;
+    margin: 0.5rem 0 0;
+}
+
+.settings-section.info li {
+    margin: 0.25rem 0;
+}
+
+.mode-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+}
+
+.mode-card {
+    border: 2px solid rgba(255,255,255,0.15);
+    border-radius: 10px;
+    padding: 1rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-align: center;
+}
+
+.mode-card:hover {
+    border-color: rgba(255,255,255,0.3);
+    background: rgba(255,255,255,0.05);
+}
+
+.mode-card.selected {
+    border-color: #3b82f6;
+    background: rgba(59, 130, 246, 0.1);
+}
+
+.mode-icon {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+.mode-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 0.3rem;
+}
+
+.mode-desc {
+    font-size: 0.85rem;
+    color: rgba(255,255,255,0.5);
+}
+
+.form-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.form-row label {
+    min-width: 60px;
+    color: rgba(255,255,255,0.7);
+    font-size: 0.95rem;
+}
+
+.form-input {
+    flex: 1;
+    max-width: 250px;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid rgba(255,255,255,0.2);
+    border-radius: 6px;
+    background: rgba(255,255,255,0.08);
+    color: white;
+    font-size: 0.95rem;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: #3b82f6;
+}
+
+.server-status {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0.75rem 0;
+    padding: 0.5rem 0.75rem;
+    background: rgba(0,0,0,0.2);
+    border-radius: 6px;
+}
+
+.status-running {
+    color: #48bb78;
+}
+
+.status-stopped {
+    color: rgba(255,255,255,0.4);
+}
+
+.status-checking {
+    color: #fbbf24;
+}
+
+.check-btn {
+    padding: 0.25rem 0.6rem;
+    border: 1px solid rgba(255,255,255,0.2);
+    border-radius: 4px;
+    background: transparent;
+    color: rgba(255,255,255,0.6);
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+
+.check-btn:hover:not(:disabled) {
+    border-color: rgba(255,255,255,0.4);
+    color: white;
+}
+
+.server-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0.75rem 0;
+}
+
+.action-btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.action-btn.start {
+    background: #48bb78;
+    color: white;
+}
+
+.action-btn.start:hover:not(:disabled) {
+    background: #38a169;
+}
+
+.action-btn.start:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.action-btn.stop {
+    background: rgba(239, 68, 68, 0.8);
+    color: white;
+}
+
+.action-btn.stop:hover {
+    background: #ef4444;
+}
+
+.action-hint {
+    font-size: 0.8rem;
+    color: rgba(255,255,255,0.3);
+    font-family: monospace;
+}
+
+.save-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.save-btn {
+    padding: 0.6rem 1.5rem;
+    border: none;
+    border-radius: 8px;
+    background: #3b82f6;
+    color: white;
+    font-size: 1rem;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.save-btn:hover {
+    background: #2563eb;
+}
+
+.save-status {
+    font-size: 0.9rem;
+    color: rgba(255,255,255,0.6);
+}
+
+.save-status.success {
+    color: #48bb78;
+}
+
+.save-status.error {
+    color: #ef4444;
+}
+
+.server-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.status-dot.alive {
+    background: #48bb78;
+    box-shadow: 0 0 6px #48bb78;
+}
+
+.status-dot.dead {
+    background: rgba(255,255,255,0.3);
+}
+
+.pid-label {
+    font-size: 0.8rem;
+    color: rgba(255,255,255,0.4);
+    font-family: monospace;
+}
+
+.port-input {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.port-input label {
+    color: rgba(255,255,255,0.7);
+}
+
+.port-input input {
+    width: 100px;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid rgba(255,255,255,0.2);
+    border-radius: 6px;
+    background: rgba(255,255,255,0.08);
+    color: white;
+    font-size: 0.95rem;
+}
+
+.port-input input:focus {
+    outline: none;
+    border-color: #3b82f6;
+}
+
+.server-buttons {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.start-btn, .stop-btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.start-btn {
+    background: #48bb78;
+    color: white;
+}
+
+.start-btn:hover:not(:disabled) {
+    background: #38a169;
+}
+
+.start-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.stop-btn {
+    background: rgba(239, 68, 68, 0.8);
+    color: white;
+}
+
+.stop-btn:hover {
+    background: #ef4444;
+}

--- a/Models/ChatMessage.cs
+++ b/Models/ChatMessage.cs
@@ -6,7 +6,8 @@ public enum ChatMessageType
     Assistant,
     Reasoning,
     ToolCall,
-    Error
+    Error,
+    System
 }
 
 public class ChatMessage
@@ -56,4 +57,7 @@ public class ChatMessage
 
     public static ChatMessage ErrorMessage(string content, string? toolName = null) =>
         new("assistant", content, DateTime.Now, ChatMessageType.Error) { ToolName = toolName, IsComplete = true };
+
+    public static ChatMessage SystemMessage(string content) =>
+        new("system", content, DateTime.Now, ChatMessageType.System) { IsComplete = true };
 }

--- a/Models/ConnectionSettings.cs
+++ b/Models/ConnectionSettings.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AutoPilot.App.Models;
+
+public enum ConnectionMode
+{
+    Embedded,   // SDK spawns copilot via stdio (default, dies with app)
+    Persistent  // App spawns detached copilot server; survives app restarts
+}
+
+public class ConnectionSettings
+{
+    public ConnectionMode Mode { get; set; } = ConnectionMode.Embedded;
+    public string Host { get; set; } = "localhost";
+    public int Port { get; set; } = 4321;
+    public bool AutoStartServer { get; set; } = false;
+
+    [JsonIgnore]
+    public string CliUrl => $"{Host}:{Port}";
+
+    private static readonly string SettingsPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".copilot", "autopilot-settings.json");
+
+    public static ConnectionSettings Load()
+    {
+        try
+        {
+            if (File.Exists(SettingsPath))
+            {
+                var json = File.ReadAllText(SettingsPath);
+                return JsonSerializer.Deserialize<ConnectionSettings>(json) ?? new();
+            }
+        }
+        catch { }
+        return new();
+    }
+
+    public void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(SettingsPath)!;
+            Directory.CreateDirectory(dir);
+            var json = JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(SettingsPath, json);
+        }
+        catch { }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,270 @@
+# AutoPilot.App
+
+A .NET MAUI Blazor hybrid desktop app that manages multiple GitHub Copilot CLI sessions. AutoPilot provides a native GUI for creating, orchestrating, and interacting with parallel Copilot agent sessions — acting as a multi-agent control plane.
+
+## What Problem It Solves
+
+Working with GitHub Copilot CLI is powerful, but limited to a single terminal session at a time. AutoPilot lets you:
+
+- Run **multiple Copilot sessions in parallel**, each with its own model, working directory, and conversation history
+- **Orchestrate agents** from a dashboard — broadcast the same prompt to all sessions at once
+- **Resume sessions** across app restarts — sessions persist to disk and can be picked up later
+- **Choose connection modes** — from simple embedded stdio to a persistent server that outlives the app
+
+## Features
+
+### Multi-Session Management
+Create named sessions with different models and working directories. Sessions appear in a sidebar and can be switched between instantly. Each session maintains its own conversation history and processing state.
+
+### Chat Interface
+Full chat UI with streaming responses, real-time activity logging, Markdown rendering (code blocks, inline code, bold), and auto-scrolling. Shows typing indicators and tool execution status as Copilot works.
+
+### Session Orchestrator Dashboard
+A grid view of all active sessions showing their last messages, streaming output, and processing state. Includes per-card message input and a **Broadcast to All** feature to send the same prompt to every idle session simultaneously.
+
+### Real-Time Activity Log
+During processing, the UI displays a live activity feed showing Copilot's intent (`💭 Thinking...`), tool calls (`🔧 Running bash...`), and completion status (`✅ Tool completed`). This gives full visibility into multi-step agent workflows.
+
+### Session Persistence & Resume
+- **Active sessions** are saved to `~/.copilot/autopilot-active-sessions.json` and automatically restored on app relaunch
+- **All Copilot sessions** persisted in `~/.copilot/session-state/` can be browsed and resumed from the sidebar's "Saved Sessions" panel
+- Conversation history is reconstructed from the SDK's `events.jsonl` files on resume
+- Sessions display their first user message as a title for easy identification
+
+### UI State Persistence
+The app remembers which page you were on (Chat, Dashboard, or Settings) and which session was active, restoring both on relaunch via `~/.copilot/autopilot-ui-state.json`.
+
+### Auto-Reconnect
+If a session disconnects during a prompt, the service automatically attempts to resume the session by its GUID and retry the message.
+
+### Per-Session Working Directory
+Each session can target a different directory on disk. A native macOS folder picker (via `UIDocumentPickerViewController`) is available for browsing.
+
+### Model Selection
+Sessions can be created with any of the supported models:
+`claude-opus-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `claude-haiku-4.5`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gemini-3-pro-preview`
+
+### System Instructions
+Automatically loads project-level instructions from `.github/copilot-instructions.md` and appends them to every session's system message. When a session targets the AutoPilot project directory, it also injects build/relaunch instructions.
+
+### Crash Logging
+Unhandled exceptions and unobserved task failures are caught globally and written to `~/.copilot/autopilot-crash.log`.
+
+## Connection Modes
+
+AutoPilot supports three transport modes, configurable from the Settings page:
+
+| Mode | Transport | Lifecycle | Best For |
+|------|-----------|-----------|----------|
+| **Embedded** (default) | stdio | Dies with app | Simple single-machine use |
+| **TCP Server** | SDK-managed TCP | Dies with app | More stable long sessions |
+| **Persistent Server** | Detached TCP server | Survives app restarts | Session continuity across relaunches |
+
+### Embedded (stdio)
+The SDK spawns a Copilot CLI process and communicates via stdin/stdout. Simplest setup — no port configuration needed. The process terminates when the app closes.
+
+### TCP Server
+The SDK spawns and manages a Copilot CLI process using TCP transport internally. More stable for long-running sessions, but the server still dies when the app exits.
+
+### Persistent Server
+The app spawns a **detached** Copilot CLI server process (`copilot --headless --port 4321`) that runs independently. The server's PID and port are tracked in `~/.copilot/autopilot-server.pid`. On relaunch, the app detects the existing server and reconnects. You can start/stop the server from the Settings page.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    AutoPilot.App                        │
+│              (.NET MAUI Blazor Hybrid)                  │
+│                                                         │
+│  ┌──────────────┐  ┌────────────┐  ┌────────────────┐  │
+│  │ SessionSidebar│  │  Home.razor│  │ Dashboard.razor│  │
+│  │  (create/     │  │  (chat UI) │  │ (orchestrator) │  │
+│  │   resume)     │  │            │  │                │  │
+│  └──────┬───────┘  └─────┬──────┘  └───────┬────────┘  │
+│         │                │                  │           │
+│         └────────────────┼──────────────────┘           │
+│                          │                              │
+│                ┌─────────▼──────────┐                   │
+│                │   CopilotService   │ (singleton)       │
+│                │ ┌───────────────┐  │                   │
+│                │ │ SessionState  │  │ ConcurrentDict    │
+│                │ │  ├─ Session   │  │ of named sessions │
+│                │ │  ├─ Info      │  │                   │
+│                │ │  └─ Response  │  │                   │
+│                │ └───────────────┘  │                   │
+│                └─────────┬──────────┘                   │
+│                          │                              │
+│                ┌─────────▼──────────┐                   │
+│                │   CopilotClient   │ (GitHub.Copilot.SDK)│
+│                └─────────┬──────────┘                   │
+│                          │                              │
+│         ┌────────────────┼────────────────┐             │
+│         │ stdio          │ TCP            │ TCP (remote)│
+│         ▼                ▼                ▼             │
+│   ┌──────────┐    ┌──────────┐    ┌──────────────┐     │
+│   │ copilot  │    │ copilot  │    │  Persistent  │     │
+│   │ (child)  │    │ (child)  │    │  Server      │     │
+│   └──────────┘    └──────────┘    │  (detached)  │     │
+│                                   └──────────────┘     │
+│                                         ▲              │
+│                          ┌──────────────┘              │
+│                   ┌──────┴────────┐                    │
+│                   │ ServerManager │ (PID file tracking) │
+│                   └───────────────┘                    │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Key Components
+
+- **`CopilotService`** — Singleton service wrapping the Copilot SDK. Manages a `ConcurrentDictionary` of named sessions, handles all SDK events (deltas, tool calls, intents, errors), marshals events to the UI thread via `SynchronizationContext`, and persists session/UI state to disk.
+- **`ServerManager`** — Manages the persistent Copilot server lifecycle: start, stop, detect existing instances, PID file tracking, TCP health checks.
+- **`CopilotClient`** / **`CopilotSession`** — From `GitHub.Copilot.SDK`. The client creates/resumes sessions; sessions send prompts and emit events via the ACP (Agent Control Protocol).
+
+### SDK Event Flow
+
+When a prompt is sent, the SDK emits events processed by `HandleSessionEvent`:
+
+1. `AssistantTurnStartEvent` → "Thinking..." activity
+2. `AssistantMessageDeltaEvent` → streaming content chunks to the UI
+3. `AssistantMessageEvent` → full message with optional tool requests
+4. `ToolExecutionStartEvent` / `ToolExecutionCompleteEvent` → tool activity indicators
+5. `AssistantIntentEvent` → intent/plan updates
+6. `SessionIdleEvent` → turn complete, response finalized, notifications fired
+
+## Project Structure
+
+```
+AutoPilot.App/
+├── AutoPilot.App.csproj        # Project config, SDK reference, trimmer settings
+├── MauiProgram.cs              # App bootstrap, DI registration, crash logging
+├── relaunch.sh                 # Build + seamless relaunch script
+├── .github/
+│   └── copilot-instructions.md # System instructions loaded into every session
+├── Models/
+│   ├── AgentSessionInfo.cs     # Session metadata (name, model, history, state)
+│   ├── ChatMessage.cs          # Chat message record (role, content, timestamp)
+│   └── ConnectionSettings.cs   # Connection mode enum + serializable settings
+├── Services/
+│   ├── CopilotService.cs       # Core service: session CRUD, events, persistence
+│   └── ServerManager.cs        # Persistent server lifecycle + PID tracking
+├── Components/
+│   ├── Layout/
+│   │   ├── MainLayout.razor    # App shell with sidebar + content area
+│   │   ├── SessionSidebar.razor# Session list, create/resume, model picker
+│   │   └── NavMenu.razor       # Top navigation bar
+│   └── Pages/
+│       ├── Home.razor          # Chat UI with streaming + activity log
+│       ├── Dashboard.razor     # Multi-session orchestrator grid
+│       └── Settings.razor      # Connection mode selector, server controls
+├── Platforms/
+│   └── MacCatalyst/
+│       ├── Entitlements.plist  # Sandbox disabled, network access enabled
+│       ├── FolderPickerService.cs # Native macOS folder picker
+│       └── Program.cs          # Mac Catalyst entry point
+└── wwwroot/
+    └── app.css                 # Global styles
+```
+
+## Prerequisites
+
+- **.NET 10 SDK** (Preview) — the project targets `net10.0-maccatalyst`
+- **.NET MAUI workload** — install with `dotnet workload install maui`
+- **GitHub Copilot CLI** — installed globally via npm (`npm install -g @github/copilot`)
+- **macOS** — the app runs as a Mac Catalyst application (macOS 15.0+)
+- **GitHub Copilot subscription** — required for the CLI to authenticate
+
+## Building & Running
+
+### First-time setup
+
+```bash
+# Install .NET MAUI workload
+dotnet workload install maui
+
+# Restore NuGet packages
+cd /path/to/AutoPilot.App
+dotnet restore
+```
+
+### Build and run
+
+```bash
+# Build for Mac Catalyst
+dotnet build -f net10.0-maccatalyst
+
+# Run the app
+open bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/AutoPilot.App.app
+```
+
+### Relaunch after code changes
+
+The project includes a `relaunch.sh` script for seamless hot-relaunch. It builds, copies to a staging directory, launches a new instance, waits for it to start, then kills the old one:
+
+```bash
+./relaunch.sh
+```
+
+This is safe to run from a Copilot session inside the app — the new instance is fully running before the old one is terminated.
+
+## Configuration
+
+### Settings files (all in `~/.copilot/`)
+
+| File | Purpose |
+|------|---------|
+| `autopilot-settings.json` | Connection mode, host, port, auto-start preference |
+| `autopilot-active-sessions.json` | List of active sessions (session ID, display name, model) for restore on relaunch |
+| `autopilot-ui-state.json` | Last active page and session name |
+| `autopilot-server.pid` | PID and port of the persistent Copilot server |
+| `autopilot-crash.log` | Unhandled exception log |
+| `session-state/<guid>/events.jsonl` | Per-session event history (managed by Copilot SDK) |
+
+### Example `autopilot-settings.json`
+
+```json
+{
+  "Mode": 0,
+  "Host": "localhost",
+  "Port": 4321,
+  "AutoStartServer": false
+}
+```
+
+Mode values: `0` = Embedded, `1` = Server, `2` = Persistent.
+
+## How It Works
+
+### Session Lifecycle
+
+1. **Create**: User enters a name, picks a model and optional working directory in the sidebar. `CopilotService.CreateSessionAsync` calls `CopilotClient.CreateSessionAsync` with a `SessionConfig` (model, working directory, system message). The SDK spawns/connects to Copilot and returns a `CopilotSession`.
+
+2. **Chat**: User types a message → `SendPromptAsync` adds it to history, calls `session.SendAsync`, and awaits a `TaskCompletionSource` that completes when `SessionIdleEvent` fires. Streaming deltas are emitted to the UI in real time.
+
+3. **Persist**: After every session create/close, the active session list is written to disk. The Copilot SDK independently persists session state in `~/.copilot/session-state/<guid>/`.
+
+4. **Resume**: On relaunch, `RestorePreviousSessionsAsync` reads the active sessions file and calls `ResumeSessionAsync` for each. Conversation history is reconstructed from the SDK's `events.jsonl`. Users can also manually resume any saved session from the sidebar.
+
+5. **Close**: `CloseSessionAsync` disposes the `CopilotSession`, removes it from the dictionary, and updates the active sessions file.
+
+### Event Handling
+
+All SDK events are received on background threads. `CopilotService` captures the UI `SynchronizationContext` during initialization and uses `_syncContext.Post` to marshal event callbacks to the Blazor UI thread, where components call `StateHasChanged()` to re-render.
+
+### Reconnect on Failure
+
+If `SendAsync` throws (e.g., the underlying process died), the service attempts to resume the session by its persisted GUID and retry the prompt once. This is transparent to the user — they see a "🔄 Reconnecting session..." activity indicator.
+
+### Persistent Server Detection
+
+On startup in Persistent mode, `ServerManager.DetectExistingServer()` reads `autopilot-server.pid`, checks if the process is alive via TCP connect, and reuses it if available. Stale PID files are cleaned up automatically.
+
+## NuGet Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `GitHub.Copilot.SDK` | 0.1.22 | Copilot CLI client (ACP protocol) |
+| `Microsoft.Maui.Controls` | (MAUI SDK) | .NET MAUI framework |
+| `Microsoft.AspNetCore.Components.WebView.Maui` | (MAUI SDK) | Blazor WebView for MAUI |
+| `Microsoft.Extensions.Logging.Debug` | 10.0.0 | Debug logging |
+
+> **Note**: The csproj includes `<TrimmerRootAssembly Include="GitHub.Copilot.SDK" />` to prevent the linker from stripping SDK event types needed for runtime pattern matching. Do not remove this.

--- a/Services/CopilotService.cs
+++ b/Services/CopilotService.cs
@@ -9,9 +9,15 @@ namespace AutoPilot.App.Services;
 public class CopilotService : IAsyncDisposable
 {
     private readonly ConcurrentDictionary<string, SessionState> _sessions = new();
+    private readonly ServerManager _serverManager;
     private CopilotClient? _client;
     private string? _activeSessionName;
     private SynchronizationContext? _syncContext;
+    
+    public CopilotService(ServerManager serverManager)
+    {
+        _serverManager = serverManager;
+    }
     
     private static readonly string SessionStatePath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
@@ -47,6 +53,7 @@ public class CopilotService : IAsyncDisposable
     public string? SystemInstructions { get; set; }
     public bool IsInitialized { get; private set; }
     public string? ActiveSessionName => _activeSessionName;
+    public ConnectionMode CurrentMode { get; private set; } = ConnectionMode.Embedded;
 
     // Debug info
     public string LastDebugMessage { get; private set; } = "";
@@ -74,6 +81,8 @@ public class CopilotService : IAsyncDisposable
         public required AgentSessionInfo Info { get; init; }
         public TaskCompletionSource<string>? ResponseCompletion { get; set; }
         public StringBuilder CurrentResponse { get; } = new();
+        public bool HasReceivedDeltasThisTurn { get; set; }
+        public string? LastMessageId { get; set; }
     }
 
     private void Debug(string message)
@@ -91,10 +100,34 @@ public class CopilotService : IAsyncDisposable
         _syncContext = SynchronizationContext.Current;
         Debug($"SyncContext captured: {_syncContext?.GetType().Name ?? "null"}");
 
-        _client = new CopilotClient();
+        var settings = ConnectionSettings.Load();
+        CurrentMode = settings.Mode;
+
+        // In Persistent mode, auto-start the server if not already running
+        if (settings.Mode == ConnectionMode.Persistent)
+        {
+            if (!_serverManager.CheckServerRunning("localhost", settings.Port))
+            {
+                Debug($"Persistent server not running, auto-starting on port {settings.Port}...");
+                var started = await _serverManager.StartServerAsync(settings.Port);
+                if (!started)
+                {
+                    Debug("Failed to auto-start server, falling back to Embedded mode");
+                    settings.Mode = ConnectionMode.Embedded;
+                    CurrentMode = ConnectionMode.Embedded;
+                }
+            }
+            else
+            {
+                Debug($"Persistent server already running on port {settings.Port}");
+            }
+        }
+
+        _client = CreateClient(settings);
+
         await _client.StartAsync(cancellationToken);
         IsInitialized = true;
-        Debug("Copilot client started");
+        Debug($"Copilot client started in {settings.Mode} mode");
 
         // Load default system instructions from the project's copilot-instructions.md
         var instructionsPath = Path.Combine(ProjectDir, ".github", "copilot-instructions.md");
@@ -105,6 +138,58 @@ public class CopilotService : IAsyncDisposable
         }
 
         OnStateChanged?.Invoke();
+
+        // Restore previous sessions (includes subscribing to untracked server sessions in Persistent mode)
+        await RestorePreviousSessionsAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Disconnect from current client and reconnect with new settings
+    /// </summary>
+    public async Task ReconnectAsync(ConnectionSettings settings, CancellationToken cancellationToken = default)
+    {
+        Debug($"Reconnecting with mode: {settings.Mode}...");
+
+        // Dispose existing sessions and client
+        foreach (var state in _sessions.Values)
+        {
+            try { await state.Session.DisposeAsync(); } catch { }
+        }
+        _sessions.Clear();
+        _activeSessionName = null;
+
+        if (_client != null)
+        {
+            try { await _client.DisposeAsync(); } catch { }
+            _client = null;
+        }
+
+        IsInitialized = false;
+        CurrentMode = settings.Mode;
+        OnStateChanged?.Invoke();
+
+        _client = CreateClient(settings);
+
+        await _client.StartAsync(cancellationToken);
+        IsInitialized = true;
+        Debug($"Reconnected in {settings.Mode} mode");
+        OnStateChanged?.Invoke();
+
+        // Restore previous sessions
+        await RestorePreviousSessionsAsync(cancellationToken);
+    }
+
+    private static CopilotClient CreateClient(ConnectionSettings settings)
+    {
+        return settings.Mode switch
+        {
+            ConnectionMode.Persistent => new CopilotClient(new CopilotClientOptions
+            {
+                CliUrl = settings.CliUrl,
+                UseStdio = false
+            }),
+            _ => new CopilotClient()
+        };
     }
 
     /// <summary>
@@ -330,6 +415,9 @@ public class CopilotService : IAsyncDisposable
         }
         info.MessageCount = info.History.Count;
 
+        // Add reconnection indicator
+        info.History.Add(ChatMessage.SystemMessage("🔄 Session reconnected"));
+
         var state = new SessionState
         {
             Session = copilotSession,
@@ -460,14 +548,18 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
 
             case AssistantMessageDeltaEvent delta:
                 var deltaContent = delta.Data.DeltaContent;
+                state.HasReceivedDeltasThisTurn = true;
                 state.CurrentResponse.Append(deltaContent);
                 Invoke(() => OnContentReceived?.Invoke(sessionName, deltaContent ?? ""));
                 break;
 
             case AssistantMessageEvent msg:
                 var msgContent = msg.Data.Content;
-                if (!string.IsNullOrEmpty(msgContent) && state.CurrentResponse.Length == 0)
+                var msgId = msg.Data.MessageId;
+                // Deduplicate: SDK fires this event multiple times for resumed sessions
+                if (!string.IsNullOrEmpty(msgContent) && !state.HasReceivedDeltasThisTurn && msgId != state.LastMessageId)
                 {
+                    state.LastMessageId = msgId;
                     state.CurrentResponse.Append(msgContent);
                     Invoke(() => OnContentReceived?.Invoke(sessionName, msgContent));
                 }
@@ -519,6 +611,7 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
                 break;
 
             case AssistantTurnStartEvent:
+                state.HasReceivedDeltasThisTurn = false;
                 Invoke(() =>
                 {
                     OnTurnStart?.Invoke(sessionName);
@@ -667,10 +760,47 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
         catch (Exception ex)
         {
             Console.WriteLine($"[DEBUG] SendAsync threw: {ex.Message}");
-            OnError?.Invoke(sessionName, $"SendAsync failed: {ex.Message}");
-            state.Info.IsProcessing = false;
-            OnStateChanged?.Invoke();
-            throw;
+            
+            // Try to reconnect the session and retry once
+            if (state.Info.SessionId != null)
+            {
+                Debug($"Session '{sessionName}' disconnected, attempting reconnect...");
+                OnActivity?.Invoke(sessionName, "🔄 Reconnecting session...");
+                try
+                {
+                    await state.Session.DisposeAsync();
+                    var newSession = await _client!.ResumeSessionAsync(state.Info.SessionId, cancellationToken: cancellationToken);
+                    var newState = new SessionState
+                    {
+                        Session = newSession,
+                        Info = state.Info
+                    };
+                    newSession.On(evt => HandleSessionEvent(newState, evt));
+                    _sessions[sessionName] = newState;
+                    state = newState;
+                    
+                    Debug($"Session '{sessionName}' reconnected, retrying prompt...");
+                    await state.Session.SendAsync(new MessageOptions
+                    {
+                        Prompt = prompt
+                    }, cancellationToken);
+                }
+                catch (Exception retryEx)
+                {
+                    Console.WriteLine($"[DEBUG] Reconnect+retry failed: {retryEx.Message}");
+                    OnError?.Invoke(sessionName, $"Session disconnected and reconnect failed: {retryEx.Message}");
+                    state.Info.IsProcessing = false;
+                    OnStateChanged?.Invoke();
+                    throw;
+                }
+            }
+            else
+            {
+                OnError?.Invoke(sessionName, $"SendAsync failed: {ex.Message}");
+                state.Info.IsProcessing = false;
+                OnStateChanged?.Invoke();
+                throw;
+            }
         }
 
         Console.WriteLine($"[DEBUG] SendAsync completed, waiting for response...");
@@ -688,6 +818,28 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
         });
 
         return await state.ResponseCompletion.Task;
+    }
+
+    public async Task AbortSessionAsync(string sessionName)
+    {
+        if (!_sessions.TryGetValue(sessionName, out var state))
+            return;
+
+        if (!state.Info.IsProcessing) return;
+
+        try
+        {
+            await state.Session.AbortAsync();
+            Debug($"Aborted session '{sessionName}'");
+        }
+        catch (Exception ex)
+        {
+            Debug($"Abort failed for '{sessionName}': {ex.Message}");
+        }
+
+        state.Info.IsProcessing = false;
+        state.ResponseCompletion?.TrySetCanceled();
+        OnStateChanged?.Invoke();
     }
 
     public void EnqueueMessage(string sessionName, string prompt)
@@ -841,40 +993,43 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
     /// </summary>
     public async Task RestorePreviousSessionsAsync(CancellationToken cancellationToken = default)
     {
-        if (!File.Exists(ActiveSessionsFile)) return;
-
-        try
+        if (File.Exists(ActiveSessionsFile))
         {
-            var json = await File.ReadAllTextAsync(ActiveSessionsFile, cancellationToken);
-            var entries = JsonSerializer.Deserialize<List<ActiveSessionEntry>>(json);
-            if (entries == null || entries.Count == 0) return;
-
-            Debug($"Restoring {entries.Count} previous sessions...");
-
-            foreach (var entry in entries)
+            try
             {
-                try
+                var json = await File.ReadAllTextAsync(ActiveSessionsFile, cancellationToken);
+                var entries = JsonSerializer.Deserialize<List<ActiveSessionEntry>>(json);
+                if (entries != null && entries.Count > 0)
                 {
-                    // Skip if already active
-                    if (_sessions.ContainsKey(entry.DisplayName)) continue;
-                    
-                    // Check the session still exists on disk
-                    var sessionDir = Path.Combine(SessionStatePath, entry.SessionId);
-                    if (!Directory.Exists(sessionDir)) continue;
+                    Debug($"Restoring {entries.Count} previous sessions...");
 
-                    await ResumeSessionAsync(entry.SessionId, entry.DisplayName, cancellationToken);
-                    Debug($"Restored session: {entry.DisplayName}");
-                }
-                catch (Exception ex)
-                {
-                    Debug($"Failed to restore '{entry.DisplayName}': {ex.Message}");
+                    foreach (var entry in entries)
+                    {
+                        try
+                        {
+                            // Skip if already active
+                            if (_sessions.ContainsKey(entry.DisplayName)) continue;
+                            
+                            // Check the session still exists on disk
+                            var sessionDir = Path.Combine(SessionStatePath, entry.SessionId);
+                            if (!Directory.Exists(sessionDir)) continue;
+
+                            await ResumeSessionAsync(entry.SessionId, entry.DisplayName, cancellationToken);
+                            Debug($"Restored session: {entry.DisplayName}");
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug($"Failed to restore '{entry.DisplayName}': {ex.Message}");
+                        }
+                    }
                 }
             }
+            catch (Exception ex)
+            {
+                Debug($"Failed to load active sessions file: {ex.Message}");
+            }
         }
-        catch (Exception ex)
-        {
-            Debug($"Failed to load active sessions file: {ex.Message}");
-        }
+
     }
 
     public async ValueTask DisposeAsync()

--- a/Services/ServerManager.cs
+++ b/Services/ServerManager.cs
@@ -1,0 +1,211 @@
+using System.Diagnostics;
+using System.Net.Sockets;
+using AutoPilot.App.Models;
+
+namespace AutoPilot.App.Services;
+
+public class ServerManager
+{
+    private static readonly string PidFilePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".copilot", "autopilot-server.pid");
+
+    public bool IsServerRunning => CheckServerRunning();
+    public int? ServerPid => ReadPidFile();
+    public int ServerPort { get; private set; } = 4321;
+
+    public event Action? OnStatusChanged;
+
+    /// <summary>
+    /// Check if a copilot server is listening on the given port
+    /// </summary>
+    public bool CheckServerRunning(string host = "localhost", int? port = null)
+    {
+        port ??= ServerPort;
+        try
+        {
+            using var client = new TcpClient();
+            var result = client.BeginConnect(host, port.Value, null, null);
+            var success = result.AsyncWaitHandle.WaitOne(TimeSpan.FromSeconds(1));
+            if (success && client.Connected)
+            {
+                client.EndConnect(result);
+                return true;
+            }
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Start copilot in headless server mode, detached from app lifecycle
+    /// </summary>
+    public async Task<bool> StartServerAsync(int port = 4321)
+    {
+        ServerPort = port;
+
+        if (CheckServerRunning("localhost", port))
+        {
+            Console.WriteLine($"[ServerManager] Server already running on port {port}");
+            OnStatusChanged?.Invoke();
+            return true;
+        }
+
+        try
+        {
+            // Use the native binary directly for better detachment
+            var copilotPath = FindCopilotBinary();
+            var psi = new ProcessStartInfo
+            {
+                FileName = copilotPath,
+                Arguments = $"--headless --log-level info --port {port}",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                RedirectStandardInput = false
+            };
+
+            var process = Process.Start(psi);
+            if (process == null)
+            {
+                Console.WriteLine("[ServerManager] Failed to start copilot process");
+                return false;
+            }
+
+            SavePidFile(process.Id, port);
+            Console.WriteLine($"[ServerManager] Started copilot server PID {process.Id} on port {port}");
+
+            // Detach stdout/stderr readers so they don't hold the process
+            _ = Task.Run(async () =>
+            {
+                try { while (await process.StandardOutput.ReadLineAsync() != null) { } } catch { }
+            });
+            _ = Task.Run(async () =>
+            {
+                try { while (await process.StandardError.ReadLineAsync() != null) { } } catch { }
+            });
+
+            // Wait for server to become available
+            for (int i = 0; i < 15; i++)
+            {
+                await Task.Delay(1000);
+                if (CheckServerRunning("localhost", port))
+                {
+                    Console.WriteLine($"[ServerManager] Server is ready on port {port}");
+                    OnStatusChanged?.Invoke();
+                    return true;
+                }
+            }
+
+            Console.WriteLine("[ServerManager] Server started but not responding on port");
+            OnStatusChanged?.Invoke();
+            return false;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[ServerManager] Error starting server: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Stop the persistent server
+    /// </summary>
+    public void StopServer()
+    {
+        var pid = ReadPidFile();
+        if (pid != null)
+        {
+            try
+            {
+                var process = Process.GetProcessById(pid.Value);
+                process.Kill();
+                Console.WriteLine($"[ServerManager] Killed server PID {pid}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[ServerManager] Error stopping server: {ex.Message}");
+            }
+            DeletePidFile();
+            OnStatusChanged?.Invoke();
+        }
+    }
+
+    /// <summary>
+    /// Check if a server from a previous app session is still alive
+    /// </summary>
+    public bool DetectExistingServer()
+    {
+        var info = ReadPidFileInfo();
+        if (info == null) return false;
+
+        ServerPort = info.Value.Port;
+        if (CheckServerRunning("localhost", info.Value.Port))
+        {
+            Console.WriteLine($"[ServerManager] Found existing server PID {info.Value.Pid} on port {info.Value.Port}");
+            return true;
+        }
+
+        // PID file exists but server is dead — clean up
+        DeletePidFile();
+        return false;
+    }
+
+    private void SavePidFile(int pid, int port)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(PidFilePath)!;
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(PidFilePath, $"{pid}\n{port}");
+        }
+        catch { }
+    }
+
+    private int? ReadPidFile()
+    {
+        return ReadPidFileInfo()?.Pid;
+    }
+
+    private (int Pid, int Port)? ReadPidFileInfo()
+    {
+        try
+        {
+            if (!File.Exists(PidFilePath)) return null;
+            var lines = File.ReadAllLines(PidFilePath);
+            if (lines.Length >= 2 && int.TryParse(lines[0], out var pid) && int.TryParse(lines[1], out var port))
+                return (pid, port);
+            if (lines.Length >= 1 && int.TryParse(lines[0], out pid))
+                return (pid, 4321);
+        }
+        catch { }
+        return null;
+    }
+
+    private void DeletePidFile()
+    {
+        try { File.Delete(PidFilePath); } catch { }
+    }
+
+    private static string FindCopilotBinary()
+    {
+        // Try the native binary first (faster startup, better detachment)
+        var nativePaths = new[]
+        {
+            "/opt/homebrew/lib/node_modules/@github/copilot/node_modules/@github/copilot-darwin-arm64/copilot",
+            "/usr/local/lib/node_modules/@github/copilot/node_modules/@github/copilot-darwin-arm64/copilot",
+        };
+
+        foreach (var path in nativePaths)
+        {
+            if (File.Exists(path)) return path;
+        }
+
+        // Fallback to node wrapper
+        return "copilot";
+    }
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -30,6 +30,16 @@
             Notification.requestPermission();
         }
 
+        window.setupTextareaEnterHandler = function(element) {
+            if (!element || element._enterHandlerSet) return;
+            element._enterHandlerSet = true;
+            element.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                }
+            });
+        };
+
         window.scrollToBottom = function(element) {
             if (element) {
                 element.scrollTop = element.scrollHeight;


### PR DESCRIPTION
## Summary

Adds persistent Copilot sessions that survive app restarts, fixes critical streaming/rendering bugs, and adds a stop button + settings page.

### Features
- **Persistent sessions**: Toggle between Embedded (default) and Persistent mode in Settings. Persistent mode spawns a detached `copilot --headless --port N` server that survives app restarts. Sessions auto-reconnect on relaunch.
- **Stop button**: Red ■ button appears next to Send when a response is streaming. Calls SDK `AbortAsync()` to interrupt.
- **Settings page**: New ⚙️ tab in sidebar to configure connection mode, start/stop persistent server.
- **Session reconnection indicator**: Shows "🔄 Session reconnected" system message after resume.

### Bug Fixes
- **Message duplication** (10x+ repeated text): SDK fires `AssistantMessageEvent` once per stacked resume handler. Fixed by deduplicating on `MessageId`.
- **Vanishing messages**: `streamingContent` was being cleared between turns in multi-turn agent loops. Now accumulates across turns until the full response completes.
- **Invisible text**: Bootstrap's dark text color overriding our dark theme. Added explicit `color: white` to assistant message text and markdown body.
- **Green lines filling chat**: Hundreds of individual tool call/reasoning cards rendering as thin colored lines. Replaced with single inline tool indicator for the currently running tool.
- **Per-turn delta tracking**: `HasReceivedDeltasThisTurn` flag prevents double-append when both delta and full message events fire for the same turn.
- **Enter key inserting newline**: JS interop handler prevents default on Enter (Shift+Enter for newlines).

### New Files
- `Models/ConnectionSettings.cs` — Connection mode enum, JSON persistence
- `Services/ServerManager.cs` — Server lifecycle: spawn, detect, stop with PID file tracking
- `Components/Pages/Settings.razor` — Settings UI
- `README.md` — Project documentation

### Technical Notes
- Uses undocumented `copilot --headless --port N` for JSON-RPC TCP server (compatible with .NET SDK's `CliUrl`)
- PID file at `~/.copilot/autopilot-server.pid` for cross-restart server detection
- Active sessions persisted to `~/.copilot/autopilot-active-sessions.json`