### PR TITLE
Tab navigation + shared ChatMessageList component

### DIFF
--- a/Components/ChatMessageList.razor
+++ b/Components/ChatMessageList.razor
@@ -1,0 +1,375 @@
+@using AutoPilot.App.Models
+@using Markdig
+
+@* Shared chat message list — used by both Home.razor (full) and Dashboard.razor (compact) *@
+
+<div class="chat-message-list @(Compact ? "compact" : "full")">
+    @if (!Messages.Any() && string.IsNullOrEmpty(StreamingContent))
+    {
+        <p class="chat-empty">@(Compact ? "No messages yet" : "Start a conversation with Copilot!")</p>
+    }
+    else
+    {
+        @foreach (var msg in Messages)
+        {
+            @switch (msg.MessageType)
+            {
+                case ChatMessageType.User:
+                    <div class="chat-msg user">
+                        @if (!Compact)
+                        {
+                            <div class="chat-msg-avatar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></div>
+                        }
+                        <div class="chat-msg-content">
+                            @if (Compact)
+                            {
+                                <span class="chat-msg-role">You</span>
+                            }
+                            <div class="chat-msg-text">@((MarkupString)FormatUserMessage(msg.Content))</div>
+                            @if (!Compact)
+                            {
+                                <div class="chat-msg-time">@msg.Timestamp.ToString("HH:mm")</div>
+                            }
+                        </div>
+                    </div>
+                    break;
+
+                case ChatMessageType.Assistant:
+                    <div class="chat-msg assistant">
+                        @if (!Compact)
+                        {
+                            <div class="chat-msg-avatar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect x="2" y="8" width="20" height="8" rx="2"/><path d="M6 16v4"/><path d="M18 16v4"/><circle cx="9" cy="12" r="1" fill="currentColor"/><circle cx="15" cy="12" r="1" fill="currentColor"/></svg></div>
+                        }
+                        <div class="chat-msg-content">
+                            @if (Compact)
+                            {
+                                <span class="chat-msg-role">AI</span>
+                            }
+                            <div class="chat-msg-text markdown-body">@((MarkupString)RenderMarkdown(msg.Content))</div>
+                            @if (!Compact)
+                            {
+                                <div class="chat-msg-time">@msg.Timestamp.ToString("HH:mm")</div>
+                            }
+                        </div>
+                    </div>
+                    break;
+
+                case ChatMessageType.Reasoning:
+                    @if (Compact)
+                    {
+                        <div class="chat-msg reasoning">
+                            <span class="chat-msg-role"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a8 8 0 0 0-8 8c0 3.4 2.1 6.3 5 7.4V20a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1v-2.6c2.9-1.1 5-4 5-7.4a8 8 0 0 0-8-8z"/><line x1="10" y1="22" x2="14" y2="22"/></svg></span>
+                            <span class="chat-msg-text">@(msg.IsComplete ? "Thought" : "Thinking...")</span>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="reasoning-block @(msg.IsCollapsed && LineCount(msg.Content) > 5 ? "collapsed" : "")">
+                            <button class="reasoning-header" @onclick="() => msg.IsCollapsed = !msg.IsCollapsed">
+                                <span class="reasoning-title"><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a8 8 0 0 0-8 8c0 3.4 2.1 6.3 5 7.4V20a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1v-2.6c2.9-1.1 5-4 5-7.4a8 8 0 0 0-8-8z"/><line x1="10" y1="22" x2="14" y2="22"/></svg> @(msg.IsComplete ? "Thought" : "Thinking...")</span>
+                                @if (LineCount(msg.Content) > 5)
+                                {
+                                    <span class="collapse-icon">@(msg.IsCollapsed ? "▶" : "▼")</span>
+                                }
+                            </button>
+                            @if (!msg.IsCollapsed || LineCount(msg.Content) <= 5)
+                            {
+                                <div class="reasoning-content">@msg.Content</div>
+                            }
+                            else
+                            {
+                                <div class="reasoning-content preview">@FirstLines(msg.Content, 3)</div>
+                            }
+                        </div>
+                    }
+                    break;
+
+                case ChatMessageType.ToolCall:
+                    @if (Compact)
+                    {
+                        <div class="chat-msg tool">
+                            <span class="chat-msg-role"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg></span>
+                            <span class="chat-msg-text">@FormatToolName(msg.ToolName ?? "tool") @(msg.IsComplete ? (msg.IsSuccess ? "✓" : "✗") : "…")</span>
+                        </div>
+                    }
+                    else if (msg.ToolName == "task_complete")
+                    {
+                        <div class="task-complete-card">
+                            <svg class="icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#4ade80" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+                            <span class="task-complete-text">@(string.IsNullOrEmpty(msg.Content) || IsUnusableResult(msg.Content) ? "Task complete" : msg.Content)</span>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="tool-card @(msg.IsComplete ? (msg.IsSuccess ? "success" : "error") : "running")">
+                            <div class="tool-header">
+                                <span class="tool-info"><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg> @FormatToolName(msg.ToolName ?? "")</span>
+                                <span class="tool-status">
+                                    @if (!msg.IsComplete)
+                                    {
+                                        <svg class="icon spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.22-8.56"/></svg> <text>Running</text>
+                                    }
+                                    else if (msg.IsSuccess)
+                                    {
+                                        <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#4ade80" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg> <text>Done</text>
+                                    }
+                                    else
+                                    {
+                                        <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg> <text>Failed</text>
+                                    }
+                                </span>
+                            </div>
+                            @if (msg.IsComplete && !string.IsNullOrEmpty(msg.Content) && !IsUnusableResult(msg.Content))
+                            {
+                                @if (GetImagePath(msg.Content) is string imgPath && FileToDataUri(imgPath) is string dataUri)
+                                {
+                                    <div class="tool-result-section tool-image-result">
+                                        <img src="@dataUri" alt="@System.IO.Path.GetFileName(imgPath)" />
+                                    </div>
+                                }
+                                else if (LineCount(msg.Content) <= 5)
+                                {
+                                    <div class="tool-result-section">
+                                        <pre class="tool-result-content">@TruncateResult(msg.Content)</pre>
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="tool-result-section">
+                                        <button class="tool-result-toggle" @onclick="() => msg.IsCollapsed = !msg.IsCollapsed">
+                                            @(msg.IsCollapsed ? "Show Full Result ▶" : "Collapse ▼")
+                                        </button>
+                                        @if (!msg.IsCollapsed)
+                                        {
+                                            <pre class="tool-result-content">@TruncateResult(msg.Content)</pre>
+                                        }
+                                        else
+                                        {
+                                            <pre class="tool-result-content preview">@FirstLines(msg.Content, 3)</pre>
+                                        }
+                                    </div>
+                                }
+                            }
+                        </div>
+                    }
+                    break;
+
+                case ChatMessageType.Error:
+                    <div class="@(Compact ? "chat-msg error" : "error-card")">
+                        @if (Compact)
+                        {
+                            <span class="chat-msg-role"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>
+                            <span class="chat-msg-text">@msg.Content</span>
+                        }
+                        else
+                        {
+                            <span class="error-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>
+                            <span class="error-text">@msg.Content</span>
+                        }
+                    </div>
+                    break;
+
+                case ChatMessageType.System:
+                    <div class="chat-msg system">
+                        <div class="system-text">@msg.Content</div>
+                    </div>
+                    break;
+            }
+        }
+
+        @* Current tool activity *@
+        @if (!string.IsNullOrEmpty(CurrentToolName))
+        {
+            @if (Compact)
+            {
+                <div class="chat-msg tool">
+                    <span class="chat-msg-role"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg></span>
+                    <span class="chat-msg-text">@FormatToolName(CurrentToolName) …</span>
+                </div>
+            }
+            else
+            {
+                <div class="tool-card running">
+                    <div class="tool-header">
+                        <span class="tool-info"><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg> @FormatToolName(CurrentToolName)</span>
+                        <span class="tool-status"><svg class="icon spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.22-8.56"/></svg> @ToolCount tool@(ToolCount != 1 ? "s" : "")</span>
+                    </div>
+                </div>
+            }
+        }
+
+        @* Streaming content *@
+        @if (!string.IsNullOrEmpty(StreamingContent))
+        {
+            <div class="chat-msg assistant streaming">
+                @if (!Compact)
+                {
+                    <div class="chat-msg-avatar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect x="2" y="8" width="20" height="8" rx="2"/><path d="M6 16v4"/><path d="M18 16v4"/><circle cx="9" cy="12" r="1" fill="currentColor"/><circle cx="15" cy="12" r="1" fill="currentColor"/></svg></div>
+                }
+                <div class="chat-msg-content">
+                    @if (Compact)
+                    {
+                        <span class="chat-msg-role">AI</span>
+                    }
+                    <div class="chat-msg-text markdown-body">@((MarkupString)RenderMarkdown(StreamingContent))</div>
+                </div>
+            </div>
+        }
+
+        @* Activity indicator *@
+        @if (IsProcessing && string.IsNullOrEmpty(StreamingContent) && string.IsNullOrEmpty(CurrentToolName))
+        {
+            <div class="chat-msg assistant">
+                @if (Compact)
+                {
+                    <span class="chat-msg-role">AI</span>
+                    <span class="chat-msg-text thinking">@(string.IsNullOrEmpty(ActivityText) ? "Thinking..." : ActivityText)</span>
+                }
+                else
+                {
+                    <div class="chat-msg-avatar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect x="2" y="8" width="20" height="8" rx="2"/><path d="M6 16v4"/><path d="M18 16v4"/><circle cx="9" cy="12" r="1" fill="currentColor"/><circle cx="15" cy="12" r="1" fill="currentColor"/></svg></div>
+                    <div class="chat-msg-content">
+                        <div class="chat-msg-text thinking">@(string.IsNullOrEmpty(ActivityText) ? "Thinking..." : ActivityText)</div>
+                    </div>
+                }
+            </div>
+        }
+    }
+</div>
+
+@code {
+    [Parameter] public List<ChatMessage> Messages { get; set; } = new();
+    [Parameter] public string StreamingContent { get; set; } = "";
+    [Parameter] public string CurrentToolName { get; set; } = "";
+    [Parameter] public int ToolCount { get; set; }
+    [Parameter] public string ActivityText { get; set; } = "";
+    [Parameter] public bool IsProcessing { get; set; }
+    [Parameter] public bool Compact { get; set; }
+
+    private static readonly MarkdownPipeline MdPipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions().Build();
+
+    private static readonly Dictionary<string, string> _imageCache = new();
+    private static readonly Dictionary<int, string> _markdownCache = new();
+
+    private static readonly System.Text.RegularExpressions.Regex ImagePathRegex = new(
+        @"(?<!\(|""|\w)((?:/[\w\-. ]+)+\.(?:png|jpg|jpeg|gif|webp|svg|bmp|tiff))(?!\)|""|\w)",
+        System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    internal static string RenderMarkdown(string content)
+    {
+        if (string.IsNullOrEmpty(content)) return "";
+        var key = content.GetHashCode();
+        if (_markdownCache.TryGetValue(key, out var cached)) return cached;
+        try
+        {
+            var html = Markdig.Markdown.ToHtml(content, MdPipeline);
+            html = ImagePathRegex.Replace(html, match =>
+            {
+                var path = match.Value;
+                var dataUri = FileToDataUri(path);
+                if (dataUri != null)
+                    return $"<img src=\"{dataUri}\" alt=\"{System.IO.Path.GetFileName(path)}\" />";
+                return match.Value;
+            });
+            if (_markdownCache.Count < 500) _markdownCache[key] = html;
+            return html;
+        }
+        catch { return System.Net.WebUtility.HtmlEncode(content).Replace("\n", "<br/>"); }
+    }
+
+    internal static string FormatUserMessage(string content)
+    {
+        var escaped = System.Net.WebUtility.HtmlEncode(content);
+        return escaped.Replace("\n", "<br/>");
+    }
+
+    internal static int LineCount(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return 0;
+        var count = 1;
+        foreach (var c in text) { if (c == '\n') count++; }
+        return count;
+    }
+
+    internal static string FirstLines(string? text, int lines)
+    {
+        if (string.IsNullOrEmpty(text)) return "";
+        var idx = 0;
+        for (var i = 0; i < lines && idx < text.Length; i++)
+        {
+            var next = text.IndexOf('\n', idx);
+            if (next < 0) break;
+            idx = next + 1;
+        }
+        if (idx <= 0 || idx >= text.Length) return text;
+        return text[..idx] + "…";
+    }
+
+    internal static string FormatToolName(string toolName)
+    {
+        if (string.IsNullOrEmpty(toolName)) return "";
+        return string.Join(" ", toolName.Split('_').Select(w =>
+            w.Length > 0 ? char.ToUpperInvariant(w[0]) + w[1..].ToLowerInvariant() : w));
+    }
+
+    internal static string TruncateResult(string result, int maxLength = 1500)
+    {
+        if (string.IsNullOrEmpty(result) || result.Length <= maxLength) return result ?? "";
+        return result[..maxLength] + "\n… (truncated)";
+    }
+
+    internal static bool IsUnusableResult(string? content)
+    {
+        if (string.IsNullOrEmpty(content)) return true;
+        if (content.StartsWith("GitHub.Copilot.SDK.")) return true;
+        if (content is "(no result)" or "Intent logged") return true;
+        return false;
+    }
+
+    private static readonly string[] ImageExtensions = { ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".tiff" };
+
+    internal static string? GetImagePath(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content)) return null;
+        var trimmed = content.Trim();
+        foreach (var ext in ImageExtensions)
+        {
+            var idx = trimmed.LastIndexOf(ext, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0) continue;
+            var endIdx = idx + ext.Length;
+            var pathStart = trimmed.LastIndexOf(' ', idx) + 1;
+            if (pathStart < 0) pathStart = 0;
+            var path = trimmed[pathStart..endIdx];
+            if (path.StartsWith('/') && System.IO.File.Exists(path))
+                return path;
+        }
+        return null;
+    }
+
+    internal static string? FileToDataUri(string path)
+    {
+        if (_imageCache.TryGetValue(path, out var cached)) return cached;
+        try
+        {
+            if (!System.IO.File.Exists(path)) return null;
+            var bytes = System.IO.File.ReadAllBytes(path);
+            var ext = System.IO.Path.GetExtension(path).ToLowerInvariant();
+            var mime = ext switch
+            {
+                ".png" => "image/png",
+                ".jpg" or ".jpeg" => "image/jpeg",
+                ".gif" => "image/gif",
+                ".webp" => "image/webp",
+                ".svg" => "image/svg+xml",
+                ".bmp" => "image/bmp",
+                ".tiff" or ".tif" => "image/tiff",
+                _ => "application/octet-stream"
+            };
+            var dataUri = $"data:{mime};base64,{Convert.ToBase64String(bytes)}";
+            _imageCache[path] = dataUri;
+            return dataUri;
+        }
+        catch { return null; }
+    }
+}

--- a/Components/ChatMessageList.razor.css
+++ b/Components/ChatMessageList.razor.css
@@ -1,0 +1,298 @@
+.chat-message-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.chat-empty {
+    color: rgba(255,255,255,0.3);
+    text-align: center;
+    margin: auto;
+    font-size: 0.95rem;
+}
+
+/* === Compact mode (dashboard cards) === */
+.chat-message-list.compact .chat-msg {
+    display: flex;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+    line-height: 1.4;
+}
+
+.chat-message-list.compact .chat-msg-role {
+    font-weight: 600;
+    flex-shrink: 0;
+    font-size: 0.8rem;
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    align-self: flex-start;
+}
+
+.chat-message-list.compact .chat-msg.user .chat-msg-role {
+    background: rgba(59, 130, 246, 0.3);
+    color: #93c5fd;
+}
+
+.chat-message-list.compact .chat-msg.assistant .chat-msg-role {
+    background: rgba(72, 187, 120, 0.3);
+    color: #86efac;
+}
+
+.chat-message-list.compact .chat-msg-text {
+    color: rgba(255,255,255,0.8);
+    word-break: break-word;
+}
+
+.chat-message-list.compact .chat-msg-text.thinking {
+    color: rgba(255,255,255,0.4);
+    font-style: italic;
+}
+
+/* === Full mode (chat page) === */
+.chat-message-list.full .chat-msg {
+    display: flex;
+    gap: 0.75rem;
+    flex-shrink: 0;
+    max-width: 100%;
+    padding: 0.75rem 1rem;
+}
+
+.chat-message-list.full .chat-msg.user {
+    justify-content: flex-end;
+}
+
+.chat-message-list.full .chat-msg.user .chat-msg-content {
+    background: rgba(59, 130, 246, 0.2);
+    border: 1px solid rgba(59, 130, 246, 0.3);
+    border-radius: 12px 12px 0 12px;
+    padding: 0.75rem 1rem;
+    max-width: 80%;
+}
+
+.chat-message-list.full .chat-msg.assistant .chat-msg-content {
+    background: rgba(72, 187, 120, 0.1);
+    border: 1px solid rgba(72, 187, 120, 0.2);
+    border-radius: 12px 12px 12px 0;
+    padding: 0.75rem 1rem;
+    max-width: 80%;
+}
+
+.chat-message-list.full .chat-msg-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.chat-message-list.full .chat-msg.user .chat-msg-avatar {
+    order: 1;
+    background: rgba(59, 130, 246, 0.3);
+}
+
+.chat-message-list.full .chat-msg.assistant .chat-msg-avatar {
+    background: rgba(72, 187, 120, 0.3);
+}
+
+.chat-message-list.full .chat-msg-text {
+    color: white;
+    word-break: break-word;
+    line-height: 1.6;
+}
+
+.chat-message-list.full .chat-msg-text.thinking {
+    color: rgba(255,255,255,0.4);
+    font-style: italic;
+}
+
+.chat-message-list.full .chat-msg-time {
+    font-size: 0.75rem;
+    color: rgba(255,255,255,0.3);
+    margin-top: 0.25rem;
+}
+
+.chat-message-list.full .chat-msg.system {
+    justify-content: center;
+}
+
+.chat-message-list.full .system-text {
+    font-size: 0.85rem;
+    color: rgba(255,255,255,0.4);
+    font-style: italic;
+    text-align: center;
+    padding: 0.5rem;
+}
+
+/* Shared tool/reasoning styles for full mode */
+::deep .reasoning-block {
+    flex-shrink: 0;
+    margin: 0.25rem 1rem;
+    border-left: 2px solid rgba(168, 85, 247, 0.3);
+    padding-left: 0.75rem;
+}
+
+::deep .reasoning-header {
+    background: none;
+    border: none;
+    color: rgba(168, 85, 247, 0.7);
+    font-size: 0.85rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0;
+    width: 100%;
+}
+
+::deep .reasoning-content {
+    font-size: 0.85rem;
+    color: rgba(255,255,255,0.5);
+    white-space: pre-wrap;
+    line-height: 1.5;
+    padding: 0.25rem 0;
+}
+
+::deep .reasoning-content.preview {
+    max-height: 4.5em;
+    overflow: hidden;
+}
+
+::deep .tool-card {
+    flex-shrink: 0;
+    margin: 0.25rem 1rem;
+    border-radius: 8px;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+    border: 1px solid rgba(255,255,255,0.1);
+    background: rgba(255,255,255,0.03);
+}
+
+::deep .tool-card.running { border-color: rgba(251, 191, 36, 0.3); }
+::deep .tool-card.success { border-color: rgba(72, 187, 120, 0.3); }
+::deep .tool-card.error { border-color: rgba(248, 113, 113, 0.3); }
+
+::deep .tool-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+::deep .tool-info { color: rgba(255,255,255,0.7); display: flex; align-items: center; gap: 0.35rem; }
+::deep .tool-status { display: flex; align-items: center; gap: 0.35rem; color: rgba(255,255,255,0.5); }
+
+::deep .tool-result-section {
+    margin-top: 0.5rem;
+    border-top: 1px solid rgba(255,255,255,0.05);
+    padding-top: 0.5rem;
+}
+
+::deep .tool-result-content {
+    font-size: 0.8rem;
+    color: rgba(255,255,255,0.5);
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 300px;
+    overflow-y: auto;
+    margin: 0;
+}
+
+::deep .tool-result-toggle {
+    background: none;
+    border: none;
+    color: rgba(59, 130, 246, 0.7);
+    font-size: 0.8rem;
+    cursor: pointer;
+    padding: 0;
+}
+
+::deep .tool-image-result img {
+    max-width: 100%;
+    max-height: 400px;
+    border-radius: 6px;
+}
+
+::deep .task-complete-card {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0.25rem 1rem;
+    padding: 0.75rem 1rem;
+    background: rgba(72, 187, 120, 0.1);
+    border: 1px solid rgba(72, 187, 120, 0.3);
+    border-radius: 8px;
+    color: #86efac;
+    font-size: 0.95rem;
+}
+
+::deep .error-card {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0.25rem 1rem;
+    padding: 0.5rem 0.75rem;
+    background: rgba(248, 113, 113, 0.1);
+    border: 1px solid rgba(248, 113, 113, 0.3);
+    border-radius: 8px;
+    color: #fca5a5;
+    font-size: 0.9rem;
+}
+
+::deep .markdown-body {
+    color: white;
+}
+
+::deep .markdown-body h1, ::deep .markdown-body h2, ::deep .markdown-body h3 {
+    margin: 0.5em 0 0.25em;
+    border: none;
+    color: white;
+}
+
+::deep .markdown-body code {
+    background: rgba(255,255,255,0.1);
+    padding: 0.15em 0.3em;
+    border-radius: 3px;
+    font-size: 0.9em;
+}
+
+::deep .markdown-body pre {
+    background: rgba(0,0,0,0.3);
+    padding: 0.75rem;
+    border-radius: 6px;
+    overflow-x: auto;
+}
+
+::deep .markdown-body pre code {
+    background: none;
+    padding: 0;
+}
+
+::deep .markdown-body a { color: #60a5fa; }
+::deep .markdown-body blockquote {
+    border-left: 3px solid rgba(255,255,255,0.2);
+    margin: 0.5rem 0;
+    padding: 0 0.75rem;
+    color: rgba(255,255,255,0.6);
+}
+
+::deep .markdown-body ul, ::deep .markdown-body ol {
+    padding-left: 1.5rem;
+    margin: 0.25rem 0;
+}
+
+::deep .markdown-body table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+::deep .markdown-body th, ::deep .markdown-body td {
+    border: 1px solid rgba(255,255,255,0.15);
+    padding: 0.4rem 0.6rem;
+    text-align: left;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+::deep .spin { animation: spin 1s linear infinite; }

--- a/Components/Layout/SessionSidebar.razor
+++ b/Components/Layout/SessionSidebar.razor
@@ -125,8 +125,11 @@ else
             }
             else
             {
+                var sessionIndex = 0;
                 @foreach (var session in sessions)
                 {
+                    sessionIndex++;
+                    var idx = sessionIndex;
                     var cssClass = session.Name == CopilotService.ActiveSessionName ? "active" : 
                                    completedSessions.Contains(session.Name) ? "completed" :
                                    session.IsProcessing ? "busy" : "";
@@ -134,6 +137,10 @@ else
                          @onclick="() => SelectSession(session.Name)">
                         <div class="session-info">
                             <span class="session-name">
+                                @if (idx <= 9)
+                                {
+                                    <span class="shortcut-badge" title="⌘@idx">@idx</span>
+                                }
                                 @if (completedSessions.Contains(session.Name))
                                 {
                                     <span class="done-badge"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span>

--- a/Components/Layout/SessionSidebar.razor.css
+++ b/Components/Layout/SessionSidebar.razor.css
@@ -253,6 +253,21 @@
     color: #fbbf24;
 }
 
+.shortcut-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.2em;
+    height: 1.2em;
+    font-size: 0.7rem;
+    font-weight: 600;
+    background: rgba(255,255,255,0.12);
+    border: 1px solid rgba(255,255,255,0.2);
+    border-radius: 3px;
+    color: rgba(255,255,255,0.5);
+    flex-shrink: 0;
+}
+
 .session-meta {
     font-size: 0.95rem;
     color: rgba(255,255,255,0.5);

--- a/Components/Pages/Dashboard.razor
+++ b/Components/Pages/Dashboard.razor
@@ -3,6 +3,7 @@
 @using AutoPilot.App.Models
 @inject CopilotService CopilotService
 @inject IJSRuntime JS
+@inject NavigationManager Nav
 @implements IDisposable
 
 <div class="dashboard">
@@ -26,7 +27,7 @@
                 var cardClass = session.IsProcessing ? "processing" : isCompleted ? "completed" : "idle";
                 <div class="session-card @cardClass">
                     <div class="card-header">
-                        <div class="card-title">
+                        <div class="card-title" @onclick="() => GoToSession(session.Name)" style="cursor:pointer">
                             <span class="card-status-dot @cardClass"></span>
                             <h3>@session.Name</h3>
                         </div>
@@ -34,67 +35,18 @@
                         <button class="card-close" @onclick="() => CloseSession(session.Name)" title="Close session">✕</button>
                     </div>
 
+
                     <div class="card-messages">
                         @{
-                            var lastMessages = session.History.ToList().TakeLast(6).ToList();
+                            List<ChatMessage> lastMessages;
+                            try { lastMessages = session.History.TakeLast(6).ToList(); }
+                            catch { lastMessages = new(); }
                         }
-                        @if (!lastMessages.Any())
-                        {
-                            <p class="card-empty">No messages yet</p>
-                        }
-                        else
-                        {
-                            @foreach (var msg in lastMessages)
-                            {
-                                @switch (msg.MessageType)
-                                {
-                                    case ChatMessageType.User:
-                                        <div class="card-msg user">
-                                            <span class="card-msg-role">You</span>
-                                            <span class="card-msg-text">@Truncate(msg.Content, 120)</span>
-                                        </div>
-                                        break;
-                                    case ChatMessageType.Assistant:
-                                        <div class="card-msg assistant">
-                                            <span class="card-msg-role">AI</span>
-                                            <span class="card-msg-text">@Truncate(msg.Content, 120)</span>
-                                        </div>
-                                        break;
-                                    case ChatMessageType.ToolCall:
-                                        <div class="card-msg tool">
-                                            <span class="card-msg-role"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg></span>
-                                            <span class="card-msg-text">@(msg.ToolName ?? "tool") @(msg.IsComplete ? (msg.IsSuccess ? "✓" : "✗") : "…")</span>
-                                        </div>
-                                        break;
-                                    case ChatMessageType.Reasoning:
-                                        <div class="card-msg reasoning">
-                                            <span class="card-msg-role"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a8 8 0 0 0-8 8c0 3.4 2.1 6.3 5 7.4V20a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1v-2.6c2.9-1.1 5-4 5-7.4a8 8 0 0 0-8-8z"/><line x1="10" y1="22" x2="14" y2="22"/></svg></span>
-                                            <span class="card-msg-text">@(msg.IsComplete ? "Thought" : "Thinking...")</span>
-                                        </div>
-                                        break;
-                                    case ChatMessageType.Error:
-                                        <div class="card-msg error">
-                                            <span class="card-msg-role"><svg style="vertical-align:middle" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>
-                                            <span class="card-msg-text">@Truncate(msg.Content, 80)</span>
-                                        </div>
-                                        break;
-                                }
-                            }
-                        }
-                        @if (session.IsProcessing)
-                        {
-                            @if (streamingBySession.TryGetValue(session.Name, out var streaming) && !string.IsNullOrEmpty(streaming))
-                            {
-                                <div class="card-msg assistant">
-                                    <span class="card-msg-role">AI</span>
-                                    <span class="card-msg-text">@streaming</span>
-                                </div>
-                            }
-                            <div class="card-msg assistant">
-                                <span class="card-msg-role">AI</span>
-                                <span class="card-msg-text thinking">@(activityBySession.TryGetValue(session.Name, out var act) && !string.IsNullOrEmpty(act) ? act : "Thinking...")</span>
-                            </div>
-                        }
+                        <ChatMessageList Messages="lastMessages"
+                                         StreamingContent="@(streamingBySession.TryGetValue(session.Name, out var s) ? s : "")"
+                                         ActivityText="@(activityBySession.TryGetValue(session.Name, out var a) ? a : "")"
+                                         IsProcessing="session.IsProcessing"
+                                         Compact="true" />
                     </div>
 
                     <div class="card-input">
@@ -140,16 +92,29 @@
     {
         if (firstRender)
         {
-            // Set up Enter key handlers for all card inputs
+            // Set up Enter and Tab key handlers for card inputs
             await JS.InvokeVoidAsync("eval", @"
                 document.addEventListener('keydown', function(e) {
-                    if (e.key === 'Enter' && e.target.closest('.card-input input')) {
+                    var isCardInput = e.target.matches && e.target.matches('.card-input input');
+                    var isBroadcast = e.target.id === 'broadcastInput';
+                    if (e.key === 'Enter' && isCardInput) {
                         e.preventDefault();
                         e.target.closest('.card-input').querySelector('button')?.click();
                     }
-                    if (e.key === 'Enter' && e.target.id === 'broadcastInput') {
+                    if (e.key === 'Enter' && isBroadcast) {
                         e.preventDefault();
                         document.querySelector('.broadcast-input button')?.click();
+                    }
+                    // Tab / Shift+Tab to cycle between card inputs only when focused on one
+                    if (e.key === 'Tab' && (isCardInput || isBroadcast)) {
+                        e.preventDefault();
+                        e.stopImmediatePropagation();
+                        var inputs = Array.from(document.querySelectorAll('.card-input input:not(:disabled), #broadcastInput'));
+                        if (inputs.length < 2) return;
+                        var idx = inputs.indexOf(e.target);
+                        if (idx < 0) idx = 0;
+                        idx = e.shiftKey ? (idx - 1 + inputs.length) % inputs.length : (idx + 1) % inputs.length;
+                        inputs[idx].focus();
                     }
                 });
             ");
@@ -248,11 +213,11 @@
         await CopilotService.CloseSessionAsync(sessionName);
     }
 
-    private string Truncate(string text, int maxLength)
+    private void GoToSession(string sessionName)
     {
-        if (string.IsNullOrEmpty(text)) return "";
-        text = text.Replace("\n", " ").Replace("\r", "");
-        return text.Length > maxLength ? text[..maxLength] + "..." : text;
+        CopilotService.SwitchSession(sessionName);
+        CopilotService.SaveUiState("/", sessionName);
+        Nav.NavigateTo("/");
     }
 
     public void Dispose()

--- a/Components/Pages/Home.razor
+++ b/Components/Pages/Home.razor
@@ -1,7 +1,6 @@
 @page "/"
 @using AutoPilot.App.Services
 @using AutoPilot.App.Models
-@using Markdig
 @inject CopilotService CopilotService
 @inject IJSRuntime JS
 @inject NavigationManager Nav
@@ -30,7 +29,9 @@
     else
     {
         <div class="chat-header">
+            <button class="session-nav-btn" title="Previous session (▲)" @onclick="() => CycleSession(true)">◀</button>
             <h2>@activeSession.Name</h2>
+            <button class="session-nav-btn" title="Next session (▼)" @onclick="() => CycleSession(false)">▶</button>
             <span class="model-badge">@activeSession.Model</span>
             @if (activeSession.SessionId != null)
             {
@@ -43,165 +44,19 @@
         </div>
 
         <div class="messages" @ref="messagesContainer">
-            @if (!activeSession.History.Any() && string.IsNullOrEmpty(streamingContent))
+            @if (HasMoreMessages)
             {
-                <div class="empty-chat">
-                    <p>Start a conversation with Copilot!</p>
-                </div>
+                <button class="load-more-btn" @onclick="LoadMoreMessages">
+                    <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 11 12 6 7 11"/><polyline points="17 18 12 13 7 18"/></svg>
+                    Load @Math.Min(50, activeSession.History.Count - visibleMessageCount) older messages (@(activeSession.History.Count - visibleMessageCount) remaining)
+                </button>
             }
-            else
-            {
-                @if (HasMoreMessages)
-                {
-                    <button class="load-more-btn" @onclick="LoadMoreMessages">
-                        <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 11 12 6 7 11"/><polyline points="17 18 12 13 7 18"/></svg>
-                        Load @Math.Min(50, activeSession.History.Count - visibleMessageCount) older messages (@(activeSession.History.Count - visibleMessageCount) remaining)
-                    </button>
-                }
-
-                @foreach (var msg in VisibleHistory)
-                {
-                    @switch (msg.MessageType)
-                    {
-                        case ChatMessageType.User:
-                            <div class="message user">
-                                <div class="message-avatar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></div>
-                                <div class="message-content">
-                                    <div class="message-text">@((MarkupString)FormatUserMessage(msg.Content))</div>
-                                    <div class="message-time">@msg.Timestamp.ToString("HH:mm")</div>
-                                </div>
-                            </div>
-                            break;
-
-                        case ChatMessageType.Assistant:
-                            <div class="message assistant">
-                                <div class="message-avatar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect x="2" y="8" width="20" height="8" rx="2"/><path d="M6 16v4"/><path d="M18 16v4"/><circle cx="9" cy="12" r="1" fill="currentColor"/><circle cx="15" cy="12" r="1" fill="currentColor"/></svg></div>
-                                <div class="message-content">
-                                    <div class="message-text markdown-body">@((MarkupString)RenderMarkdown(msg.Content))</div>
-                                    <div class="message-time">@msg.Timestamp.ToString("HH:mm")</div>
-                                </div>
-                            </div>
-                            break;
-
-                        case ChatMessageType.Reasoning:
-                            <div class="reasoning-block @(msg.IsCollapsed && LineCount(msg.Content) > 5 ? "collapsed" : "")">
-                                <button class="reasoning-header" @onclick="() => msg.IsCollapsed = !msg.IsCollapsed">
-                                    <span class="reasoning-title"><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a8 8 0 0 0-8 8c0 3.4 2.1 6.3 5 7.4V20a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1v-2.6c2.9-1.1 5-4 5-7.4a8 8 0 0 0-8-8z"/><line x1="10" y1="22" x2="14" y2="22"/></svg> @(msg.IsComplete ? "Thought" : "Thinking...")</span>
-                                    @if (LineCount(msg.Content) > 5)
-                                    {
-                                        <span class="collapse-icon">@(msg.IsCollapsed ? "▶" : "▼")</span>
-                                    }
-                                </button>
-                                @if (!msg.IsCollapsed || LineCount(msg.Content) <= 5)
-                                {
-                                    <div class="reasoning-content">@msg.Content</div>
-                                }
-                                else
-                                {
-                                    <div class="reasoning-content preview">@FirstLines(msg.Content, 3)</div>
-                                }
-                            </div>
-                            break;
-
-                        case ChatMessageType.ToolCall:
-                            @if (msg.ToolName == "task_complete")
-                            {
-                                <div class="task-complete-card">
-                                    <svg class="icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#4ade80" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-                                    <span class="task-complete-text">@(string.IsNullOrEmpty(msg.Content) || IsUnusableResult(msg.Content) ? "Task complete" : msg.Content)</span>
-                                </div>
-                            }
-                            else
-                            {
-                            <div class="tool-card @(msg.IsComplete ? (msg.IsSuccess ? "success" : "error") : "running")">
-                                <div class="tool-header">
-                                    <span class="tool-info"><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg> @FormatToolName(msg.ToolName ?? "")</span>
-                                    <span class="tool-status">
-                                        @if (!msg.IsComplete)
-                                        {
-                                            <svg class="icon spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.22-8.56"/></svg> <text>Running</text>
-                                        }
-                                        else if (msg.IsSuccess)
-                                        {
-                                            <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#4ade80" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg> <text>Done</text>
-                                        }
-                                        else
-                                        {
-                                            <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg> <text>Failed</text>
-                                        }
-                                    </span>
-                                </div>
-                                @if (msg.IsComplete && !string.IsNullOrEmpty(msg.Content) && !IsUnusableResult(msg.Content))
-                                {
-                                    @if (GetImagePath(msg.Content) is string imgPath && FileToDataUri(imgPath) is string dataUri)
-                                    {
-                                        <div class="tool-result-section tool-image-result">
-                                            <img src="@dataUri" alt="@System.IO.Path.GetFileName(imgPath)" />
-                                        </div>
-                                    }
-                                    else if (LineCount(msg.Content) <= 5)
-                                    {
-                                        <div class="tool-result-section">
-                                            <pre class="tool-result-content">@TruncateResult(msg.Content)</pre>
-                                        </div>
-                                    }
-                                    else
-                                    {
-                                        <div class="tool-result-section">
-                                            <button class="tool-result-toggle" @onclick="() => msg.IsCollapsed = !msg.IsCollapsed">
-                                                @(msg.IsCollapsed ? "Show Full Result ▶" : "Collapse ▼")
-                                            </button>
-                                            @if (!msg.IsCollapsed)
-                                            {
-                                                <pre class="tool-result-content">@TruncateResult(msg.Content)</pre>
-                                            }
-                                            else
-                                            {
-                                                <pre class="tool-result-content preview">@FirstLines(msg.Content, 3)</pre>
-                                            }
-                                        </div>
-                                    }
-                                }
-                            </div>
-                            }
-                            break;
-
-                        case ChatMessageType.Error:
-                            <div class="error-card">
-                                <span class="error-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>
-                                <span class="error-text">@msg.Content</span>
-                            </div>
-                            break;
-
-                        case ChatMessageType.System:
-                            <div class="message system">
-                                <div class="system-text">@msg.Content</div>
-                            </div>
-                            break;
-                    }
-                }
-
-                @* Show current tool activity inline *@
-                @if (!string.IsNullOrEmpty(currentToolName))
-                {
-                    <div class="tool-card running">
-                        <div class="tool-header">
-                            <span class="tool-info"><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg> @FormatToolName(currentToolName)</span>
-                            <span class="tool-status"><svg class="icon spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.22-8.56"/></svg> @currentTurnToolCount tool@(currentTurnToolCount != 1 ? "s" : "")</span>
-                        </div>
-                    </div>
-                }
-
-                @if (!string.IsNullOrEmpty(streamingContent))
-                {
-                    <div class="message assistant streaming">
-                        <div class="message-avatar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect x="2" y="8" width="20" height="8" rx="2"/><path d="M6 16v4"/><path d="M18 16v4"/><circle cx="9" cy="12" r="1" fill="currentColor"/><circle cx="15" cy="12" r="1" fill="currentColor"/></svg></div>
-                        <div class="message-content">
-                            <div class="message-text markdown-body">@((MarkupString)RenderMarkdown(streamingContent))</div>
-                        </div>
-                    </div>
-                }
-            }
+            <ChatMessageList Messages="VisibleHistory"
+                             StreamingContent="@streamingContent"
+                             CurrentToolName="@currentToolName"
+                             ToolCount="currentTurnToolCount"
+                             IsProcessing="activeSession.IsProcessing"
+                             Compact="false" />
         </div>
 
         @if (!string.IsNullOrEmpty(lastError))
@@ -309,10 +164,6 @@
 </div>
 
 @code {
-    private static readonly MarkdownPipeline MdPipeline = new MarkdownPipelineBuilder()
-        .UseAdvancedExtensions()
-        .Build();
-
     private AgentSessionInfo? activeSession;
     private string userInput = "";
     private bool isPlanMode = false;
@@ -326,22 +177,28 @@
     private bool showDebugPanel = false;
     private ElementReference messagesContainer;
     private ElementReference textareaRef;
+    private DotNetObjectReference<Home>? _dotNetRef;
     private bool _needsRedirect;
     private string? _redirectTo;
     private bool _needsScroll = true;
-    private bool shouldPreventDefault;
     private int visibleMessageCount = 50;
-    private static readonly Dictionary<string, string> _imageCache = new();
-    private static readonly Dictionary<int, string> _markdownCache = new();
 
     private List<ChatMessage> VisibleHistory
     {
         get
         {
             if (activeSession == null) return new();
-            var all = activeSession.History;
-            if (all.Count <= visibleMessageCount) return all.ToList();
-            return all.Skip(all.Count - visibleMessageCount).ToList();
+            try
+            {
+                var all = activeSession.History;
+                if (all.Count <= visibleMessageCount) return all.ToList();
+                return all.Skip(all.Count - visibleMessageCount).ToList();
+            }
+            catch (InvalidOperationException)
+            {
+                // Collection modified during enumeration — retry with snapshot
+                return activeSession.History.ToArray().ToList();
+            }
         }
     }
 
@@ -385,6 +242,11 @@
             await ForceScrollToBottom();
         }
         try { await JS.InvokeVoidAsync("setupTextareaEnterHandler", textareaRef); } catch { }
+        if (_dotNetRef == null)
+        {
+            _dotNetRef = DotNetObjectReference.Create(this);
+        }
+        try { await JS.InvokeVoidAsync("setupTabNavigation", _dotNetRef); } catch { }
     }
 
     private string currentToolName = "";
@@ -508,6 +370,10 @@
     {
         if (sessionName == CopilotService.ActiveSessionName)
         {
+            // Suppress cancellation errors (expected during app restart/abort)
+            if (error.Contains("cancel", StringComparison.OrdinalIgnoreCase) ||
+                error.Contains("TaskCanceled", StringComparison.OrdinalIgnoreCase))
+                return;
             lastError = error;
             InvokeAsync(StateHasChanged);
         }
@@ -555,13 +421,33 @@
         });
     }
 
+    private string _lastKeyDebug = "";
+
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {
+        _lastKeyDebug = $"Key:{e.Key} Code:{e.Code} Meta:{e.MetaKey} Ctrl:{e.CtrlKey} Shift:{e.ShiftKey}";
+
         if (e.Key == "Enter" && !e.ShiftKey)
         {
             await SendMessage();
-            // Force-clear via JS to remove any residual newline
             await JS.InvokeVoidAsync("eval", "document.querySelector('.input-row textarea').value = ''");
+        }
+        // Tab / Shift+Tab to cycle sessions
+        if (e.Key == "Tab")
+        {
+            CycleSession(e.ShiftKey);
+        }
+        // Cmd+1 through Cmd+9 to switch sessions
+        if (e.MetaKey && e.Key.Length == 1 && e.Key[0] >= '1' && e.Key[0] <= '9')
+        {
+            var sessions = CopilotService.GetAllSessions().ToList();
+            var idx = (int)(e.Key[0] - '1');
+            if (idx < sessions.Count)
+            {
+                CopilotService.SwitchSession(sessions[idx].Name);
+                CopilotService.SaveUiState("/", sessions[idx].Name);
+                StateHasChanged();
+            }
         }
     }
 
@@ -597,6 +483,14 @@
         {
             await CopilotService.SendPromptAsync(activeSession.Name, prompt);
             streamingContent = "";
+        }
+        catch (TaskCanceledException)
+        {
+            // Expected during abort or app restart — not an error
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during abort or app restart — not an error
         }
         catch (Exception ex)
         {
@@ -640,132 +534,6 @@
         return text.Length > maxLen ? text[..maxLen] + "…" : text;
     }
 
-    private static readonly System.Text.RegularExpressions.Regex ImagePathRegex = new(
-        @"(?<!\(|""|\w)((?:/[\w\-. ]+)+\.(?:png|jpg|jpeg|gif|webp|svg|bmp|tiff))(?!\)|""|\w)",
-        System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled);
-
-    private static string RenderMarkdown(string content)
-    {
-        if (string.IsNullOrEmpty(content)) return "";
-
-        var key = content.GetHashCode();
-        if (_markdownCache.TryGetValue(key, out var cached)) return cached;
-
-        try
-        {
-            var html = Markdig.Markdown.ToHtml(content, MdPipeline);
-            html = ImagePathRegex.Replace(html, match =>
-            {
-                var path = match.Value;
-                var dataUri = FileToDataUri(path);
-                if (dataUri != null)
-                    return $"<img src=\"{dataUri}\" alt=\"{System.IO.Path.GetFileName(path)}\" />";
-                return match.Value;
-            });
-
-            // Only cache completed (non-streaming) content — limit cache size
-            if (_markdownCache.Count < 500)
-                _markdownCache[key] = html;
-
-            return html;
-        }
-        catch { return System.Net.WebUtility.HtmlEncode(content).Replace("\n", "<br/>"); }
-    }
-
-    private static string FormatUserMessage(string content)
-    {
-        var escaped = System.Net.WebUtility.HtmlEncode(content);
-        return escaped.Replace("\n", "<br/>");
-    }
-
-    private static int LineCount(string? text)
-    {
-        if (string.IsNullOrEmpty(text)) return 0;
-        var count = 1;
-        foreach (var c in text) { if (c == '\n') count++; }
-        return count;
-    }
-
-    private static string FirstLines(string? text, int lines)
-    {
-        if (string.IsNullOrEmpty(text)) return "";
-        var idx = 0;
-        for (var i = 0; i < lines && idx < text.Length; i++)
-        {
-            var next = text.IndexOf('\n', idx);
-            if (next < 0) break;
-            idx = next + 1;
-        }
-        if (idx <= 0 || idx >= text.Length) return text;
-        return text[..idx] + "…";
-    }
-
-    private static string FormatToolName(string toolName)
-    {
-        if (string.IsNullOrEmpty(toolName)) return "";
-        return string.Join(" ", toolName.Split('_').Select(w =>
-            w.Length > 0 ? char.ToUpperInvariant(w[0]) + w[1..].ToLowerInvariant() : w));
-    }
-
-    private static string TruncateResult(string result, int maxLength = 1500)
-    {
-        if (string.IsNullOrEmpty(result) || result.Length <= maxLength) return result ?? "";
-        return result[..maxLength] + "\n… (truncated)";
-    }
-
-    private static bool IsUnusableResult(string? content)
-    {
-        if (string.IsNullOrEmpty(content)) return true;
-        if (content.StartsWith("GitHub.Copilot.SDK.")) return true;
-        if (content is "(no result)" or "Intent logged") return true;
-        return false;
-    }
-
-    private static readonly string[] ImageExtensions = { ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".tiff" };
-
-    private static string? GetImagePath(string? content)
-    {
-        if (string.IsNullOrWhiteSpace(content)) return null;
-        var trimmed = content.Trim();
-        foreach (var ext in ImageExtensions)
-        {
-            var idx = trimmed.LastIndexOf(ext, StringComparison.OrdinalIgnoreCase);
-            if (idx < 0) continue;
-            var endIdx = idx + ext.Length;
-            var pathStart = trimmed.LastIndexOf(' ', idx) + 1;
-            if (pathStart < 0) pathStart = 0;
-            var path = trimmed[pathStart..endIdx];
-            if (path.StartsWith('/') && System.IO.File.Exists(path))
-                return path;
-        }
-        return null;
-    }
-
-    private static string? FileToDataUri(string path)
-    {
-        if (_imageCache.TryGetValue(path, out var cached)) return cached;
-        try
-        {
-            if (!System.IO.File.Exists(path)) return null;
-            var bytes = System.IO.File.ReadAllBytes(path);
-            var ext = System.IO.Path.GetExtension(path).ToLowerInvariant();
-            var mime = ext switch
-            {
-                ".png" => "image/png",
-                ".jpg" or ".jpeg" => "image/jpeg",
-                ".gif" => "image/gif",
-                ".webp" => "image/webp",
-                ".svg" => "image/svg+xml",
-                ".bmp" => "image/bmp",
-                ".tiff" or ".tif" => "image/tiff",
-                _ => "application/octet-stream"
-            };
-            var dataUri = $"data:{mime};base64,{Convert.ToBase64String(bytes)}";
-            _imageCache[path] = dataUri;
-            return dataUri;
-        }
-        catch { return null; }
-    }
 
     private static string FormatTokenCount(int count) =>
         count >= 1000 ? $"{count / 1000}k" : count.ToString();
@@ -782,8 +550,32 @@
         catch { }
     }
 
+    [JSInvokable]
+    public void CycleSession(bool reverse)
+    {
+        var sessions = CopilotService.GetAllSessions().OrderBy(s => s.Name).ToList();
+        if (sessions.Count < 2) return;
+
+        var currentName = CopilotService.ActiveSessionName;
+        var idx = sessions.FindIndex(s => s.Name == currentName);
+        if (idx < 0) idx = 0;
+
+        idx = reverse
+            ? (idx - 1 + sessions.Count) % sessions.Count
+            : (idx + 1) % sessions.Count;
+
+        CopilotService.SwitchSession(sessions[idx].Name);
+        CopilotService.SaveUiState("/", sessions[idx].Name);
+        streamingContent = "";
+        currentToolName = "";
+        currentIntent = "";
+        visibleMessageCount = 50;
+        InvokeAsync(StateHasChanged);
+    }
+
     public void Dispose()
     {
+        _dotNetRef?.Dispose();
         CopilotService.OnStateChanged -= RefreshState;
         CopilotService.OnContentReceived -= HandleContentReceived;
         CopilotService.OnSessionComplete -= HandleSessionComplete;

--- a/Components/Pages/Home.razor.css
+++ b/Components/Pages/Home.razor.css
@@ -58,6 +58,22 @@
 
 .chat-header h2 { margin: 0; font-size: 1.6rem; }
 
+.session-nav-btn {
+    background: rgba(255,255,255,0.08);
+    border: 1px solid rgba(255,255,255,0.15);
+    border-radius: 6px;
+    color: rgba(255,255,255,0.6);
+    cursor: pointer;
+    font-size: 0.9rem;
+    padding: 0.25rem 0.5rem;
+    transition: all 0.15s;
+}
+.session-nav-btn:hover {
+    background: rgba(59,130,246,0.3);
+    color: white;
+    border-color: rgba(59,130,246,0.5);
+}
+
 .model-badge {
     padding: 0.25rem 0.5rem;
     background: rgba(59, 130, 246, 0.2);

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -37,6 +37,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<CopilotService>();
 		builder.Services.AddSingleton<ChatDatabase>();
 		builder.Services.AddSingleton<ServerManager>();
+		builder.Services.AddSingleton<KeyCommandService>();
 
 #if DEBUG
 		builder.Services.AddBlazorWebViewDeveloperTools();

--- a/Models/AgentSessionInfo.cs
+++ b/Models/AgentSessionInfo.cs
@@ -15,4 +15,7 @@ public class AgentSessionInfo
     // For resumed sessions
     public string? SessionId { get; set; }
     public bool IsResumed { get; init; }
+    
+    // Timestamp of last state change (message received, turn end, etc.)
+    public DateTime LastUpdatedAt { get; set; } = DateTime.Now;
 }

--- a/Services/KeyCommandService.cs
+++ b/Services/KeyCommandService.cs
@@ -1,0 +1,11 @@
+namespace AutoPilot.App.Services;
+
+/// <summary>
+/// Bridges native Mac Catalyst key commands to Blazor components.
+/// </summary>
+public class KeyCommandService
+{
+    public event Action<bool>? OnCycleSession; // bool = reverse (shift+tab)
+
+    public void CycleSession(bool reverse) => OnCycleSession?.Invoke(reverse);
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -30,12 +30,30 @@
             Notification.requestPermission();
         }
 
+        // Global keyboard listener — registered immediately on load
+        document.addEventListener('keydown', function(e) {
+            // Ctrl+] for next session, Ctrl+[ for previous
+            if (e.ctrlKey && e.code === 'BracketRight' && window._tabDotNetRef) {
+                e.preventDefault();
+                window._tabDotNetRef.invokeMethodAsync('CycleSession', false);
+            } else if (e.ctrlKey && e.code === 'BracketLeft' && window._tabDotNetRef) {
+                e.preventDefault();
+                window._tabDotNetRef.invokeMethodAsync('CycleSession', true);
+            }
+        }, true);
+
         window.setupTextareaEnterHandler = function(element) {
             if (!element || element._enterHandlerSet) return;
             element._enterHandlerSet = true;
             element.addEventListener('keydown', function(e) {
                 if (e.key === 'Enter' && !e.shiftKey) {
                     e.preventDefault();
+                }
+                // Tab / Shift+Tab to cycle sessions
+                if (e.key === 'Tab' && window._tabDotNetRef) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    window._tabDotNetRef.invokeMethodAsync('CycleSession', !e.shiftKey);
                 }
             });
         };
@@ -82,6 +100,10 @@
                 });
             }
             return result;
+        };
+
+        window.setupTabNavigation = function(dotnetRef) {
+            window._tabDotNetRef = dotnetRef;
         };
 
         window.showNotification = function(sessionName, summary) {


### PR DESCRIPTION
## Changes

### Tab/Shift+Tab Session Switching
- **Chat view**: Press Tab to cycle forward, Shift+Tab to go back between sessions (handled via JS on textarea element)
- **Session Orchestrator**: Tab/Shift+Tab cycles between card input boxes
- Clicking session name in orchestrator cards navigates to that session's chat

### Shared ChatMessageList Component
- Extracted `ChatMessageList.razor` — single component rendering all message types
- Used by both Home.razor (`Compact=false`, full mode with avatars/timestamps/tool details) and Dashboard.razor (`Compact=true`, card mode with role badges)
- All rendering improvements now automatically apply to both views

### UI Improvements
- Session number badges (1-9) in sidebar for quick identification
- Prev/Next (◀ ▶) buttons in chat header
- Dashboard card messages show full text (removed 120-char truncation)

### Infrastructure
- `KeyCommandService` for native Mac Catalyst keyboard shortcuts
- `LastUpdatedAt` tracking on sessions
- Cleaned up debug artifacts