### PR TITLE
Use localhost as default Android host

### DIFF
--- a/Models/ConnectionSettings.cs
+++ b/Models/ConnectionSettings.cs
@@ -54,11 +54,12 @@ public class ConnectionSettings
     private static ConnectionSettings DefaultSettings()
     {
 #if ANDROID
-        // Android can't run Copilot locally — default to persistent mode with common LAN IP
+        // Android can't run Copilot locally — default to persistent mode
+        // User must configure the host IP in Settings to point to their Mac
         return new ConnectionSettings
         {
             Mode = ConnectionMode.Persistent,
-            Host = "192.168.50.72", // Mac host on local network
+            Host = "localhost",
             Port = 4321
         };
 #else


### PR DESCRIPTION
Default Android connection settings now use `localhost` instead of a specific host. Users configure the actual host IP in the Settings page when connecting to their Copilot server.