### PR TITLE
Clean up Android edge-to-edge layout

### DIFF
--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="AutoPilot.App.MainPage"
-             SafeAreaEdges="Container">
+             x:Class="AutoPilot.App.MainPage">
 
     <BlazorWebView x:Name="blazorWebView" HostPage="wwwroot/index.html" />
 

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -25,6 +25,7 @@ public partial class MainPage : ContentPage
 	private void OnBlazorWebViewInitialized(object? sender, BlazorWebViewInitializedEventArgs e)
 	{
 		var webView = e.WebView;
+
 		// Wait for layout so WindowInsets are available
 		webView.ViewTreeObserver!.GlobalLayout += (s, args) =>
 		{

--- a/Platforms/Android/MainActivity.cs
+++ b/Platforms/Android/MainActivity.cs
@@ -1,24 +1,9 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Android.OS;
-using Android.Views;
-using AndroidX.Core.View;
 
 namespace AutoPilot.App;
 
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
-    protected override void OnCreate(Bundle? savedInstanceState)
-    {
-        base.OnCreate(savedInstanceState);
-
-        // Edge-to-edge with transparent system bars
-        if (Window != null)
-        {
-            WindowCompat.SetDecorFitsSystemWindows(Window, false);
-            Window.SetStatusBarColor(Android.Graphics.Color.Transparent);
-            Window.SetNavigationBarColor(Android.Graphics.Color.Transparent);
-        }
-    }
 }

--- a/wwwroot/app.css
+++ b/wwwroot/app.css
@@ -2,8 +2,6 @@ html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     font-size: var(--app-font-size, 20px);
     color: #a0b4cc;
-    /* Android bottom nav bar safe area */
-    padding-bottom: var(--nav-bar-height, env(safe-area-inset-bottom, 0px));
 }
 
 a, .btn-link {


### PR DESCRIPTION
## Changes

- Remove custom `SetDecorFitsSystemWindows`/`SetStatusBarColor`/`SetNavigationBarColor` from `MainActivity` — .NET 10 MAUI handles edge-to-edge natively via `ContentPage` defaults
- Remove redundant `padding-bottom` from `html, body` in `app.css` — the chat input area already handles bottom spacing via the `--nav-bar-height` CSS variable
- Remove unnecessary `Grid SafeAreaEdges` wrapper from `MainPage.xaml`
- Simplify `MainActivity` to bare `MauiAppCompatActivity` with no custom `OnCreate`