### PR TITLE
Add image paste/drop support to chat

### DIFF
--- a/Components/Pages/Dashboard.razor
+++ b/Components/Pages/Dashboard.razor
@@ -114,6 +114,21 @@
                             }
                         </div>
                     }
+                    @if (pendingImagesBySession.TryGetValue(session.Name, out var pendingImgs) && pendingImgs.Any())
+                    {
+                        <div class="pending-images">
+                            @for (var pi = 0; pi < pendingImgs.Count; pi++)
+                            {
+                                var pidx = pi;
+                                var pimg = pendingImgs[pi];
+                                <div class="image-badge">
+                                    <span class="image-badge-icon">🖼️</span>
+                                    <span class="image-badge-name">@pimg.FileName</span>
+                                    <button class="image-badge-remove" @onclick="() => RemovePendingImage(session.Name, pidx)">×</button>
+                                </div>
+                            }
+                        </div>
+                    }
                     <div class="input-row">
                         <textarea id="input-@session.Name.Replace(" ", "-")"
                                   placeholder="@(session.IsProcessing ? "Message will be queued…" : $"Send to {session.Name}...")"
@@ -245,6 +260,22 @@
                         <div class="intent-pill compact">💭 @intentG</div>
                     }
 
+                    @if (pendingImagesBySession.TryGetValue(session.Name, out var cardPendingImgs) && cardPendingImgs.Any())
+                    {
+                        <div class="pending-images">
+                            @for (var cpi = 0; cpi < cardPendingImgs.Count; cpi++)
+                            {
+                                var cpidx = cpi;
+                                var cpimg = cardPendingImgs[cpi];
+                                <div class="image-badge">
+                                    <span class="image-badge-icon">🖼️</span>
+                                    <span class="image-badge-name">@cpimg.FileName</span>
+                                    <button class="image-badge-remove" @onclick="() => RemovePendingImage(session.Name, cpidx)">×</button>
+                                </div>
+                            }
+                        </div>
+                    }
+
                     <div class="card-input">
                         <input type="text" id="input-@session.Name.Replace(" ", "-")"
                                placeholder="@(session.IsProcessing ? "Queue a message…" : $"Send to {session.Name}...")" />
@@ -276,6 +307,7 @@
     private Dictionary<string, SessionUsageInfo> usageBySession = new();
     private Dictionary<string, bool> planModeBySession = new();
     private Dictionary<string, string> modelOverrideBySession = new();
+    private Dictionary<string, List<PendingImage>> pendingImagesBySession = new();
     private int fontSize = 20;
     private string? expandedSession;
     private string? _focusedInputId;
@@ -652,14 +684,22 @@
     {
         var inputId = $"input-{sessionName.Replace(" ", "-")}";
         var prompt = await JS.InvokeAsync<string>("eval", $"document.getElementById('{inputId}')?.value || ''");
-        if (string.IsNullOrWhiteSpace(prompt)) return;
+        var hasImages = pendingImagesBySession.TryGetValue(sessionName, out var pendingSendImages) && pendingSendImages.Count > 0;
+        if (string.IsNullOrWhiteSpace(prompt) && !hasImages) return;
 
         await JS.InvokeVoidAsync("eval", $"document.getElementById('{inputId}').value = ''");
         draftBySession.Remove(sessionName);
 
-        var finalPrompt = prompt.Trim();
+        var finalPrompt = (prompt ?? "").Trim();
         if (planModeBySession.GetValueOrDefault(sessionName))
             finalPrompt = $"[[PLAN]] {finalPrompt}";
+
+        List<string>? imagePaths = null;
+        if (hasImages)
+        {
+            imagePaths = pendingSendImages!.Select(i => i.TempPath).ToList();
+            pendingImagesBySession.Remove(sessionName);
+        }
 
         var session = sessions.FirstOrDefault(s => s.Name == sessionName);
         if (session?.IsProcessing == true)
@@ -673,7 +713,7 @@
 
         try
         {
-            _ = CopilotService.SendPromptAsync(sessionName, finalPrompt).ContinueWith(t =>
+            _ = CopilotService.SendPromptAsync(sessionName, finalPrompt, imagePaths).ContinueWith(t =>
             {
                 if (t.IsFaulted)
                 {
@@ -749,6 +789,45 @@
         [property: System.Text.Json.Serialization.JsonPropertyName("selStart")] int SelStart,
         [property: System.Text.Json.Serialization.JsonPropertyName("selEnd")] int SelEnd,
         [property: System.Text.Json.Serialization.JsonPropertyName("items")] List<DraftItem>? Items);
+
+    private record PendingImage(string TempPath, string FileName, string Extension);
+
+    [JSInvokable]
+    public async Task JsImagePasted(string base64, string fileName, string extension, string inputId)
+    {
+        var rawName = inputId.Replace("input-", "");
+        var sessionName = sessions.FirstOrDefault(s => s.Name.Replace(" ", "-") == rawName)?.Name;
+        if (string.IsNullOrEmpty(sessionName)) return;
+
+        try
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "autopilot-images");
+            Directory.CreateDirectory(tempDir);
+            var tempPath = Path.Combine(tempDir, $"{Guid.NewGuid()}.{extension}");
+            var bytes = Convert.FromBase64String(base64);
+            await File.WriteAllBytesAsync(tempPath, bytes);
+
+            if (!pendingImagesBySession.ContainsKey(sessionName))
+                pendingImagesBySession[sessionName] = new();
+            pendingImagesBySession[sessionName].Add(new PendingImage(tempPath, fileName, extension));
+
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error saving pasted image: {ex.Message}");
+        }
+    }
+
+    private void RemovePendingImage(string sessionName, int index)
+    {
+        if (pendingImagesBySession.TryGetValue(sessionName, out var images) && index >= 0 && index < images.Count)
+        {
+            try { File.Delete(images[index].TempPath); } catch { }
+            images.RemoveAt(index);
+            if (images.Count == 0) pendingImagesBySession.Remove(sessionName);
+        }
+    }
 
     private async Task StopSession(string sessionName)
     {
@@ -938,6 +1017,9 @@
         CopilotService.OnError -= HandleError;
         CopilotService.OnTurnStart -= HandleTurnStart;
         CopilotService.OnTurnEnd -= HandleTurnEnd;
+        foreach (var images in pendingImagesBySession.Values)
+            foreach (var img in images)
+                try { File.Delete(img.TempPath); } catch { }
         _dotNetRef?.Dispose();
     }
 }

--- a/Components/Pages/Dashboard.razor.css
+++ b/Components/Pages/Dashboard.razor.css
@@ -646,3 +646,54 @@
     .card-messages { max-height: 180px; gap: 0.3rem; font-size: var(--type-callout, 0.8rem); }
     .card-dir { max-width: 160px; }
 }
+
+/* Image paste/drop badges */
+.pending-images {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    padding: 0.15rem 0;
+}
+
+.image-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.5rem;
+    background: rgba(78,168,209,0.12);
+    border: 1px solid rgba(78,168,209,0.25);
+    border-radius: 6px;
+    font-size: 0.7rem;
+    color: #a0b4cc;
+    max-width: 180px;
+}
+
+.image-badge-icon { flex-shrink: 0; font-size: 0.75rem; }
+
+.image-badge-name {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+}
+
+.image-badge-remove {
+    all: unset;
+    cursor: pointer;
+    color: rgba(255,255,255,0.35);
+    font-size: 0.8rem;
+    line-height: 1;
+    padding: 0 0.1rem;
+    flex-shrink: 0;
+}
+
+.image-badge-remove:hover { color: #ef4444; }
+
+/* Drag-over visual feedback */
+::deep .input-area.drag-over,
+::deep .card-input.drag-over {
+    background: rgba(78,168,209,0.15);
+    outline: 2px dashed rgba(78,168,209,0.5);
+    outline-offset: -2px;
+    border-radius: 8px;
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -42,6 +42,69 @@
             }
         }, true);
 
+        // Global image paste handler for chat inputs
+        document.addEventListener('paste', function(e) {
+            var sel = '.card-input input, .card-input textarea, .input-row textarea';
+            if (!e.target.matches || !e.target.matches(sel)) return;
+            var items = e.clipboardData && e.clipboardData.items;
+            if (!items) return;
+            for (var i = 0; i < items.length; i++) {
+                if (items[i].type.startsWith('image/')) {
+                    if (!window.__dashRef) return;
+                    e.preventDefault();
+                    var file = items[i].getAsFile();
+                    if (file) {
+                        var reader = new FileReader();
+                        reader.onload = function() {
+                            var base64 = reader.result.split(',')[1];
+                            var ext = (file.name && file.name.includes('.')) ? file.name.split('.').pop() : 'png';
+                            var name = file.name || ('pasted-image.' + ext);
+                            window.__dashRef.invokeMethodAsync('JsImagePasted', base64, name, ext, e.target.id || '');
+                        };
+                        reader.readAsDataURL(file);
+                    }
+                    return;
+                }
+            }
+        }, true);
+
+        // Global image drop handler for chat input areas
+        document.addEventListener('dragover', function(e) {
+            var zone = e.target.closest && (e.target.closest('.input-area') || e.target.closest('.card-input'));
+            if (zone && e.dataTransfer && Array.from(e.dataTransfer.types).includes('Files')) {
+                e.preventDefault();
+                zone.classList.add('drag-over');
+            }
+        });
+        document.addEventListener('dragleave', function(e) {
+            var zone = e.target.closest && (e.target.closest('.input-area') || e.target.closest('.card-input'));
+            if (zone) zone.classList.remove('drag-over');
+        });
+        document.addEventListener('drop', function(e) {
+            var zone = e.target.closest && (e.target.closest('.input-area') || e.target.closest('.card-input'));
+            if (!zone) return;
+            e.preventDefault();
+            zone.classList.remove('drag-over');
+            var input = zone.querySelector('textarea') || zone.querySelector('input');
+            var inputId = input ? input.id : '';
+            var files = e.dataTransfer && e.dataTransfer.files;
+            if (!files || !window.__dashRef) return;
+            for (var i = 0; i < files.length; i++) {
+                if (files[i].type.startsWith('image/')) {
+                    (function(f) {
+                        var reader = new FileReader();
+                        reader.onload = function() {
+                            var base64 = reader.result.split(',')[1];
+                            var ext = (f.name && f.name.includes('.')) ? f.name.split('.').pop() : 'png';
+                            var name = f.name || ('dropped-image.' + ext);
+                            window.__dashRef.invokeMethodAsync('JsImagePasted', base64, name, ext, inputId);
+                        };
+                        reader.readAsDataURL(f);
+                    })(files[i]);
+                }
+            }
+        });
+
         window.setupTextareaEnterHandler = function(element) {
             if (!element || element._enterHandlerSet) return;
             element._enterHandlerSet = true;


### PR DESCRIPTION
Allow users to paste or drop images into chat inputs and attach them to prompts. UI: show pending image badges with remove buttons in Dashboard, add drag-over visuals in CSS, and clear temp files on dispose. JS: global paste and drop handlers added in index.html that pass base64 image data to Blazor via JsImagePasted. Razor: track PendingImage per session, save pasted/dropped images to temp files, prevent sending empty prompts unless images exist, and expose removal and state updates. Service: CopilotService now accepts and attaches image paths to MessageOptions.Attachments (replaced reflection-based construction) and includes image paths in the user history display for rendering. Overall enables image attachments in conversations and cleans up temp files.