### PR TITLE
Android fixes: auto-reconnect, history loading, processing state, expand button

### DIFF
--- a/Components/Pages/Dashboard.razor
+++ b/Components/Pages/Dashboard.razor
@@ -207,6 +207,7 @@
                         {
                             <button class="card-stop" @onclick="() => StopSession(session.Name)" title="Stop">■</button>
                         }
+                        <button class="card-expand" @onclick="() => ExpandSession(session.Name)" title="Expand">⤢</button>
                         <button class="card-close" @onclick="() => CloseSession(session.Name)" title="Close session">✕</button>
                     </div>
                     <div class="card-context">

--- a/Components/Pages/Dashboard.razor.css
+++ b/Components/Pages/Dashboard.razor.css
@@ -283,6 +283,24 @@
     gap: 0.5rem;
 }
 
+.card-expand {
+    background: none;
+    border: none;
+    color: rgba(255,255,255,0.4);
+    font-size: var(--type-body);
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    cursor: pointer;
+    line-height: 1;
+    flex-shrink: 0;
+    transition: all 0.15s ease;
+}
+
+.card-expand:hover {
+    background: rgba(96, 165, 250, 0.2);
+    color: #60a5fa;
+}
+
 .card-close {
     background: none;
     border: none;


### PR DESCRIPTION
## Fixes

### WsBridge auto-reconnect
WebSocket disconnects (common on mobile/WiFi) now trigger automatic reconnection with exponential backoff (2s → 30s max). Previously the client silently died and never recovered, leaving the app unable to send/receive messages.

### History loading for all sessions
On connect, history is now requested for all sessions with messages — not just the active one. Previously non-active sessions showed empty message lists on Android.

### Processing state sync
`IsProcessing` now syncs the actual server state instead of only setting `true` and never clearing. Previously sessions got stuck showing "busy" permanently on Android.

### Expand button
Added ⤢ expand button to each grid card header for quick full-screen chat access, especially useful on mobile where keyboard shortcuts aren't available.