### PR TITLE
Fix DotNetObjectReference disposed crash on dashboard navigation

### DIFF
--- a/AutoPilot.App/Components/Layout/SessionSidebar.razor
+++ b/AutoPilot.App/Components/Layout/SessionSidebar.razor
@@ -566,7 +566,7 @@ else
         CopilotService.SetActiveSession(null);
         CopilotService.SaveUiState("/");
         currentPage = "/";
-        await JS.InvokeVoidAsync("eval", "window.__dashRef?.invokeMethodAsync('JsCollapseToGrid')");
+        try { await JS.InvokeVoidAsync("eval", "window.__dashRef?.invokeMethodAsync('JsCollapseToGrid')"); } catch { }
         Nav.NavigateTo("/");
     }
 

--- a/AutoPilot.App/Components/Pages/Dashboard.razor
+++ b/AutoPilot.App/Components/Pages/Dashboard.razor
@@ -6,7 +6,7 @@
 @inject IJSRuntime JS
 @inject NavigationManager Nav
 @inject DevTunnelService DevTunnelService
-@implements IDisposable
+@implements IAsyncDisposable
 
 <div class="dashboard @(expandedSession != null ? "expanded-mode" : "")">
     @if (!sessions.Any())
@@ -1137,7 +1137,7 @@
         try { await JS.InvokeVoidAsync("navigator.clipboard.writeText", text); } catch { }
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         CopilotService.OnStateChanged -= RefreshState;
         CopilotService.OnSessionComplete -= HandleComplete;
@@ -1153,6 +1153,7 @@
         foreach (var images in pendingImagesBySession.Values)
             foreach (var img in images)
                 try { File.Delete(img.TempPath); } catch { }
+        try { await JS.InvokeVoidAsync("eval", "window.__dashRef = null;"); } catch { }
         _dotNetRef?.Dispose();
     }
 }


### PR DESCRIPTION
When navigating away from the Dashboard, Dispose() called _dotNetRef.Dispose() which unregistered the .NET object from JS interop tracking. However, window.__dashRef in JavaScript still held the stale reference. When SessionSidebar.DashboardClicked() later invoked
window.__dashRef?.invokeMethodAsync('JsCollapseToGrid'), the JS optional chaining saw a non-null (but disposed) reference and attempted the call, causing System.ArgumentException: 'no tracked object with id 2'.

Changes:
- Dashboard.razor: Switch from IDisposable to IAsyncDisposable so DisposeAsync() can clear window.__dashRef = null in JS before disposing the .NET reference, preventing stale ref invocations.
- SessionSidebar.razor: Wrap the invokeMethodAsync call in try/catch as defense-in-depth against race conditions where disposal and sidebar click overlap.