### PR TITLE
Add session ordering, pinning, and grouping

### DIFF
--- a/AutoPilot.App.Tests/AutoPilot.App.Tests.csproj
+++ b/AutoPilot.App.Tests/AutoPilot.App.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="../AutoPilot.App/Models/BridgeMessages.cs" Link="Shared/BridgeMessages.cs" />
     <Compile Include="../AutoPilot.App/Models/ConnectionSettings.cs" Link="Shared/ConnectionSettings.cs" />
     <Compile Include="../AutoPilot.App/Models/PlatformHelper.cs" Link="Shared/PlatformHelper.cs" />
+    <Compile Include="../AutoPilot.App/Models/SessionOrganization.cs" Link="Shared/SessionOrganization.cs" />
   </ItemGroup>
 
 </Project>

--- a/AutoPilot.App.Tests/SessionOrganizationTests.cs
+++ b/AutoPilot.App.Tests/SessionOrganizationTests.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using AutoPilot.App.Models;
+
+namespace AutoPilot.App.Tests;
+
+public class SessionOrganizationTests
+{
+    [Fact]
+    public void DefaultState_HasDefaultGroup()
+    {
+        var state = new OrganizationState();
+        Assert.Single(state.Groups);
+        Assert.Equal(SessionGroup.DefaultId, state.Groups[0].Id);
+        Assert.Equal(SessionGroup.DefaultName, state.Groups[0].Name);
+    }
+
+    [Fact]
+    public void DefaultState_HasLastActiveSortMode()
+    {
+        var state = new OrganizationState();
+        Assert.Equal(SessionSortMode.LastActive, state.SortMode);
+    }
+
+    [Fact]
+    public void SessionMeta_DefaultsToDefaultGroup()
+    {
+        var meta = new SessionMeta { SessionName = "test" };
+        Assert.Equal(SessionGroup.DefaultId, meta.GroupId);
+        Assert.False(meta.IsPinned);
+        Assert.Equal(0, meta.ManualOrder);
+    }
+
+    [Fact]
+    public void Serialization_RoundTrips()
+    {
+        var state = new OrganizationState
+        {
+            SortMode = SessionSortMode.Alphabetical
+        };
+        state.Groups.Add(new SessionGroup
+        {
+            Id = "custom-1",
+            Name = "Work",
+            SortOrder = 1,
+            IsCollapsed = true
+        });
+        state.Sessions.Add(new SessionMeta
+        {
+            SessionName = "my-session",
+            GroupId = "custom-1",
+            IsPinned = true,
+            ManualOrder = 3
+        });
+
+        var json = JsonSerializer.Serialize(state);
+        var deserialized = JsonSerializer.Deserialize<OrganizationState>(json);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal(2, deserialized!.Groups.Count);
+        Assert.Equal(SessionSortMode.Alphabetical, deserialized.SortMode);
+
+        var customGroup = deserialized.Groups.Find(g => g.Id == "custom-1");
+        Assert.NotNull(customGroup);
+        Assert.Equal("Work", customGroup!.Name);
+        Assert.True(customGroup.IsCollapsed);
+        Assert.Equal(1, customGroup.SortOrder);
+
+        var meta = deserialized.Sessions[0];
+        Assert.Equal("my-session", meta.SessionName);
+        Assert.Equal("custom-1", meta.GroupId);
+        Assert.True(meta.IsPinned);
+        Assert.Equal(3, meta.ManualOrder);
+    }
+
+    [Fact]
+    public void SortMode_SerializesAsString()
+    {
+        var state = new OrganizationState { SortMode = SessionSortMode.CreatedAt };
+        var json = JsonSerializer.Serialize(state);
+        Assert.Contains("\"CreatedAt\"", json);
+    }
+
+    [Fact]
+    public void EmptyState_DeserializesGracefully()
+    {
+        var json = "{}";
+        var state = JsonSerializer.Deserialize<OrganizationState>(json);
+        Assert.NotNull(state);
+        // Default group is created by constructor
+        Assert.Single(state!.Groups);
+        Assert.Equal(SessionGroup.DefaultId, state.Groups[0].Id);
+    }
+
+    [Fact]
+    public void SessionGroup_DefaultConstants()
+    {
+        Assert.Equal("_default", SessionGroup.DefaultId);
+        Assert.Equal("Sessions", SessionGroup.DefaultName);
+    }
+
+    [Fact]
+    public void OrganizationCommandPayload_Serializes()
+    {
+        var cmd = new OrganizationCommandPayload
+        {
+            Command = "pin",
+            SessionName = "test-session"
+        };
+        var json = JsonSerializer.Serialize(cmd, BridgeJson.Options);
+        Assert.Contains("pin", json);
+        Assert.Contains("test-session", json);
+
+        var deserialized = JsonSerializer.Deserialize<OrganizationCommandPayload>(json, BridgeJson.Options);
+        Assert.NotNull(deserialized);
+        Assert.Equal("pin", deserialized!.Command);
+        Assert.Equal("test-session", deserialized.SessionName);
+    }
+}

--- a/AutoPilot.App/Components/Layout/SessionSidebar.razor
+++ b/AutoPilot.App/Components/Layout/SessionSidebar.razor
@@ -58,7 +58,7 @@ else if (IsFlyoutPanel)
         </div>
 
         <div class="sidebar-divider"></div>
-
+        @RenderSortToolbar
         @RenderSessionList
     </div>
 }
@@ -113,7 +113,7 @@ else
         </div>
 
         <div class="sidebar-divider"></div>
-
+        @RenderSortToolbar
         @RenderSessionList
     </div>
 }
@@ -124,70 +124,167 @@ else
     [Parameter] public EventCallback OnToggleFlyout { get; set; }
     [Parameter] public EventCallback OnSessionSelected { get; set; }
 
+    private RenderFragment RenderSortToolbar => __builder =>
+    {
+        <div class="sidebar-toolbar">
+            <select class="sort-select" title="Sort sessions" @onchange="OnSortModeChanged">
+                <option value="LastActive" selected="@(CopilotService.Organization.SortMode == SessionSortMode.LastActive)">↕ Last Active</option>
+                <option value="CreatedAt" selected="@(CopilotService.Organization.SortMode == SessionSortMode.CreatedAt)">↕ Created</option>
+                <option value="Alphabetical" selected="@(CopilotService.Organization.SortMode == SessionSortMode.Alphabetical)">↕ A–Z</option>
+                <option value="Manual" selected="@(CopilotService.Organization.SortMode == SessionSortMode.Manual)">↕ Manual</option>
+            </select>
+            @if (isAddingGroup)
+            {
+                <input type="text" class="new-group-input" id="newGroupInput"
+                       placeholder="Group name..."
+                       @onblur="CommitNewGroup"
+                       @onkeydown="HandleNewGroupKeyDown" />
+            }
+            else
+            {
+                <button class="new-group-btn" @onclick="StartAddGroup" title="New group">+ Group</button>
+            }
+        </div>
+    };
+
     private RenderFragment RenderSessionList => __builder =>
     {
         <div class="session-list">
-            <div class="section-header"><span class="section-header-label">Active Sessions</span></div>
+            @{
+                var organized = CopilotService.GetOrganizedSessions().ToList();
+                var showGroupHeaders = CopilotService.HasMultipleGroups;
+                var sessionIndex = 0;
+            }
+
             @if (!sessions.Any())
             {
+                <div class="section-header"><span class="section-header-label">Active Sessions</span></div>
                 <p class="no-sessions">No active sessions.<br/>Create one above or resume below.</p>
             }
             else
             {
-                var sessionIndex = 0;
-                @foreach (var session in sessions)
+                @if (!showGroupHeaders)
                 {
-                    sessionIndex++;
-                    var idx = sessionIndex;
-                    var cssClass = session.Name == CopilotService.ActiveSessionName ? "active" : 
-                                   completedSessions.Contains(session.Name) ? "completed" :
-                                   session.IsProcessing ? "busy" : "";
-                    <div class="session-item @cssClass"
-                         @onclick="() => SelectSession(session.Name)">
-                        <div class="session-info">
-                            <span class="session-name">
-                                @if (idx <= 9)
-                                {
-                                    <span class="shortcut-badge" title="⌘@idx">@idx</span>
-                                }
-                                @if (completedSessions.Contains(session.Name))
-                                {
-                                    <span class="done-badge">✅</span>
-                                }
-                                @if (renamingSession == session.Name)
-                                {
-                                    <input type="text" class="rename-input" id="renameInput"
-                                           value="@session.Name"
-                                           @onclick:stopPropagation="true"
-                                           @onblur="CommitRename"
-                                           @onkeydown="HandleRenameKeyDown" />
-                                }
-                                else
-                                {
-                                    <span class="session-name-text" @ondblclick="() => StartRename(session.Name)" @ondblclick:stopPropagation="true">@session.Name</span>
-                                }
-                            </span>
-                            <div class="session-meta-row">
-                                <span class="session-meta">
-                                    @session.MessageCount msgs@(session.Model != "resumed" ? $" • {session.Model}" : "")
-                                    @if (session.IsProcessing)
-                                    {
-                                        <span class="processing"> • Working</span>
-                                    }
-                                    @if (!string.IsNullOrEmpty(session.WorkingDirectory))
-                                    {
-                                        <text> • @GetShortPath(session.WorkingDirectory)</text>
-                                    }
-                                </span>
-                                <div class="session-actions">
-                                    <button class="rename-btn" @onclick:stopPropagation="true"
-                                            @onclick="() => StartRename(session.Name)" title="Rename session">rename</button>
-                                    <button class="close-btn" @onclick:stopPropagation="true" 
-                                            @onclick="() => CloseSession(session.Name)">×</button>
+                    <div class="section-header"><span class="section-header-label">Active Sessions</span></div>
+                }
+
+                @foreach (var (group, groupSessions) in organized)
+                {
+                    @if (showGroupHeaders)
+                    {
+                        <div class="group-header @(group.IsCollapsed ? "collapsed" : "")"
+                             @onclick="() => CopilotService.ToggleGroupCollapsed(group.Id)">
+                            <span class="group-chevron">@(group.IsCollapsed ? "▶" : "▼")</span>
+                            <span class="group-name">@group.Name</span>
+                            <span class="group-count">@groupSessions.Count</span>
+                            @if (group.IsCollapsed && groupSessions.Any(s => s.IsProcessing))
+                            {
+                                <span class="group-busy-dot"></span>
+                            }
+                            @if (group.Id != SessionGroup.DefaultId)
+                            {
+                                <button class="group-delete-btn" title="Delete group"
+                                        @onclick="() => CopilotService.DeleteGroup(group.Id)"
+                                        @onclick:stopPropagation="true">×</button>
+                            }
+                        </div>
+                    }
+
+                    @if (!group.IsCollapsed || !showGroupHeaders)
+                    {
+                        @foreach (var session in groupSessions)
+                        {
+                            sessionIndex++;
+                            var idx = sessionIndex;
+                            var meta = CopilotService.GetSessionMeta(session.Name);
+                            var isPinned = meta?.IsPinned ?? false;
+                            var cssClass = session.Name == CopilotService.ActiveSessionName ? "active" : 
+                                           completedSessions.Contains(session.Name) ? "completed" :
+                                           session.IsProcessing ? "busy" : "";
+                            <div class="session-item @cssClass @(isPinned ? "pinned" : "")"
+                                 @onclick="() => SelectSession(session.Name)">
+                                <div class="session-info">
+                                    <span class="session-name">
+                                        @if (idx <= 9)
+                                        {
+                                            <span class="shortcut-badge" title="⌘@idx">@idx</span>
+                                        }
+                                        @if (isPinned)
+                                        {
+                                            <span class="pin-badge" title="Pinned" @onclick="() => CopilotService.PinSession(session.Name, false)" @onclick:stopPropagation="true">📌</span>
+                                        }
+                                        @if (completedSessions.Contains(session.Name))
+                                        {
+                                            <span class="done-badge">✅</span>
+                                        }
+                                        @if (renamingSession == session.Name)
+                                        {
+                                            <input type="text" class="rename-input" id="renameInput"
+                                                   value="@session.Name"
+                                                   @onclick:stopPropagation="true"
+                                                   @onblur="CommitRename"
+                                                   @onkeydown="HandleRenameKeyDown" />
+                                        }
+                                        else
+                                        {
+                                            <span class="session-name-text" @ondblclick="() => StartRename(session.Name)" @ondblclick:stopPropagation="true">@session.Name</span>
+                                        }
+                                    </span>
+                                    <div class="session-meta-row">
+                                        <span class="session-meta">
+                                            @session.MessageCount msgs@(session.Model != "resumed" ? $" • {session.Model}" : "")
+                                            @if (session.IsProcessing)
+                                            {
+                                                <span class="processing"> • Working</span>
+                                            }
+                                            @if (!string.IsNullOrEmpty(session.WorkingDirectory))
+                                            {
+                                                <text> • @GetShortPath(session.WorkingDirectory)</text>
+                                            }
+                                        </span>
+                                        <div class="session-actions">
+                                            <button class="more-btn" @onclick:stopPropagation="true"
+                                                    @onclick="() => ToggleSessionMenu(session.Name)" title="More actions">⋯</button>
+                                            @if (openMenuSession == session.Name)
+                                            {
+                                                <div class="session-menu" @onclick:stopPropagation="true">
+                                                    <button class="menu-item" @onclick="() => { openMenuSession = null; StartRename(session.Name); }">
+                                                        ✏️ Rename
+                                                    </button>
+                                                    @if (isPinned)
+                                                    {
+                                                        <button class="menu-item" @onclick="() => { openMenuSession = null; CopilotService.PinSession(session.Name, false); }">
+                                                            📌 Unpin
+                                                        </button>
+                                                    }
+                                                    else
+                                                    {
+                                                        <button class="menu-item" @onclick="() => { openMenuSession = null; CopilotService.PinSession(session.Name, true); }">
+                                                            📌 Pin
+                                                        </button>
+                                                    }
+                                                    @if (CopilotService.Organization.Groups.Count > 1)
+                                                    {
+                                                        @foreach (var g in CopilotService.Organization.Groups.Where(g => g.Id != (meta?.GroupId ?? SessionGroup.DefaultId)))
+                                                        {
+                                                            var targetGroup = g;
+                                                            <button class="menu-item" @onclick="() => { openMenuSession = null; CopilotService.MoveSession(session.Name, targetGroup.Id); }">
+                                                                📁 Move to @targetGroup.Name
+                                                            </button>
+                                                        }
+                                                    }
+                                                    <div class="menu-separator"></div>
+                                                    <button class="menu-item destructive" @onclick="() => { openMenuSession = null; CloseSession(session.Name); }">
+                                                        🗑 Close Session
+                                                    </button>
+                                                </div>
+                                            }
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                    </div>
+                        }
+                    }
                 }
             }
 
@@ -266,6 +363,8 @@ else
     private string? confirmResumeId = null;
     private string? resumeError = null;
     private string currentPage = "/";
+    private bool isAddingGroup = false;
+    private string? openMenuSession = null;
     private List<AgentSessionInfo> sessions = new();
     private List<PersistedSessionInfo> persistedSessions = new();
 
@@ -588,6 +687,48 @@ else
     private async Task CloseSession(string name)
     {
         await CopilotService.CloseSessionAsync(name);
+    }
+
+    private void MoveSessionToGroup(string sessionName, ChangeEventArgs e)
+    {
+        if (e.Value is string groupId && !string.IsNullOrEmpty(groupId))
+        {
+            CopilotService.MoveSession(sessionName, groupId);
+        }
+    }
+
+    private void OnSortModeChanged(ChangeEventArgs e)
+    {
+        if (e.Value is string val && Enum.TryParse<SessionSortMode>(val, out var mode))
+        {
+            CopilotService.SetSortMode(mode);
+        }
+    }
+
+    private void StartAddGroup()
+    {
+        isAddingGroup = true;
+    }
+
+    private async Task CommitNewGroup()
+    {
+        var name = await JS.InvokeAsync<string>("eval", "document.getElementById('newGroupInput')?.value ?? ''");
+        isAddingGroup = false;
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            CopilotService.CreateGroup(name.Trim());
+        }
+    }
+
+    private async Task HandleNewGroupKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter") await CommitNewGroup();
+        else if (e.Key == "Escape") isAddingGroup = false;
+    }
+
+    private void ToggleSessionMenu(string sessionName)
+    {
+        openMenuSession = openMenuSession == sessionName ? null : sessionName;
     }
 
     private string GetTooltip(PersistedSessionInfo persisted)

--- a/AutoPilot.App/Components/Layout/SessionSidebar.razor.css
+++ b/AutoPilot.App/Components/Layout/SessionSidebar.razor.css
@@ -163,6 +163,169 @@
     padding: 0.5rem;
 }
 
+/* Sort/group toolbar */
+.sidebar-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.75rem;
+}
+
+.sort-select {
+    all: unset;
+    font-size: var(--type-caption1);
+    color: rgba(255,255,255,0.4);
+    cursor: pointer;
+    padding: 0.15rem 0.3rem;
+    border-radius: 4px;
+    background: rgba(78,168,209,0.08);
+    border: 1px solid rgba(78,168,209,0.12);
+}
+.sort-select:hover { color: rgba(255,255,255,0.6); background: rgba(78,168,209,0.15); }
+.sort-select option { background: #1a1e3a; color: #a0b4cc; }
+
+.new-group-btn {
+    all: unset;
+    margin-left: auto;
+    font-size: var(--type-caption1);
+    color: rgba(78,168,209,0.5);
+    cursor: pointer;
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    border: 1px solid rgba(78,168,209,0.15);
+}
+.new-group-btn:hover { color: #4ea8d1; background: rgba(78,168,209,0.15); border-color: rgba(78,168,209,0.3); }
+
+.new-group-input {
+    margin-left: auto;
+    font-size: var(--type-caption1);
+    color: #a0b4cc;
+    background: rgba(78,168,209,0.15);
+    border: 1px solid rgba(78,168,209,0.3);
+    border-radius: 4px;
+    padding: 0.15rem 0.4rem;
+    width: 100px;
+    outline: none;
+}
+
+/* Group headers */
+.group-header {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.4rem 0.75rem 0.25rem;
+    cursor: pointer;
+    user-select: none;
+}
+.group-header:hover { background: rgba(255,255,255,0.03); }
+
+.group-chevron {
+    font-size: var(--type-caption2);
+    color: rgba(255,255,255,0.35);
+    width: 0.8rem;
+    text-align: center;
+}
+
+.group-name {
+    font-size: var(--type-callout);
+    font-weight: 600;
+    color: rgba(255,255,255,0.55);
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.group-count {
+    font-size: var(--type-caption2);
+    color: rgba(255,255,255,0.25);
+}
+.group-count::before { content: "("; }
+.group-count::after { content: ")"; }
+
+.group-busy-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #fbbf24;
+    animation: pulse-dot 1s infinite;
+}
+@keyframes pulse-dot { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+.group-delete-btn {
+    all: unset;
+    margin-left: auto;
+    font-size: var(--type-callout);
+    color: rgba(255,255,255,0.2);
+    cursor: pointer;
+    padding: 0 0.3rem;
+    border-radius: 3px;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+.group-header:hover .group-delete-btn { opacity: 1; }
+.group-delete-btn:hover { color: #ef4444; background: rgba(239,68,68,0.15); }
+
+/* Pinned session styles */
+.session-item.pinned {
+    border-left: 2px solid rgba(251,191,36,0.4);
+}
+
+.pin-badge {
+    font-size: 0.65rem;
+    cursor: pointer;
+    margin-right: 0.15rem;
+}
+.pin-badge:hover { opacity: 0.6; }
+
+/* ⋯ More menu */
+.more-btn {
+    all: unset;
+    font-size: var(--type-body);
+    color: rgba(255,255,255,0.3);
+    cursor: pointer;
+    padding: 0 0.3rem;
+    border-radius: 3px;
+    line-height: 1;
+    letter-spacing: 0.1em;
+}
+.more-btn:hover { color: rgba(255,255,255,0.7); background: rgba(255,255,255,0.08); }
+
+.session-menu {
+    position: absolute;
+    right: 0.5rem;
+    top: 100%;
+    z-index: 100;
+    min-width: 140px;
+    background: #1e2240;
+    border: 1px solid rgba(78,168,209,0.25);
+    border-radius: 8px;
+    padding: 0.25rem 0;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+    display: flex;
+    flex-direction: column;
+}
+
+.menu-item {
+    all: unset;
+    display: block;
+    width: 100%;
+    padding: 0.35rem 0.65rem;
+    font-size: var(--type-callout);
+    color: rgba(255,255,255,0.7);
+    cursor: pointer;
+    white-space: nowrap;
+    box-sizing: border-box;
+}
+.menu-item:hover { background: rgba(78,168,209,0.15); color: #fff; }
+
+.menu-separator {
+    height: 1px;
+    background: rgba(255,255,255,0.08);
+    margin: 0.2rem 0.5rem;
+}
+
+.menu-item.destructive { color: rgba(239,68,68,0.7); }
+.menu-item.destructive:hover { background: rgba(239,68,68,0.12); color: #ef4444; }
+
 .section-header {
     padding: 0.5rem 0.75rem;
     font-size: var(--type-callout);
@@ -194,6 +357,7 @@
 }
 
 .session-item {
+    position: relative;
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/AutoPilot.App/Components/Pages/Dashboard.razor
+++ b/AutoPilot.App/Components/Pages/Dashboard.razor
@@ -202,104 +202,201 @@
                     @(CopilotService.IsBridgeConnected ? "🟢" : "🔴")
                 </span>
             }
-        </div>
-        <div class="session-grid">
-            @foreach (var session in sessions)
+            <button class="grid-density-btn" @onclick="ToggleGridDensity" title="@(expandedGrid ? "Compact grid" : "Expanded grid")">
+                @(expandedGrid ? "▦ Compact" : "▤ Expanded")
+            </button>
+            <span class="font-size-controls">
+                <button class="font-size-btn" @onclick="DecreaseFontSize" disabled="@(fontSize <= 12)">A−</button>
+                <span class="font-size-label" @onclick="ResetFontSize">@(fontSize)px</span>
+                <button class="font-size-btn" @onclick="IncreaseFontSize" disabled="@(fontSize >= 24)">A+</button>
+            </span>
+            <select class="sort-select" @onchange="OnSortModeChanged">
+                <option value="LastActive" selected="@(CopilotService.Organization.SortMode == SessionSortMode.LastActive)">↕ Last Active</option>
+                <option value="CreatedAt" selected="@(CopilotService.Organization.SortMode == SessionSortMode.CreatedAt)">↕ Created</option>
+                <option value="Alphabetical" selected="@(CopilotService.Organization.SortMode == SessionSortMode.Alphabetical)">↕ A–Z</option>
+                <option value="Manual" selected="@(CopilotService.Organization.SortMode == SessionSortMode.Manual)">↕ Manual</option>
+            </select>
+            @if (isAddingDashGroup)
             {
-                var isCompleted = completedSessions.Contains(session.Name);
-                var cardClass = session.IsProcessing ? "processing" : isCompleted ? "completed" : "idle";
-                <div class="session-card @cardClass" data-session="@session.Name">
-                    <div class="card-header">
-                        <div class="card-title" @onclick="() => GoToSession(session.Name)" style="cursor:pointer">
-                            <span class="card-status-dot @cardClass"></span>
-                            <h3>@session.Name</h3>
-                        </div>
-                        @if (session.IsProcessing)
-                        {
-                            <button class="card-stop" @onclick="() => StopSession(session.Name)" title="Stop">■</button>
-                        }
-                        <button class="card-expand" @onclick="() => ExpandSession(session.Name)" title="Expand">⤢</button>
-                        <button class="card-close" @onclick="() => CloseSession(session.Name)" title="Close session">✕</button>
-                    </div>
-                    <div class="card-context">
-                        <span class="card-model">@GetSessionModel(session)</span>
-                        @if (!string.IsNullOrEmpty(session.WorkingDirectory))
-                        {
-                            <span class="card-dir" title="@session.WorkingDirectory">📁 @ShortenPath(session.WorkingDirectory)</span>
-                        }
-                        @if (!string.IsNullOrEmpty(session.GitBranch))
-                        {
-                            <span class="card-branch-sub"> @session.GitBranch</span>
-                        }
-                    </div>
-
-                    <div class="card-messages">
-                        @{
-                            var cardMsgs = GetCardMessages(session.Name, session.History);
-                            var hasMoreCard = session.History.Count > cardMsgs.Count;
-                        }
-                        @if (hasMoreCard)
-                        {
-                            <button class="load-more-btn" @onclick="() => LoadMoreCardMessages(session.Name)">▲ Load earlier messages (@(session.History.Count - cardMsgs.Count) more)</button>
-                        }
-                        <ChatMessageList Messages="cardMsgs"
-                                         StreamingContent="@(streamingBySession.TryGetValue(session.Name, out var s) ? s : "")"
-                                         CurrentToolName="@(currentToolBySession.TryGetValue(session.Name, out var t) ? t : "")"
-                                         ToolActivities="@(toolActivitiesBySession.TryGetValue(session.Name, out var ta) ? ta : new())"
-                                         ActivityText="@(activityBySession.TryGetValue(session.Name, out var a) ? a : "")"
-                                         IsProcessing="session.IsProcessing"
-                                         Compact="true" />
-                    </div>
-
-                    @if (errorBySession.TryGetValue(session.Name, out var errG))
-                    {
-                        <div class="card-error">
-                            <span>⚠️ @errG</span>
-                            <button @onclick="() => DismissError(session.Name)">✕</button>
-                        </div>
-                    }
-
-                    @if (session.MessageQueue.Any())
-                    {
-                        <div class="card-queue">
-                            <span class="queue-label">📋 Queued (@session.MessageQueue.Count)</span>
-                            <button class="queue-clear-btn" @onclick="() => ClearQueue(session.Name)">Clear</button>
-                        </div>
-                    }
-
-                    @if (intentBySession.TryGetValue(session.Name, out var intentG) && !string.IsNullOrEmpty(intentG))
-                    {
-                        <div class="intent-pill compact">💭 @intentG</div>
-                    }
-
-                    @if (pendingImagesBySession.TryGetValue(session.Name, out var cardPendingImgs) && cardPendingImgs.Any())
-                    {
-                        <div class="attachment-strip">
-                            @for (var cpi = 0; cpi < cardPendingImgs.Count; cpi++)
-                            {
-                                var cpidx = cpi;
-                                var cpimg = cardPendingImgs[cpi];
-                                <div class="attachment-thumb">
-                                    <img src="@cpimg.DataUri" alt="@cpimg.FileName" />
-                                    <button class="attachment-remove" @onclick="() => RemovePendingImage(session.Name, cpidx)" title="Remove">×</button>
-                                    <span class="attachment-name">@TruncateFileName(cpimg.FileName, 15)</span>
-                                </div>
-                            }
-                        </div>
-                    }
-
-                    <div class="card-input">
-                        <input type="text" id="input-@session.Name.Replace(" ", "-")"
-                               placeholder="@(session.IsProcessing ? "Queue a message…" : $"Send to {session.Name}...")" />
-                        @if (session.IsProcessing)
-                        {
-                            <button class="card-stop-btn" @onclick="() => StopSession(session.Name)" title="Stop">■</button>
-                        }
-                        <button @onclick="() => SendFromCard(session.Name)">➤</button>
-                    </div>
-                </div>
+                <input type="text" class="new-group-input" id="dashNewGroupInput"
+                       placeholder="Group name..."
+                       @onblur="CommitDashGroup"
+                       @onkeydown="HandleDashGroupKeyDown" />
+            }
+            else
+            {
+                <button class="grid-density-btn" @onclick="() => { isAddingDashGroup = true; }" title="New group">+ Group</button>
             }
         </div>
+        @foreach (var (group, groupSessions) in CopilotService.GetOrganizedSessions().ToList())
+        {
+            var showGroupHeaders = CopilotService.HasMultipleGroups;
+            @if (showGroupHeaders)
+            {
+                <div class="group-divider @(group.IsCollapsed ? "collapsed" : "")"
+                     @onclick="() => CopilotService.ToggleGroupCollapsed(group.Id)">
+                    <span class="group-divider-name">@group.Name</span>
+                    <span class="group-divider-count">@groupSessions.Count sessions</span>
+                    @if (group.IsCollapsed && groupSessions.Any(s => s.IsProcessing))
+                    {
+                        <span class="group-divider-busy">● working</span>
+                    }
+                    <span class="group-divider-chevron">@(group.IsCollapsed ? "▶" : "▼")</span>
+                </div>
+            }
+
+            @if (!group.IsCollapsed || !showGroupHeaders)
+            {
+                <div class="session-grid @(expandedGrid ? "expanded-grid" : "")">
+                @foreach (var session in groupSessions)
+                {
+                    var isCompleted = completedSessions.Contains(session.Name);
+                    var cardClass = session.IsProcessing ? "processing" : isCompleted ? "completed" : "idle";
+                    var meta = CopilotService.GetSessionMeta(session.Name);
+                    var isPinned = meta?.IsPinned ?? false;
+                    <div class="session-card @cardClass @(isPinned ? "pinned" : "")" data-session="@session.Name">
+                        <div class="card-header">
+                            <div class="card-title" @onclick="() => GoToSession(session.Name)" style="cursor:pointer">
+                                @if (isPinned)
+                                {
+                                    <span class="card-pin-indicator">📌</span>
+                                }
+                                <span class="card-status-dot @cardClass"></span>
+                                @if (cardRenamingSession == session.Name)
+                                {
+                                    <input type="text" class="card-rename-input" id="cardRenameInput"
+                                           value="@session.Name"
+                                           @onclick:stopPropagation="true"
+                                           @onblur="CommitCardRename"
+                                           @onkeydown="HandleCardRenameKeyDown" />
+                                }
+                                else
+                                {
+                                    <h3>@session.Name</h3>
+                                }
+                            </div>
+                            <button class="card-more-btn" @onclick="() => ToggleCardMenu(session.Name)" @onclick:stopPropagation="true" title="More actions">⋯</button>
+                            @if (cardMenuSession == session.Name)
+                            {
+                                <div class="card-menu" @onclick:stopPropagation="true">
+                                    <button class="card-menu-item" @onclick="() => { cardMenuSession = null; StartCardRename(session.Name); }">
+                                        ✏️ Rename
+                                    </button>
+                                    @if (isPinned)
+                                    {
+                                        <button class="card-menu-item" @onclick="() => { cardMenuSession = null; CopilotService.PinSession(session.Name, false); }">
+                                            📌 Unpin
+                                        </button>
+                                    }
+                                    else
+                                    {
+                                        <button class="card-menu-item" @onclick="() => { cardMenuSession = null; CopilotService.PinSession(session.Name, true); }">
+                                            📌 Pin
+                                        </button>
+                                    }
+                                    @if (CopilotService.Organization.Groups.Count > 1)
+                                    {
+                                        @foreach (var g in CopilotService.Organization.Groups.Where(g => g.Id != (meta?.GroupId ?? SessionGroup.DefaultId)))
+                                        {
+                                            var targetGroup = g;
+                                            <button class="card-menu-item" @onclick="() => { cardMenuSession = null; CopilotService.MoveSession(session.Name, targetGroup.Id); }">
+                                                📁 Move to @targetGroup.Name
+                                            </button>
+                                        }
+                                    }
+                                    <div class="card-menu-separator"></div>
+                                    <button class="card-menu-item destructive" @onclick="() => { cardMenuSession = null; CloseSession(session.Name); }">
+                                        🗑 Close Session
+                                    </button>
+                                </div>
+                            }
+                            @if (session.IsProcessing)
+                            {
+                                <button class="card-stop" @onclick="() => StopSession(session.Name)" title="Stop">■</button>
+                            }
+                            <button class="card-expand" @onclick="() => ExpandSession(session.Name)" title="Expand">⤢</button>
+                        </div>
+                        <div class="card-context">
+                            <span class="card-model">@GetSessionModel(session)</span>
+                            @if (!string.IsNullOrEmpty(session.WorkingDirectory))
+                            {
+                                <span class="card-dir" title="@session.WorkingDirectory">📁 @ShortenPath(session.WorkingDirectory)</span>
+                            }
+                            @if (!string.IsNullOrEmpty(session.GitBranch))
+                            {
+                                <span class="card-branch-sub"> @session.GitBranch</span>
+                            }
+                        </div>
+
+                        <div class="card-messages">
+                            @{
+                                var cardMsgs = GetCardMessages(session.Name, session.History);
+                                var hasMoreCard = session.History.Count > cardMsgs.Count;
+                            }
+                            @if (hasMoreCard)
+                            {
+                                <button class="load-more-btn" @onclick="() => LoadMoreCardMessages(session.Name)">▲ Load earlier messages (@(session.History.Count - cardMsgs.Count) more)</button>
+                            }
+                            <ChatMessageList Messages="cardMsgs"
+                                             StreamingContent="@(streamingBySession.TryGetValue(session.Name, out var s) ? s : "")"
+                                             CurrentToolName="@(currentToolBySession.TryGetValue(session.Name, out var t) ? t : "")"
+                                             ToolActivities="@(toolActivitiesBySession.TryGetValue(session.Name, out var ta) ? ta : new())"
+                                             ActivityText="@(activityBySession.TryGetValue(session.Name, out var a) ? a : "")"
+                                             IsProcessing="session.IsProcessing"
+                                             Compact="true" />
+                        </div>
+
+                        @if (errorBySession.TryGetValue(session.Name, out var errG))
+                        {
+                            <div class="card-error">
+                                <span>⚠️ @errG</span>
+                                <button @onclick="() => DismissError(session.Name)">✕</button>
+                            </div>
+                        }
+
+                        @if (session.MessageQueue.Any())
+                        {
+                            <div class="card-queue">
+                                <span class="queue-label">📋 Queued (@session.MessageQueue.Count)</span>
+                                <button class="queue-clear-btn" @onclick="() => ClearQueue(session.Name)">Clear</button>
+                            </div>
+                        }
+
+                        @if (intentBySession.TryGetValue(session.Name, out var intentG) && !string.IsNullOrEmpty(intentG))
+                        {
+                            <div class="intent-pill compact">💭 @intentG</div>
+                        }
+
+                        @if (pendingImagesBySession.TryGetValue(session.Name, out var cardPendingImgs) && cardPendingImgs.Any())
+                        {
+                            <div class="attachment-strip">
+                                @for (var cpi = 0; cpi < cardPendingImgs.Count; cpi++)
+                                {
+                                    var cpidx = cpi;
+                                    var cpimg = cardPendingImgs[cpi];
+                                    <div class="attachment-thumb">
+                                        <img src="@cpimg.DataUri" alt="@cpimg.FileName" />
+                                        <button class="attachment-remove" @onclick="() => RemovePendingImage(session.Name, cpidx)" title="Remove">×</button>
+                                        <span class="attachment-name">@TruncateFileName(cpimg.FileName, 15)</span>
+                                    </div>
+                                }
+                            </div>
+                        }
+
+                        <div class="card-input">
+                            <input type="text" id="input-@session.Name.Replace(" ", "-")"
+                                   placeholder="@(session.IsProcessing ? "Queue a message…" : $"Send to {session.Name}...")" />
+                            @if (session.IsProcessing)
+                            {
+                                <button class="card-stop-btn" @onclick="() => StopSession(session.Name)" title="Stop">■</button>
+                            }
+                            <button @onclick="() => SendFromCard(session.Name)">➤</button>
+                        </div>
+                    </div>
+                }
+                </div>
+            }
+        }
     }
 </div>
 
@@ -321,6 +418,10 @@
     private int fontSize = 20;
     private string? expandedSession;
     private bool _needsScrollToBottom;
+    private bool expandedGrid;
+    private string? cardMenuSession;
+    private string? cardRenamingSession;
+    private bool isAddingDashGroup;
     private string? _focusedInputId;
     private string? _lastActiveSession;
     private int _cursorStart;
@@ -847,6 +948,76 @@
         _lastActiveSession = null;
         _explicitlyCollapsed = true;
         CopilotService.SetActiveSession(null);
+    }
+
+    private void ToggleGridDensity()
+    {
+        expandedGrid = !expandedGrid;
+    }
+
+    private void ToggleCardMenu(string sessionName)
+    {
+        cardMenuSession = cardMenuSession == sessionName ? null : sessionName;
+    }
+
+    private void StartCardRename(string sessionName)
+    {
+        cardRenamingSession = sessionName;
+        _ = FocusCardRenameInput();
+    }
+
+    private async Task FocusCardRenameInput()
+    {
+        await Task.Yield();
+        StateHasChanged();
+        await Task.Yield();
+        await JS.InvokeVoidAsync("eval", @"
+            var el = document.getElementById('cardRenameInput');
+            if (el) { el.focus(); el.select(); }
+        ");
+    }
+
+    private async Task CommitCardRename()
+    {
+        if (cardRenamingSession == null) return;
+        var oldName = cardRenamingSession;
+        cardRenamingSession = null;
+
+        var newName = await JS.InvokeAsync<string>("eval", "document.getElementById('cardRenameInput')?.value || ''");
+        if (!string.IsNullOrWhiteSpace(newName) && newName.Trim() != oldName)
+        {
+            CopilotService.RenameSession(oldName, newName.Trim());
+        }
+    }
+
+    private async Task HandleCardRenameKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter") await CommitCardRename();
+        else if (e.Key == "Escape") cardRenamingSession = null;
+    }
+
+    private void OnSortModeChanged(ChangeEventArgs e)
+    {
+        if (e.Value is string val && Enum.TryParse<SessionSortMode>(val, out var mode))
+        {
+            CopilotService.SetSortMode(mode);
+        }
+    }
+
+    private async Task CommitDashGroup()
+    {
+        var name = await JS.InvokeAsync<string>("eval", "document.getElementById('dashNewGroupInput')?.value ?? ''");
+        isAddingDashGroup = false;
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            CopilotService.CreateGroup(name.Trim());
+        }
+    }
+
+    private async Task HandleDashGroupKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter") await CommitDashGroup();
+        else if (e.Key == "Escape") isAddingDashGroup = false;
     }
 
     private async Task SaveDraftsAndCursor()

--- a/AutoPilot.App/Components/Pages/Dashboard.razor.css
+++ b/AutoPilot.App/Components/Pages/Dashboard.razor.css
@@ -147,6 +147,183 @@
     margin-bottom: 1.5rem;
 }
 
+.session-grid.expanded-grid {
+    grid-template-columns: repeat(auto-fill, minmax(min(600px, 100%), 1fr));
+}
+
+.grid-density-btn {
+    margin-left: auto;
+    padding: 0.25rem 0.6rem;
+    background: rgba(78,168,209,0.1);
+    border: 1px solid rgba(78,168,209,0.2);
+    border-radius: 6px;
+    color: rgba(78,168,209,0.7);
+    font-size: var(--type-callout);
+    cursor: pointer;
+    transition: all 0.15s ease;
+    white-space: nowrap;
+}
+
+.grid-density-btn:hover {
+    background: rgba(78,168,209,0.2);
+    color: #4ea8d1;
+    border-color: rgba(78,168,209,0.4);
+}
+
+.dashboard-header .font-size-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+}
+
+.dashboard-header .font-size-btn {
+    font-size: var(--type-caption1);
+    padding: 0.15rem 0.4rem;
+}
+
+.dashboard-header .font-size-label {
+    font-size: var(--type-caption1);
+}
+
+/* Sort select in dashboard header */
+.dashboard-header .sort-select {
+    all: unset;
+    font-size: var(--type-caption1);
+    color: rgba(78,168,209,0.6);
+    cursor: pointer;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    background: rgba(78,168,209,0.08);
+    border: 1px solid rgba(78,168,209,0.15);
+}
+.dashboard-header .sort-select:hover { color: #4ea8d1; background: rgba(78,168,209,0.15); }
+.dashboard-header .sort-select option { background: #1a1e3a; color: #a0b4cc; }
+
+.dashboard-header .new-group-input {
+    font-size: var(--type-caption1);
+    color: #a0b4cc;
+    background: rgba(78,168,209,0.15);
+    border: 1px solid rgba(78,168,209,0.3);
+    border-radius: 6px;
+    padding: 0.2rem 0.5rem;
+    width: 120px;
+    outline: none;
+}
+
+/* Group dividers in dashboard */
+.group-divider {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.25rem;
+    margin: 0.5rem 0 0.25rem;
+    cursor: pointer;
+    user-select: none;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+.group-divider:first-child { margin-top: 0; }
+.group-divider:hover { border-bottom-color: rgba(78,168,209,0.2); }
+
+.group-divider-name {
+    font-size: var(--type-callout);
+    font-weight: 600;
+    color: rgba(255,255,255,0.5);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.group-divider-count {
+    font-size: var(--type-caption1);
+    color: rgba(255,255,255,0.25);
+}
+
+.group-divider-busy {
+    font-size: var(--type-caption1);
+    color: rgba(251,191,36,0.7);
+    animation: pulse-glow 1.5s ease-in-out infinite;
+}
+
+.group-divider-chevron {
+    margin-left: auto;
+    font-size: var(--type-caption1);
+    color: rgba(255,255,255,0.25);
+}
+
+/* Pinned card styles */
+.session-card.pinned {
+    border-color: rgba(251,191,36,0.25);
+}
+
+.card-pin-indicator {
+    font-size: 0.7rem;
+    flex-shrink: 0;
+}
+
+/* ⋯ More menu for cards */
+.card-more-btn {
+    all: unset;
+    font-size: var(--type-title2);
+    color: rgba(255,255,255,0.25);
+    cursor: pointer;
+    padding: 0.1rem 0.35rem;
+    border-radius: 4px;
+    line-height: 1;
+    letter-spacing: 0.1em;
+    flex-shrink: 0;
+}
+.card-more-btn:hover { color: rgba(255,255,255,0.6); background: rgba(255,255,255,0.08); }
+
+.card-menu {
+    position: absolute;
+    right: 0.75rem;
+    top: 2.5rem;
+    z-index: 100;
+    min-width: 160px;
+    background: #1e2240;
+    border: 1px solid rgba(78,168,209,0.25);
+    border-radius: 8px;
+    padding: 0.25rem 0;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+    display: flex;
+    flex-direction: column;
+}
+
+.card-menu-item {
+    all: unset;
+    display: block;
+    width: 100%;
+    padding: 0.4rem 0.75rem;
+    font-size: var(--type-callout);
+    color: rgba(255,255,255,0.7);
+    cursor: pointer;
+    white-space: nowrap;
+    box-sizing: border-box;
+}
+.card-menu-item:hover { background: rgba(78,168,209,0.15); color: #fff; }
+
+.card-menu-separator {
+    height: 1px;
+    background: rgba(255,255,255,0.08);
+    margin: 0.2rem 0.5rem;
+}
+
+.card-menu-item.destructive { color: rgba(239,68,68,0.7); }
+.card-menu-item.destructive:hover { background: rgba(239,68,68,0.12); color: #ef4444; }
+
+.card-rename-input {
+    flex: 1;
+    min-width: 0;
+    padding: 0.2rem 0.4rem;
+    border: 1px solid rgba(78,168,209,0.4);
+    border-radius: 4px;
+    background: rgba(78,168,209,0.15);
+    color: #a0b4cc;
+    font-size: var(--type-title2);
+    font-weight: 600;
+    font-family: inherit;
+    outline: none;
+}
+
 .session-card {
     position: relative;
     background: rgba(255,255,255,0.05);

--- a/AutoPilot.App/Models/BridgeMessages.cs
+++ b/AutoPilot.App/Models/BridgeMessages.cs
@@ -54,6 +54,7 @@ public static class BridgeMessageTypes
     public const string SessionsList = "sessions_list";
     public const string SessionHistory = "session_history";
     public const string PersistedSessionsList = "persisted_sessions";
+    public const string OrganizationState = "organization_state";
     public const string ContentDelta = "content_delta";
     public const string ToolStarted = "tool_started";
     public const string ToolCompleted = "tool_completed";
@@ -76,6 +77,7 @@ public static class BridgeMessageTypes
     public const string SwitchSession = "switch_session";
     public const string QueueMessage = "queue_message";
     public const string CloseSession = "close_session";
+    public const string OrganizationCommand = "organization_command";
 }
 
 // --- Server → Client payloads ---
@@ -214,4 +216,15 @@ public class ResumeSessionPayload
 {
     public string SessionId { get; set; } = "";
     public string? DisplayName { get; set; }
+}
+
+// --- Organization bridge payloads ---
+
+public class OrganizationCommandPayload
+{
+    public string Command { get; set; } = "";  // "pin", "unpin", "move", "create_group", "rename_group", "delete_group", "toggle_collapsed", "set_sort"
+    public string? SessionName { get; set; }
+    public string? GroupId { get; set; }
+    public string? Name { get; set; }
+    public string? SortMode { get; set; }
 }

--- a/AutoPilot.App/Models/SessionOrganization.cs
+++ b/AutoPilot.App/Models/SessionOrganization.cs
@@ -1,0 +1,41 @@
+using System.Text.Json.Serialization;
+
+namespace AutoPilot.App.Models;
+
+public class SessionGroup
+{
+    public const string DefaultId = "_default";
+    public const string DefaultName = "Sessions";
+
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Name { get; set; } = "";
+    public int SortOrder { get; set; }
+    public bool IsCollapsed { get; set; }
+}
+
+public class SessionMeta
+{
+    public string SessionName { get; set; } = "";
+    public string GroupId { get; set; } = SessionGroup.DefaultId;
+    public bool IsPinned { get; set; }
+    public int ManualOrder { get; set; }
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum SessionSortMode
+{
+    LastActive,
+    CreatedAt,
+    Alphabetical,
+    Manual
+}
+
+public class OrganizationState
+{
+    public List<SessionGroup> Groups { get; set; } = new()
+    {
+        new SessionGroup { Id = SessionGroup.DefaultId, Name = SessionGroup.DefaultName, SortOrder = 0 }
+    };
+    public List<SessionMeta> Sessions { get; set; } = new();
+    public SessionSortMode SortMode { get; set; } = SessionSortMode.LastActive;
+}

--- a/AutoPilot.App/Services/CopilotService.cs
+++ b/AutoPilot.App/Services/CopilotService.cs
@@ -58,6 +58,9 @@ public class CopilotService : IAsyncDisposable
     private static string? _uiStateFile;
     private static string UiStateFile => _uiStateFile ??= Path.Combine(CopilotBaseDir, "autopilot-ui-state.json");
 
+    private static string? _organizationFile;
+    private static string OrganizationFile => _organizationFile ??= Path.Combine(CopilotBaseDir, "autopilot-organization.json");
+
     private static string? _projectDir;
     private static string ProjectDir => _projectDir ??= FindProjectDir();
 
@@ -104,6 +107,9 @@ public class CopilotService : IAsyncDisposable
 
     // Debug info
     public string LastDebugMessage { get; private set; } = "";
+
+    // Session organization (groups, pinning, sorting)
+    public OrganizationState Organization { get; private set; } = new();
 
     public event Action? OnStateChanged;
     public event Action<string, string>? OnContentReceived; // sessionName, content
@@ -234,6 +240,9 @@ public class CopilotService : IAsyncDisposable
 
         // Restore previous sessions (includes subscribing to untracked server sessions in Persistent mode)
         await RestorePreviousSessionsAsync(cancellationToken);
+
+        // Load organization state (groups, pinning, sorting) — reconciles with active sessions
+        LoadOrganization();
     }
 
     /// <summary>
@@ -979,6 +988,7 @@ public class CopilotService : IAsyncDisposable
         _activeSessionName ??= displayName;
         OnStateChanged?.Invoke();
         SaveActiveSessionsToDisk();
+        ReconcileOrganization();
         return info;
     }
 
@@ -1081,6 +1091,7 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
 
         _activeSessionName ??= name;
         SaveActiveSessionsToDisk();
+        ReconcileOrganization();
         OnStateChanged?.Invoke();
         return info;
     }
@@ -1689,6 +1700,7 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
 
         OnStateChanged?.Invoke();
         SaveActiveSessionsToDisk();
+        ReconcileOrganization();
         return true;
     }
 
@@ -1705,6 +1717,239 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
     public IEnumerable<AgentSessionInfo> GetAllSessions() => _sessions.Values.Select(s => s.Info);
 
     public int SessionCount => _sessions.Count;
+
+    #region Session Organization (groups, pinning, sorting)
+
+    public void LoadOrganization()
+    {
+        try
+        {
+            if (File.Exists(OrganizationFile))
+            {
+                var json = File.ReadAllText(OrganizationFile);
+                Organization = JsonSerializer.Deserialize<OrganizationState>(json) ?? new OrganizationState();
+            }
+            else
+            {
+                Organization = new OrganizationState();
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug($"Failed to load organization: {ex.Message}");
+            Organization = new OrganizationState();
+        }
+
+        // Ensure default group always exists
+        if (!Organization.Groups.Any(g => g.Id == SessionGroup.DefaultId))
+        {
+            Organization.Groups.Insert(0, new SessionGroup
+            {
+                Id = SessionGroup.DefaultId,
+                Name = SessionGroup.DefaultName,
+                SortOrder = 0
+            });
+        }
+
+        ReconcileOrganization();
+    }
+
+    public void SaveOrganization()
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(Organization, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(OrganizationFile, json);
+        }
+        catch (Exception ex)
+        {
+            Debug($"Failed to save organization: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Ensure every active session has a SessionMeta entry and clean up orphans.
+    /// </summary>
+    private void ReconcileOrganization()
+    {
+        var activeNames = _sessions.Keys.ToHashSet();
+        bool changed = false;
+
+        // Add missing sessions to default group
+        foreach (var name in activeNames)
+        {
+            if (!Organization.Sessions.Any(m => m.SessionName == name))
+            {
+                Organization.Sessions.Add(new SessionMeta
+                {
+                    SessionName = name,
+                    GroupId = SessionGroup.DefaultId
+                });
+                changed = true;
+            }
+        }
+
+        // Fix sessions pointing to deleted groups
+        var groupIds = Organization.Groups.Select(g => g.Id).ToHashSet();
+        foreach (var meta in Organization.Sessions)
+        {
+            if (!groupIds.Contains(meta.GroupId))
+            {
+                meta.GroupId = SessionGroup.DefaultId;
+                changed = true;
+            }
+        }
+
+        // Remove metadata for sessions that no longer exist
+        int removed = Organization.Sessions.RemoveAll(m => !activeNames.Contains(m.SessionName));
+        if (removed > 0) changed = true;
+
+        if (changed) SaveOrganization();
+    }
+
+    public void PinSession(string sessionName, bool pinned)
+    {
+        var meta = Organization.Sessions.FirstOrDefault(m => m.SessionName == sessionName);
+        if (meta != null)
+        {
+            meta.IsPinned = pinned;
+            SaveOrganization();
+            OnStateChanged?.Invoke();
+        }
+    }
+
+    public void MoveSession(string sessionName, string groupId)
+    {
+        var meta = Organization.Sessions.FirstOrDefault(m => m.SessionName == sessionName);
+        if (meta != null && Organization.Groups.Any(g => g.Id == groupId))
+        {
+            meta.GroupId = groupId;
+            SaveOrganization();
+            OnStateChanged?.Invoke();
+        }
+    }
+
+    public SessionGroup CreateGroup(string name)
+    {
+        var group = new SessionGroup
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = name,
+            SortOrder = Organization.Groups.Max(g => g.SortOrder) + 1
+        };
+        Organization.Groups.Add(group);
+        SaveOrganization();
+        OnStateChanged?.Invoke();
+        return group;
+    }
+
+    public void RenameGroup(string groupId, string name)
+    {
+        var group = Organization.Groups.FirstOrDefault(g => g.Id == groupId);
+        if (group != null)
+        {
+            group.Name = name;
+            SaveOrganization();
+            OnStateChanged?.Invoke();
+        }
+    }
+
+    public void DeleteGroup(string groupId)
+    {
+        if (groupId == SessionGroup.DefaultId) return;
+
+        // Move all sessions in this group to default
+        foreach (var meta in Organization.Sessions.Where(m => m.GroupId == groupId))
+        {
+            meta.GroupId = SessionGroup.DefaultId;
+        }
+
+        Organization.Groups.RemoveAll(g => g.Id == groupId);
+        SaveOrganization();
+        OnStateChanged?.Invoke();
+    }
+
+    public void ToggleGroupCollapsed(string groupId)
+    {
+        var group = Organization.Groups.FirstOrDefault(g => g.Id == groupId);
+        if (group != null)
+        {
+            group.IsCollapsed = !group.IsCollapsed;
+            SaveOrganization();
+            OnStateChanged?.Invoke();
+        }
+    }
+
+    public void SetSortMode(SessionSortMode mode)
+    {
+        Organization.SortMode = mode;
+        SaveOrganization();
+        OnStateChanged?.Invoke();
+    }
+
+    public void SetSessionManualOrder(string sessionName, int order)
+    {
+        var meta = Organization.Sessions.FirstOrDefault(m => m.SessionName == sessionName);
+        if (meta != null)
+        {
+            meta.ManualOrder = order;
+            SaveOrganization();
+        }
+    }
+
+    public void SetGroupOrder(string groupId, int order)
+    {
+        var group = Organization.Groups.FirstOrDefault(g => g.Id == groupId);
+        if (group != null)
+        {
+            group.SortOrder = order;
+            SaveOrganization();
+            OnStateChanged?.Invoke();
+        }
+    }
+
+    /// <summary>
+    /// Returns sessions organized by group, with pinned sessions first and sorted by the current sort mode.
+    /// </summary>
+    public IEnumerable<(SessionGroup Group, List<AgentSessionInfo> Sessions)> GetOrganizedSessions()
+    {
+        var metas = Organization.Sessions.ToDictionary(m => m.SessionName);
+        var allSessions = GetAllSessions().ToList();
+
+        foreach (var group in Organization.Groups.OrderBy(g => g.SortOrder))
+        {
+            var groupSessions = allSessions
+                .Where(s => metas.TryGetValue(s.Name, out var m) && m.GroupId == group.Id)
+                .ToList();
+
+            // Pinned first, then apply sort mode within each partition
+            var sorted = groupSessions
+                .OrderByDescending(s => metas.TryGetValue(s.Name, out var m) && m.IsPinned)
+                .ThenBy(s => ApplySort(s, metas))
+                .ToList();
+
+            yield return (group, sorted);
+        }
+    }
+
+    private object ApplySort(AgentSessionInfo session, Dictionary<string, SessionMeta> metas)
+    {
+        return Organization.SortMode switch
+        {
+            SessionSortMode.LastActive => DateTime.MaxValue - session.LastUpdatedAt,
+            SessionSortMode.CreatedAt => DateTime.MaxValue - session.CreatedAt,
+            SessionSortMode.Alphabetical => session.Name,
+            SessionSortMode.Manual => (object)(metas.TryGetValue(session.Name, out var m) ? m.ManualOrder : int.MaxValue),
+            _ => DateTime.MaxValue - session.LastUpdatedAt
+        };
+    }
+
+    public bool HasMultipleGroups => Organization.Groups.Count > 1;
+
+    public SessionMeta? GetSessionMeta(string sessionName) =>
+        Organization.Sessions.FirstOrDefault(m => m.SessionName == sessionName);
+
+    #endregion
 
     /// <summary>
     /// Save active session list to disk so we can restore on relaunch

--- a/AutoPilot.slnx
+++ b/AutoPilot.slnx
@@ -1,0 +1,7 @@
+<Solution>
+  <Folder Name="/AutoPilot.Console/">
+    <Project Path="AutoPilot.Console/AutoPilot.csproj" />
+  </Folder>
+  <Project Path="AutoPilot.App.Tests/AutoPilot.App.Tests.csproj" />
+  <Project Path="AutoPilot.App/AutoPilot.App.csproj" />
+</Solution>


### PR DESCRIPTION
## Summary

Adds session organization features to both the sidebar and dashboard: **grouping**, **pinning**, **sorting**, and **collapsible groups**.

### Design: "Everything is always in a group"
- Every session belongs to a group. There's always a default group ("Sessions").
- If only the default group exists, group headers are hidden — looks exactly like before.
- Creating a second group reveals group headers everywhere.

### Features
- **Pinning** — pin sessions to top of their group via ⋯ menu
- **Grouping** — create/delete/rename groups, move sessions between groups
- **Sorting** — Last Active, Created, A–Z, Manual (global sort mode)
- **Collapse/expand** — per-group, persisted across restarts
- **Unified ⋯ menu** — rename, pin/unpin, move to group, close (with separator for destructive action)
- **Dashboard extras** — grid density toggle (compact/expanded), font size controls, sort dropdown, + Group button

### Architecture
- New `Models/SessionOrganization.cs` — `SessionGroup`, `SessionMeta`, `SessionSortMode`, `OrganizationState`
- `CopilotService` — full CRUD + `GetOrganizedSessions()` rendering helper with auto-reconciliation
- Persisted to `~/.copilot/autopilot-organization.json` (new file, purely additive)
- Bridge protocol — `organization_state`/`organization_command` message types for remote/mobile sync

### Upgrade Safety
- **Zero-risk upgrade** — no existing files modified. Old `autopilot-active-sessions.json` and `autopilot-ui-state.json` untouched.
- First launch after upgrade creates default state, auto-assigns all existing sessions to default group.
- Downgrade-safe: old versions ignore the new file.

### Other
- Convert `AutoPilot.sln` → `AutoPilot.slnx`
- 8 new tests (99 total, all passing)