### PR TITLE
Raise sidebar breakpoint from 641px to 1024px

### DIFF
--- a/AutoPilot.App/Components/Layout/MainLayout.razor.css
+++ b/AutoPilot.App/Components/Layout/MainLayout.razor.css
@@ -83,7 +83,7 @@ main {
 }
 
 /* Desktop: show sidebar, hide mobile elements */
-@media (min-width: 641px) {
+@media (min-width: 1024px) {
     .page {
         flex-direction: row;
     }

--- a/AutoPilot.App/Components/Layout/NavMenu.razor.css
+++ b/AutoPilot.App/Components/Layout/NavMenu.razor.css
@@ -89,7 +89,7 @@
     display: block;
 }
 
-@media (min-width: 641px) {
+@media (min-width: 1024px) {
     .navbar-toggler {
         display: none;
     }

--- a/AutoPilot.App/wwwroot/app.css
+++ b/AutoPilot.App/wwwroot/app.css
@@ -31,7 +31,7 @@
 }
 
 /* Mac Catalyst / desktop: bump scale to compensate for 77% Catalyst scaling */
-@media (min-width: 641px) {
+@media (min-width: 1024px) {
     :root {
         --type-body: 0.95rem;
         --type-headline: 0.95rem;
@@ -201,7 +201,7 @@ h1:focus {
     color: #48bb78;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 1023px) {
     .toast-notification {
         top: 10px;
         bottom: auto;


### PR DESCRIPTION
Sidebar collapses to flyout overlay below 1024px (was 641px), giving chat content full width at medium window sizes.

**Files changed:** MainLayout.razor.css, NavMenu.razor.css, app.css — only the sidebar show/hide breakpoint. Component-specific 640px breakpoints (content density) are unchanged.