### PR TITLE
Replace deprecated ApplicationIconBadgeNumber with UNUserNotification Center.SetBadgeCount

### DIFF
--- a/AutoPilot.App/Components/Layout/SessionSidebar.razor
+++ b/AutoPilot.App/Components/Layout/SessionSidebar.razor
@@ -198,7 +198,7 @@ else
                     {
                         var isOpen = IsSessionOpen(persisted.SessionId);
                         <div class="session-item persisted @(isOpen ? "already-open" : "") @(confirmResumeId == persisted.SessionId ? "confirm-active" : "")" 
-                             @onclick="() => { if (isOpen) SwitchToOpenSession(persisted.SessionId); else ConfirmResume(persisted); }"
+                             @onclick="async () => { if (isOpen) await SwitchToOpenSession(persisted.SessionId); else ConfirmResume(persisted); }"
                              title="@(isOpen ? "Click to switch to this session" : GetTooltip(persisted))">
                             <div class="session-info">
                                 <span class="session-name persisted-name">@(persisted.Title ?? "Untitled")</span>
@@ -243,7 +243,6 @@ else
     };
 
     private string selectedModel = "claude-opus-4.6";
-    private string _lastSavedModel = "";
     private string sessionFilter = "";
     private bool isCreating = false;
     private string newSessionName = "";

--- a/AutoPilot.App/Components/Pages/Dashboard.razor
+++ b/AutoPilot.App/Components/Pages/Dashboard.razor
@@ -231,7 +231,6 @@
                 await Task.Delay(2000);
             }
             sessions = CopilotService.GetAllSessions().ToList();
-            _sessionsLoaded = true;
 
             if (CopilotService.NeedsConfiguration)
             {
@@ -476,7 +475,6 @@
     }
 
     private bool _explicitlyCollapsed;
-    private bool _sessionsLoaded;
     private bool _initialGridSet;
     private bool _refreshing;
 
@@ -487,7 +485,6 @@
         try
         {
             sessions = CopilotService.GetAllSessions().ToList();
-            _sessionsLoaded = true;
 
             // On first load with multiple sessions, default to grid view
             if (!_initialGridSet && sessions.Count > 1)

--- a/AutoPilot.App/Components/SessionCard.razor
+++ b/AutoPilot.App/Components/SessionCard.razor
@@ -54,7 +54,7 @@
                     }
                 }
                 <div class="card-menu-separator"></div>
-                <button class="card-menu-item destructive" @onclick="() => { OnCloseMenu.InvokeAsync(); CopilotService.CloseSessionAsync(Session.Name); }">
+                <button class="card-menu-item destructive" @onclick="async () => { await OnCloseMenu.InvokeAsync(); _ = CopilotService.CloseSessionAsync(Session.Name); }">
                     🗑 Close Session
                 </button>
             </div>

--- a/AutoPilot.App/MauiProgram.cs
+++ b/AutoPilot.App/MauiProgram.cs
@@ -79,7 +79,8 @@ public static class MauiProgram
 				ios.OnActivated(app =>
 				{
 					// Clear dock badge when app becomes active
-					app.ApplicationIconBadgeNumber = 0;
+					if (OperatingSystem.IsIOSVersionAtLeast(16) || OperatingSystem.IsMacCatalystVersionAtLeast(16))
+						try { UserNotifications.UNUserNotificationCenter.Current.SetBadgeCount(0, null); } catch { }
 				});
 			});
 		});

--- a/AutoPilot.App/Services/CopilotService.Events.cs
+++ b/AutoPilot.App/Services/CopilotService.Events.cs
@@ -87,7 +87,7 @@ public partial class CopilotService
                 if (toolDone.Data == null) break;
                 var completeCallId = toolDone.Data.ToolCallId ?? "";
                 var completeToolName = toolDone.Data?.GetType().GetProperty("ToolName")?.GetValue(toolDone.Data)?.ToString();
-                var resultStr = FormatToolResult(toolDone.Data.Result);
+                var resultStr = FormatToolResult(toolDone.Data!.Result);
                 var hasError = toolDone.Data.Error != null;
 
                 // Skip filtered tools

--- a/AutoPilot.App/Services/CopilotService.Utilities.cs
+++ b/AutoPilot.App/Services/CopilotService.Utilities.cs
@@ -273,7 +273,11 @@ public partial class CopilotService
         _badgeCount++;
         MainThread.BeginInvokeOnMainThread(() =>
         {
-            try { UIKit.UIApplication.SharedApplication.ApplicationIconBadgeNumber = _badgeCount; }
+            try
+            {
+                if (OperatingSystem.IsIOSVersionAtLeast(16) || OperatingSystem.IsMacCatalystVersionAtLeast(16))
+                    UserNotifications.UNUserNotificationCenter.Current.SetBadgeCount(_badgeCount, null);
+            }
             catch { }
         });
 #endif
@@ -285,7 +289,11 @@ public partial class CopilotService
         _badgeCount = 0;
         MainThread.BeginInvokeOnMainThread(() =>
         {
-            try { UIKit.UIApplication.SharedApplication.ApplicationIconBadgeNumber = 0; }
+            try
+            {
+                if (OperatingSystem.IsIOSVersionAtLeast(16) || OperatingSystem.IsMacCatalystVersionAtLeast(16))
+                    UserNotifications.UNUserNotificationCenter.Current.SetBadgeCount(0, null);
+            }
             catch { }
         });
 #endif


### PR DESCRIPTION
UIApplication.ApplicationIconBadgeNumber was deprecated in macCatalyst/iOS 17. Migrate all three call sites to the modern UNUserNotificationCenter.Current .SetBadgeCount API:

- MauiProgram.cs: OnActivated handler that clears the dock badge
- CopilotService.Utilities.cs: IncrementBadge() and ClearBadge() methods

Each call is guarded with OperatingSystem.IsIOSVersionAtLeast(16) || IsMacCatalystVersionAtLeast(16) to satisfy the static analyzer, since the project's SupportedOSPlatformVersion is set to 15.0. In practice .NET 10 MAUI requires 16+ at runtime, so no fallback is needed.

Also removes the unused _sessionsLoaded field from Dashboard.razor (CS0414 warning).