### PR TITLE
Add drag-to-resize handle on desktop sidebar

### DIFF
--- a/AutoPilot.App/Components/Layout/MainLayout.razor
+++ b/AutoPilot.App/Components/Layout/MainLayout.razor
@@ -3,6 +3,7 @@
 <div class="page @(flyoutOpen ? "flyout-open" : "")">
     <div class="sidebar desktop-only">
         <SessionSidebar />
+        <div class="sidebar-resize-handle" @onmousedown="StartResize"></div>
     </div>
 
     <div class="mobile-top-bar mobile-only">
@@ -23,6 +24,34 @@
 
 @code {
     private bool flyoutOpen;
+
+    [Inject] private IJSRuntime JS { get; set; } = default!;
+
+    private async Task StartResize(MouseEventArgs e)
+    {
+        await JS.InvokeVoidAsync("eval", $@"
+            (function() {{
+                var sidebar = document.querySelector('.sidebar.desktop-only');
+                if (!sidebar) return;
+                var startX = {e.ClientX};
+                var startW = sidebar.offsetWidth;
+                function onMove(e) {{
+                    var w = Math.min(Math.max(startW + e.clientX - startX, 200), 600);
+                    sidebar.style.width = w + 'px';
+                }}
+                function onUp() {{
+                    document.removeEventListener('mousemove', onMove);
+                    document.removeEventListener('mouseup', onUp);
+                    document.body.style.userSelect = '';
+                    document.body.style.cursor = '';
+                }}
+                document.body.style.userSelect = 'none';
+                document.body.style.cursor = 'col-resize';
+                document.addEventListener('mousemove', onMove);
+                document.addEventListener('mouseup', onUp);
+            }})();
+        ");
+    }
 
     private void ToggleFlyout()
     {

--- a/AutoPilot.App/Components/Layout/MainLayout.razor.css
+++ b/AutoPilot.App/Components/Layout/MainLayout.razor.css
@@ -21,6 +21,7 @@ main {
 
 .sidebar {
     background: #1a1a2e;
+    position: relative;
 }
 
 /* Mobile: hide desktop sidebar, show top bar + flyout */
@@ -99,11 +100,28 @@ main {
     .sidebar {
         width: 17.5rem;
         min-width: 200px;
-        max-width: 360px;
+        max-width: 600px;
         height: 100vh;
         position: sticky;
         top: 0;
         flex-shrink: 0;
         overflow: hidden;
+    }
+
+    .sidebar-resize-handle {
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: 5px;
+        height: 100%;
+        cursor: col-resize;
+        z-index: 10;
+        background: transparent;
+        transition: background 0.15s;
+    }
+
+    .sidebar-resize-handle:hover,
+    .sidebar-resize-handle:active {
+        background: rgba(100, 140, 255, 0.4);
     }
 }


### PR DESCRIPTION
The sidebar had a fixed width of 17.5rem (280px) which caused the model dropdown and other content to be clipped. Add a draggable resize handle on the sidebar's right edge that allows users to adjust the width between 200px and 600px.

Implementation:
- MainLayout.razor: Add a resize handle div inside the sidebar container and a StartResize handler that injects mousemove/mouseup JS listeners. The initial mouse X position is passed from C# MouseEventArgs into the JS closure to avoid relying on the global 'event' object which is not available in Blazor's JS interop eval context.
- MainLayout.razor.css: Add position:relative to the sidebar container, increase max-width from 360px to 600px, and style the resize handle as a 5px-wide invisible strip that highlights blue on hover/active with a col-resize cursor.

The resize handle is desktop-only (inside .sidebar.desktop-only) and does not affect the mobile flyout panel.