### PR TITLE
Fix duplicate tool items, expand tool input on click, sidebar navigation

### DIFF
--- a/AutoPilot.App/Components/ChatMessageItem.razor
+++ b/AutoPilot.App/Components/ChatMessageItem.razor
@@ -108,19 +108,28 @@
                     }
                 }
             </div>
-            @if (!Message.IsCollapsed && Message.IsComplete && !string.IsNullOrEmpty(Message.Content) && !ChatMessageList.IsUnusableResult(Message.Content))
+            @if (!Message.IsCollapsed)
             {
-                @if (ChatMessageList.GetImagePath(Message.Content) is string imgPath2 && ChatMessageList.FileToDataUri(imgPath2) is string dataUri2)
+                @if (!string.IsNullOrEmpty(Message.ToolInput))
                 {
-                    <div class="action-expanded-result">
-                        <img src="@dataUri2" alt="@System.IO.Path.GetFileName(imgPath2)" />
+                    <div class="action-expanded-input">
+                        <pre>@ChatMessageList.FormatToolInputExpanded(Message.ToolName ?? "", Message.ToolInput)</pre>
                     </div>
                 }
-                else
+                @if (Message.IsComplete && !string.IsNullOrEmpty(Message.Content) && !ChatMessageList.IsUnusableResult(Message.Content))
                 {
-                    <div class="action-expanded-result">
-                        <pre>@ChatMessageList.TruncateResult(Message.Content)</pre>
-                    </div>
+                    @if (ChatMessageList.GetImagePath(Message.Content) is string imgPath2 && ChatMessageList.FileToDataUri(imgPath2) is string dataUri2)
+                    {
+                        <div class="action-expanded-result">
+                            <img src="@dataUri2" alt="@System.IO.Path.GetFileName(imgPath2)" />
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="action-expanded-result">
+                            <pre>@ChatMessageList.TruncateResult(Message.Content)</pre>
+                        </div>
+                    }
                 }
             }
         }

--- a/AutoPilot.App/Components/ChatMessageList.razor
+++ b/AutoPilot.App/Components/ChatMessageList.razor
@@ -15,12 +15,12 @@
             <ChatMessageItem Message="msg" Compact="Compact" />
         }
 
-        @* Current turn tool activity feed *@
-        @if (ToolActivities.Any())
+        @* Current turn tool activity feed — skip activities already in history *@
+        @if (GetNewActivities().Any())
         {
             @if (Compact)
             {
-                @foreach (var activity in ToolActivities.TakeLast(3))
+                @foreach (var activity in GetNewActivities().TakeLast(3))
                 {
                     <div class="chat-msg tool">
                         <span class="chat-msg-role">🔧</span>
@@ -30,7 +30,7 @@
             }
             else
             {
-                @foreach (var activity in ToolActivities)
+                @foreach (var activity in GetNewActivities())
                 {
                     <div class="action-item @(GetActionLabel(activity.Name).CssClass) @(activity.IsComplete ? (activity.IsSuccess ? "done" : "failed") : "running")">
                         <span class="action-dot"></span>
@@ -106,6 +106,12 @@
     [Parameter] public string ActivityText { get; set; } = "";
     [Parameter] public bool IsProcessing { get; set; }
     [Parameter] public bool Compact { get; set; }
+
+    private IEnumerable<ToolActivity> GetNewActivities()
+    {
+        var historyCallIds = Messages.Where(m => m.ToolCallId != null).Select(m => m.ToolCallId).ToHashSet();
+        return ToolActivities.Where(a => !historyCallIds.Contains(a.CallId));
+    }
 
     private static readonly MarkdownPipeline MdPipeline = new MarkdownPipelineBuilder()
         .UseAdvancedExtensions().Build();
@@ -405,6 +411,33 @@
             var s = val.GetString();
             return string.IsNullOrEmpty(s) ? null : Truncate(s, 120);
         }
+        return null;
+    }
+
+    internal static string FormatToolInputExpanded(string toolName, string input)
+    {
+        if (string.IsNullOrEmpty(input)) return "";
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(input);
+            var root = doc.RootElement;
+            return toolName switch
+            {
+                "bash" => $"$ {ExtractJsonPropFull(root, "command") ?? input}",
+                "edit" or "create" => ExtractJsonPropFull(root, "path") ?? input,
+                "view" => ExtractJsonPropFull(root, "path") ?? input,
+                "grep" => $"grep '{ExtractJsonPropFull(root, "pattern")}' {ExtractJsonPropFull(root, "glob") ?? ExtractJsonPropFull(root, "path") ?? "."}",
+                "sql" => ExtractJsonPropFull(root, "query") ?? input,
+                _ => input.Length > 2000 ? input[..2000] + "…" : input
+            };
+        }
+        catch { return input.Length > 2000 ? input[..2000] + "…" : input; }
+    }
+
+    private static string? ExtractJsonPropFull(System.Text.Json.JsonElement root, string prop)
+    {
+        if (root.TryGetProperty(prop, out var val) && val.ValueKind == System.Text.Json.JsonValueKind.String)
+            return val.GetString();
         return null;
     }
 

--- a/AutoPilot.App/Components/ChatMessageList.razor.css
+++ b/AutoPilot.App/Components/ChatMessageList.razor.css
@@ -339,6 +339,30 @@
     flex-shrink: 0;
 }
 
+::deep .action-expanded-input {
+    margin: 0.15rem 1rem 0 2rem;
+    padding: 0.4rem 0.6rem;
+    background: rgba(15,15,35,0.35);
+    border-radius: 6px 6px 0 0;
+    border: 1px solid rgba(78,168,209,0.08);
+    border-bottom: none;
+}
+
+::deep .action-expanded-input pre {
+    font-size: var(--type-subhead);
+    color: rgba(200,216,240,0.7);
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 150px;
+    overflow-y: auto;
+    margin: 0;
+}
+
+::deep .action-expanded-input + .action-expanded-result {
+    margin-top: 0;
+    border-radius: 0 0 6px 6px;
+}
+
 ::deep .action-expanded-result {
     margin: 0.15rem 1rem 0.3rem 2rem;
     padding: 0.4rem 0.6rem;

--- a/AutoPilot.App/Components/Pages/Dashboard.razor
+++ b/AutoPilot.App/Components/Pages/Dashboard.razor
@@ -504,22 +504,15 @@
                 expandedSession = sessions[0].Name;
                 CopilotService.SwitchSession(sessions[0].Name);
             }
-            // Detect sidebar-initiated session switch (only expand if already in expanded mode)
+            // Detect sidebar-initiated session switch — expand to chat view
             var active = CopilotService.ActiveSessionName;
             if (active != null && active != _lastActiveSession && sessions.Any(s => s.Name == active))
             {
                 _lastActiveSession = active;
-                if (expandedSession != null)
-                {
-                    expandedSession = active;
-                    _focusedInputId = $"input-{active.Replace(" ", "-")}";
-                }
+                expandedSession = active;
+                _focusedInputId = $"input-{active.Replace(" ", "-")}";
             }
             // Clear sidebar highlight when showing grid view
-            if (expandedSession == null && sessions.Count > 1 && CopilotService.ActiveSessionName != null)
-            {
-                CopilotService.SetActiveSession(null);
-            }
             // Clear stale streaming content for sessions that finished
             foreach (var s in sessions)
             {
@@ -563,6 +556,13 @@
         currentToolBySession[sessionName] = toolName;
         if (!toolActivitiesBySession.ContainsKey(sessionName))
             toolActivitiesBySession[sessionName] = new();
+        // Deduplicate: update existing activity if replayed
+        var existing = toolActivitiesBySession[sessionName].FirstOrDefault(a => a.CallId == callId);
+        if (existing != null)
+        {
+            if (!string.IsNullOrEmpty(inputSummary)) existing.Input = inputSummary;
+            return;
+        }
         toolActivitiesBySession[sessionName].Add(new ToolActivity
         {
             Name = toolName,

--- a/AutoPilot.App/Services/CopilotService.Events.cs
+++ b/AutoPilot.App/Services/CopilotService.Events.cs
@@ -64,6 +64,15 @@ public partial class CopilotService
                 var toolInput = ExtractToolInput(toolStart.Data);
                 if (!FilteredTools.Contains(startToolName))
                 {
+                    // Deduplicate: SDK replays events on resume/reconnect — update existing
+                    var existingTool = state.Info.History.FirstOrDefault(m => m.ToolCallId == startCallId);
+                    if (existingTool != null)
+                    {
+                        // Update with potentially fresher data
+                        if (!string.IsNullOrEmpty(toolInput)) existingTool.ToolInput = toolInput;
+                        break;
+                    }
+
                     // Flush any accumulated assistant text before adding tool message
                     FlushCurrentResponse(state);
                     


### PR DESCRIPTION
## Changes

### Fix duplicate tool call items in chat
- **Root cause**: Two rendering paths showed the same tool call — one from `ChatMessage` history, one from the live `ToolActivity` feed
- **Fix**: `ChatMessageList` now filters `ToolActivities` to skip items whose `callId` already exists in the message history
- Also added update-instead-of-skip dedup in both `CopilotService.Events.cs` and `Dashboard.razor` for replayed SDK events

### Expand tool input on click
- Clicking a tool action now shows the **full command/input** (e.g. the complete bash command) in addition to the result
- New `FormatToolInputExpanded` helper shows untruncated commands
- Styled with `.action-expanded-input` CSS that flows visually into the result

### Sidebar navigation
- Clicking a session in the sidebar now always expands to chat view (removed `expandedSession != null` guard)
- Removed stale active-session clearing that fought with sidebar selection