### PR TITLE
Update bridge helpers and JS DOM utilities

### DIFF
--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -480,7 +480,7 @@ else
         var oldName = renamingSession;
         renamingSession = null;
 
-        var newName = await JS.InvokeAsync<string>("eval", "document.getElementById('renameInput')?.value || ''");
+        var newName = await JS.InvokeAsync<string>("getElementValue", "renameInput");
         if (!string.IsNullOrWhiteSpace(newName) && newName.Trim() != oldName)
         {
             CopilotService.RenameSession(oldName, newName.Trim());
@@ -551,7 +551,7 @@ else
 
     private async Task CommitNewGroup()
     {
-        var name = await JS.InvokeAsync<string>("eval", "document.getElementById('newGroupInput')?.value ?? ''");
+        var name = await JS.InvokeAsync<string>("getElementValue", "newGroupInput");
         isAddingGroup = false;
         if (!string.IsNullOrWhiteSpace(name))
         {

--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -368,36 +368,10 @@
         var selEnd = _cursorEnd;
         _focusedInputId = null;
 
-        var forceScroll = _needsScrollToBottom ? "true" : "false";
+        var forceScroll = _needsScrollToBottom;
         _needsScrollToBottom = false;
 
-        await JS.InvokeVoidAsync("eval", $@"
-            (function() {{
-                function doScroll() {{
-                    document.querySelectorAll('.card-messages, .messages').forEach(function(el) {{
-                        if (!el.__scrollInit) {{
-                            el.__scrollInit = true;
-                            el.scrollTop = el.scrollHeight;
-                            return;
-                        }}
-                        var atBottom = {forceScroll} || (el.scrollHeight - el.scrollTop - el.clientHeight) < 120;
-                        if (atBottom) el.scrollTop = el.scrollHeight;
-                    }});
-                }}
-                doScroll();
-                if ({forceScroll}) setTimeout(doScroll, 50);
-                var drafts = {draftsJson};
-                for (var id in drafts) {{
-                    var el = document.getElementById(id);
-                    if (el) el.value = drafts[id];
-                }}
-                var focusId = '{focusId}';
-                if (focusId) {{
-                    var fel = document.getElementById(focusId);
-                    if (fel) {{ fel.focus(); fel.setSelectionRange({selStart}, {selEnd}); }}
-                }}
-            }})();
-        ");
+        await JS.InvokeVoidAsync("restoreDraftsAndFocus", draftsJson, focusId, selStart, selEnd, forceScroll);
 
         // Auto-load more messages when scrolled to top (IntersectionObserver on load-more buttons)
         await JS.InvokeVoidAsync("eval", @"
@@ -643,12 +617,12 @@
     private async Task SendFromCard(string sessionName, string? explicitText = null)
     {
         var inputId = $"input-{sessionName.Replace(" ", "-")}";
-        var prompt = explicitText ?? await JS.InvokeAsync<string>("eval", $"document.getElementById('{inputId}')?.value || ''");
+        var prompt = explicitText ?? await JS.InvokeAsync<string>("getElementValue", inputId);
         var hasImages = pendingImagesBySession.TryGetValue(sessionName, out var pendingSendImages) && pendingSendImages.Count > 0;
         if (string.IsNullOrWhiteSpace(prompt) && !hasImages) return;
 
         if (explicitText == null) // Only clear if we read from DOM, otherwise child component cleared it
-            await JS.InvokeVoidAsync("eval", $"var el = document.getElementById('{inputId}'); el.value = ''; el.style.height = 'auto';");
+            await JS.InvokeVoidAsync("clearElementValue", inputId);
         draftBySession.Remove(sessionName);
 
         var finalPrompt = (prompt ?? "").Trim();
@@ -699,7 +673,7 @@
     private async Task TriggerAttach(string sessionName)
     {
         var fileId = $"file-{sessionName.Replace(" ", "-")}";
-        await JS.InvokeVoidAsync("eval", $"document.getElementById('{fileId}')?.click()");
+        await JS.InvokeVoidAsync("clickElement", fileId);
     }
 
     private async Task ExpandSession(string sessionName)
@@ -753,7 +727,7 @@
         var oldName = cardRenamingSession;
         cardRenamingSession = null;
 
-        var newName = await JS.InvokeAsync<string>("eval", "document.getElementById('cardRenameInput')?.value || ''");
+        var newName = await JS.InvokeAsync<string>("getElementValue", "cardRenameInput");
         if (!string.IsNullOrWhiteSpace(newName) && newName.Trim() != oldName)
         {
             CopilotService.RenameSession(oldName, newName.Trim());
@@ -776,7 +750,7 @@
 
     private async Task CommitDashGroup()
     {
-        var name = await JS.InvokeAsync<string>("eval", "document.getElementById('dashNewGroupInput')?.value ?? ''");
+        var name = await JS.InvokeAsync<string>("getElementValue", "dashNewGroupInput");
         isAddingDashGroup = false;
         if (!string.IsNullOrWhiteSpace(name))
         {

--- a/PolyPilot/Components/SessionCard.razor
+++ b/PolyPilot/Components/SessionCard.razor
@@ -195,8 +195,7 @@
 
     private async Task CommitRename()
     {
-        // Get value from input
-        var val = await JS.InvokeAsync<string>("eval", $"document.getElementById('cardRenameInput')?.value");
+        var val = await JS.InvokeAsync<string>("getElementValue", "cardRenameInput");
         if (!string.IsNullOrWhiteSpace(val))
         {
             await OnCommitRename.InvokeAsync(val);
@@ -214,10 +213,10 @@
     private async Task SendInput()
     {
         var id = $"input-{Session.Name.Replace(" ", "-")}";
-        var text = await JS.InvokeAsync<string>("eval", $"document.getElementById('{id}')?.value");
+        var text = await JS.InvokeAsync<string>("getElementValue", id);
         if (!string.IsNullOrWhiteSpace(text))
         {
-            await JS.InvokeVoidAsync("eval", $"document.getElementById('{id}').value = ''");
+            await JS.InvokeVoidAsync("clearElementValue", id);
             await OnSend.InvokeAsync(text);
         }
     }

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -391,6 +391,9 @@ public partial class CopilotService : IAsyncDisposable
         if (string.IsNullOrWhiteSpace(sessionId))
             throw new ArgumentException("Session ID cannot be empty.", nameof(sessionId));
 
+        if (!Guid.TryParse(sessionId, out _))
+            throw new ArgumentException("Session ID must be a valid GUID.", nameof(sessionId));
+
         if (_sessions.ContainsKey(displayName))
             throw new InvalidOperationException($"Session '{displayName}' already exists.");
 

--- a/PolyPilot/wwwroot/index.html
+++ b/PolyPilot/wwwroot/index.html
@@ -199,8 +199,8 @@
             // Also show in-app notification
             const toast = document.createElement('div');
             toast.className = 'toast-notification';
-            toast.innerHTML = '<strong>' + sessionName + '</strong> finished<br/>' + 
-                summary.substring(0, 80) + (summary.length > 80 ? '...' : '');
+            toast.innerHTML = '<strong>' + window.escapeHtml(sessionName) + '</strong> finished<br/>' + 
+                window.escapeHtml(summary.substring(0, 80)) + (summary.length > 80 ? '...' : '');
             document.body.appendChild(toast);
             setTimeout(() => toast.classList.add('show'), 10);
             setTimeout(() => {
@@ -298,6 +298,53 @@
 
         window.setAppFontSize = function(size) {
             document.documentElement.style.setProperty('--app-font-size', size + 'px');
+        };
+
+        // Safe DOM helpers — avoid eval() with interpolated strings
+        window.getElementValue = function(elementId) {
+            var el = document.getElementById(elementId);
+            return el ? (el.value || '') : '';
+        };
+
+        window.clearElementValue = function(elementId) {
+            var el = document.getElementById(elementId);
+            if (el) { el.value = ''; el.style.height = 'auto'; }
+        };
+
+        window.escapeHtml = function(str) {
+            var div = document.createElement('div');
+            div.appendChild(document.createTextNode(str));
+            return div.innerHTML;
+        };
+
+        window.clickElement = function(elementId) {
+            var el = document.getElementById(elementId);
+            if (el) el.click();
+        };
+
+        window.restoreDraftsAndFocus = function(draftsJson, focusId, selStart, selEnd, forceScroll) {
+            function doScroll() {
+                document.querySelectorAll('.card-messages, .messages').forEach(function(el) {
+                    if (!el.__scrollInit) {
+                        el.__scrollInit = true;
+                        el.scrollTop = el.scrollHeight;
+                        return;
+                    }
+                    var atBottom = forceScroll || (el.scrollHeight - el.scrollTop - el.clientHeight) < 120;
+                    if (atBottom) el.scrollTop = el.scrollHeight;
+                });
+            }
+            doScroll();
+            if (forceScroll) setTimeout(doScroll, 50);
+            var drafts = JSON.parse(draftsJson || '{}');
+            for (var id in drafts) {
+                var el = document.getElementById(id);
+                if (el) el.value = drafts[id];
+            }
+            if (focusId) {
+                var fel = document.getElementById(focusId);
+                if (fel) { fel.focus(); fel.setSelectionRange(selStart || 0, selEnd || 0); }
+            }
         };
     </script>
 


### PR DESCRIPTION
Replaces inline `eval()` calls with named JS helper functions for DOM interactions and adds input validation to bridge message handlers.

### Changes
- Add safe JS helpers (`getElementValue`, `clearElementValue`, `clickElement`, `restoreDraftsAndFocus`, `escapeHtml`) in index.html
- Replace all interpolated `eval()` calls in Dashboard.razor, SessionCard.razor, and SessionSidebar.razor with the new helpers
- Add validation for bridge message payloads (non-empty required fields, GUID format for session IDs, path validation for WorkingDirectory)
- Add WebSocket connection validation with loopback trust
- Restrict `/token` endpoint to loopback requests only
- Escape session names in notification toast HTML