### PR TITLE
Add tooltip to new session (+) button

### DIFF
--- a/PolyPilot/Components/Layout/CreateSessionForm.razor
+++ b/PolyPilot/Components/Layout/CreateSessionForm.razor
@@ -12,7 +12,7 @@
             }
         </select>
         <button class="dir-toggle-btn" @onclick="() => showDirectoryInput = !showDirectoryInput" title="Set working directory">⋯</button>
-        <button @onclick="TriggerCreate" disabled="@(IsCreating || string.IsNullOrWhiteSpace(SessionName))">
+        <button @onclick="TriggerCreate" disabled="@(IsCreating || string.IsNullOrWhiteSpace(SessionName))" title="Create new session">
             @(IsCreating ? "..." : "+")
         </button>
     </div>


### PR DESCRIPTION
Adds `title="Create new session"` to the + button in CreateSessionForm, so users see a helpful hint on hover.

**Change:** One attribute added to `CreateSessionForm.razor`.