### PR TITLE
Add Ctrl+C to interrupt running session

### DIFF
--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -370,6 +370,7 @@
                         if (e.ctrlKey && e.key === 'c' && !e.metaKey && !e.shiftKey) {
                             var selection = window.getSelection();
                             if (!selection || selection.toString().length === 0) {
+                                e.preventDefault();
                                 if (window.__dashRef) {
                                     window.__dashRef.invokeMethodAsync('JsInterruptSession');
                                 }


### PR DESCRIPTION
Adds Ctrl+C keyboard shortcut to interrupt a running session, matching copilot-cli behavior.

- Stops the expanded or active session when processing
- Only triggers when no text is selected (preserves normal copy)
- Uses the existing AbortSessionAsync mechanism