### PR TITLE
Fix session count after rename

### DIFF
--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -834,11 +834,17 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
         if (_activeSessionName == oldName)
             _activeSessionName = newName;
 
+        // Update organization metadata to reflect new name
+        var meta = Organization.Sessions.FirstOrDefault(m => m.SessionName == oldName);
+        if (meta != null)
+            meta.SessionName = newName;
+
         // Persist alias so saved sessions also show the custom name
         if (state.Info.SessionId != null)
             SetSessionAlias(state.Info.SessionId, newName);
 
         SaveActiveSessionsToDisk();
+        ReconcileOrganization();
         OnStateChanged?.Invoke();
         return true;
     }


### PR DESCRIPTION
Renaming a session didn't update `SessionMeta.SessionName` in the organization list or call `ReconcileOrganization()`, causing the old name to ghost in the sidebar and inflate the session count.

This adds two lines to `RenameSession()`:
1. Update the `SessionMeta.SessionName` entry for the old name
2. Call `ReconcileOrganization()` to sync state