### PR TITLE
Auto-update from main branch

### DIFF
--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -6,6 +6,7 @@
 @inject IJSRuntime JS
 @inject NavigationManager Nav
 @inject DevTunnelService DevTunnelService
+@inject GitAutoUpdateService GitAutoUpdate
 @implements IAsyncDisposable
 
 <div class="dashboard @(expandedSession != null ? "expanded-mode" : "")">
@@ -274,6 +275,8 @@
                     catch (Exception ex) { Console.WriteLine($"[AutoStart] Tunnel failed: {ex.Message}"); }
                 });
             }
+
+            GitAutoUpdate.Initialize();
         }
         catch (Exception ex)
         {

--- a/PolyPilot/Components/Pages/Settings.razor
+++ b/PolyPilot/Components/Pages/Settings.razor
@@ -5,6 +5,7 @@
 @inject ServerManager ServerManager
 @inject DevTunnelService DevTunnelService
 @inject QrScannerService QrScanner
+@inject GitAutoUpdateService GitAutoUpdate
 @inject NavigationManager Nav
 @inject IJSRuntime JS
 @implements IDisposable
@@ -285,6 +286,30 @@
         </div>
     </div>
 
+    @if (GitAutoUpdate.IsAvailable)
+    {
+    <div class="settings-group @(GroupVisible("developer") ? "" : "search-hidden")">
+        <h2 class="group-title">Developer</h2>
+
+        <div class="settings-section @(SectionVisible("auto update main git watch relaunch rebuild") ? "" : "search-hidden")">
+            <h3>Auto-Update from Main</h3>
+            <p class="section-desc">Watches <code>origin/main</code> for new commits every 30s. When changes are detected, automatically pulls, rebuilds, and relaunches.</p>
+            <div class="auto-update-row">
+                <label class="toggle-label">
+                    <span class="toggle-track @(GitAutoUpdate.IsEnabled ? "on" : "")" @onclick="ToggleAutoUpdate">
+                        <span class="toggle-thumb"></span>
+                    </span>
+                    <span>@(GitAutoUpdate.IsEnabled ? "Enabled" : "Disabled")</span>
+                </label>
+                @if (GitAutoUpdate.IsEnabled && !string.IsNullOrEmpty(GitAutoUpdate.Status))
+                {
+                    <span class="auto-update-status">@GitAutoUpdate.Status</span>
+                }
+            </div>
+        </div>
+    </div>
+    }
+
     @if (!string.IsNullOrEmpty(statusMessage))
     {
         <div class="status-toast @statusClass">@(statusClass == "success" ? "✓ " : statusClass == "error" ? "✗ " : "")@statusMessage</div>
@@ -338,6 +363,7 @@
         {
             "connection" => SectionVisible("transport mode embedded persistent remote server port start stop pid devtunnel share tunnel mobile qr url token connect save reconnect"),
             "ui" => SectionVisible("chat message layout default reversed both left theme"),
+            "developer" => SectionVisible("auto update main git watch relaunch rebuild"),
             _ => true
         };
     }
@@ -369,6 +395,7 @@
             tunnelLoggedIn = await DevTunnelService.IsLoggedInAsync();
 
         DevTunnelService.OnStateChanged += OnTunnelStateChanged;
+        GitAutoUpdate.OnStateChanged += OnAutoUpdateStateChanged;
 
         if (DevTunnelService.State == TunnelState.Running && DevTunnelService.TunnelUrl != null)
             GenerateQrCode(DevTunnelService.TunnelUrl, DevTunnelService.AccessToken);
@@ -401,6 +428,7 @@
     public void Dispose()
     {
         DevTunnelService.OnStateChanged -= OnTunnelStateChanged;
+        GitAutoUpdate.OnStateChanged -= OnAutoUpdateStateChanged;
         _ = JS.InvokeVoidAsync("eval", "window.__settingsRef = null;");
         _selfRef?.Dispose();
     }
@@ -571,6 +599,27 @@
         settings.Save();
         CopilotService.ChatLayout = layout;
         ShowStatus("Layout updated", "success");
+    }
+
+    private void ToggleAutoUpdate()
+    {
+        if (GitAutoUpdate.IsEnabled)
+        {
+            GitAutoUpdate.Stop();
+            settings.AutoUpdateFromMain = false;
+        }
+        else
+        {
+            GitAutoUpdate.Start();
+            settings.AutoUpdateFromMain = true;
+        }
+        settings.Save();
+        StateHasChanged();
+    }
+
+    private void OnAutoUpdateStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
     }
 
     private string GetLayoutLabel(ChatLayout layout) => layout switch

--- a/PolyPilot/Components/Pages/Settings.razor.css
+++ b/PolyPilot/Components/Pages/Settings.razor.css
@@ -989,3 +989,72 @@
 .tp-system .tp-line-2 {
     background: linear-gradient(90deg, rgba(78, 168, 209, 0.3) 50%, rgba(41, 128, 185, 0.25) 50%);
 }
+
+/* Auto-update toggle */
+.section-desc {
+    color: var(--text-dim, #6a7a8a);
+    font-size: var(--type-footnote);
+    margin: 0 0 0.8rem;
+    line-height: 1.5;
+}
+
+.section-desc code {
+    background: rgba(255,255,255,0.08);
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    font-size: inherit;
+}
+
+.auto-update-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.toggle-label {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    cursor: pointer;
+    font-size: var(--type-callout);
+    color: var(--text-primary);
+    user-select: none;
+}
+
+.toggle-track {
+    position: relative;
+    width: 40px;
+    height: 22px;
+    background: rgba(255,255,255,0.12);
+    border-radius: 11px;
+    transition: background 0.2s;
+    cursor: pointer;
+}
+
+.toggle-track.on {
+    background: rgba(78, 168, 209, 0.8);
+}
+
+.toggle-thumb {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 18px;
+    height: 18px;
+    background: #fff;
+    border-radius: 50%;
+    transition: transform 0.2s;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+}
+
+.toggle-track.on .toggle-thumb {
+    transform: translateX(18px);
+}
+
+.auto-update-status {
+    font-size: var(--type-footnote);
+    color: var(--text-dim, #6a7a8a);
+    padding: 0.2rem 0.6rem;
+    background: rgba(255,255,255,0.05);
+    border-radius: 6px;
+}

--- a/PolyPilot/MauiProgram.cs
+++ b/PolyPilot/MauiProgram.cs
@@ -97,6 +97,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<WsBridgeClient>();
 		builder.Services.AddSingleton<QrScannerService>();
 		builder.Services.AddSingleton<KeyCommandService>();
+	builder.Services.AddSingleton<GitAutoUpdateService>();
 
 #if DEBUG
 		builder.Services.AddBlazorWebViewDeveloperTools();

--- a/PolyPilot/Models/ConnectionSettings.cs
+++ b/PolyPilot/Models/ConnectionSettings.cs
@@ -39,6 +39,7 @@ public class ConnectionSettings
     public bool AutoStartTunnel { get; set; } = false;
     public ChatLayout ChatLayout { get; set; } = ChatLayout.Default;
     public UiTheme Theme { get; set; } = UiTheme.PolyPilotDark;
+    public bool AutoUpdateFromMain { get; set; } = false;
 
     [JsonIgnore]
     public string CliUrl => Mode == ConnectionMode.Remote && !string.IsNullOrEmpty(RemoteUrl)

--- a/PolyPilot/Services/GitAutoUpdateService.cs
+++ b/PolyPilot/Services/GitAutoUpdateService.cs
@@ -1,0 +1,219 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using PolyPilot.Models;
+
+namespace PolyPilot.Services;
+
+public class GitAutoUpdateService : IDisposable
+{
+    private Timer? _timer;
+    private string? _projectDir;
+    private string? _gitRoot;
+    private bool _isAvailable;
+    private int _checking;
+    private string _status = "";
+    private string? _lastLocalCommit;
+    private readonly ILogger<GitAutoUpdateService> _logger;
+    private readonly SynchronizationContext? _syncCtx;
+
+    public bool IsAvailable => _isAvailable;
+    public bool IsEnabled { get; private set; }
+    public string Status => _status;
+    public string? Branch { get; private set; }
+
+    public event Action? OnStateChanged;
+
+    public GitAutoUpdateService(ILogger<GitAutoUpdateService> logger)
+    {
+        _logger = logger;
+        _syncCtx = SynchronizationContext.Current;
+        DetectSourceEnvironment();
+    }
+
+    public void Initialize()
+    {
+        if (!_isAvailable) return;
+        var settings = ConnectionSettings.Load();
+        if (settings.AutoUpdateFromMain)
+            Start();
+    }
+
+    private void DetectSourceEnvironment()
+    {
+        try
+        {
+            var dir = AppContext.BaseDirectory;
+            for (int i = 0; i < 20 && dir != null; i++)
+            {
+                dir = Path.GetDirectoryName(dir);
+                if (dir == null) break;
+                if (File.Exists(Path.Combine(dir, "relaunch.sh")) &&
+                    File.Exists(Path.Combine(dir, "PolyPilot.csproj")))
+                {
+                    _projectDir = dir;
+                    var gitRoot = Path.GetDirectoryName(dir);
+                    if (gitRoot != null && Directory.Exists(Path.Combine(gitRoot, ".git")))
+                    {
+                        _gitRoot = gitRoot;
+                        _isAvailable = true;
+                        _logger.LogInformation("Auto-update available: project={Project}, git={Git}", _projectDir, _gitRoot);
+                    }
+                    break;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to detect source environment");
+        }
+    }
+
+    public void Start()
+    {
+        if (!_isAvailable || IsEnabled) return;
+        IsEnabled = true;
+        _status = "Watching main...";
+        _timer = new Timer(CheckForUpdates, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(30));
+        _logger.LogInformation("Auto-update watcher started");
+        NotifyChanged();
+    }
+
+    public void Stop()
+    {
+        if (!IsEnabled) return;
+        IsEnabled = false;
+        _timer?.Dispose();
+        _timer = null;
+        _status = "Stopped";
+        _logger.LogInformation("Auto-update watcher stopped");
+        NotifyChanged();
+    }
+
+    private async void CheckForUpdates(object? state)
+    {
+        if (Interlocked.CompareExchange(ref _checking, 1, 0) != 0) return;
+        try
+        {
+            var branch = (await RunGit("rev-parse --abbrev-ref HEAD")).Trim();
+            Branch = branch;
+            if (branch != "main")
+            {
+                _status = $"Not on main (on {branch})";
+                NotifyChanged();
+                return;
+            }
+
+            // Check for uncommitted changes
+            var dirtyCheck = (await RunGit("status --porcelain")).Trim();
+            if (!string.IsNullOrEmpty(dirtyCheck))
+            {
+                _status = "Working tree dirty — skipping";
+                NotifyChanged();
+                return;
+            }
+
+            await RunGit("fetch origin main --quiet");
+
+            var local = (await RunGit("rev-parse HEAD")).Trim();
+            var remote = (await RunGit("rev-parse origin/main")).Trim();
+
+            if (local == remote)
+            {
+                _status = $"Up to date ({local[..7]})";
+                if (_lastLocalCommit != local)
+                {
+                    _lastLocalCommit = local;
+                    NotifyChanged();
+                }
+                return;
+            }
+
+            // Count commits behind
+            var behindCount = (await RunGit("rev-list --count HEAD..origin/main")).Trim();
+            _status = $"Updating ({behindCount} new commit{(behindCount == "1" ? "" : "s")})...";
+            NotifyChanged();
+
+            var pullResult = await RunGit("pull origin main --ff-only");
+            _logger.LogInformation("Pulled updates: {Result}", pullResult.Trim());
+
+            _status = "Rebuilding & relaunching...";
+            NotifyChanged();
+
+            await Relaunch();
+        }
+        catch (Exception ex)
+        {
+            _status = $"Error: {ex.Message}";
+            _logger.LogError(ex, "Auto-update check failed");
+            NotifyChanged();
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _checking, 0);
+        }
+    }
+
+    private async Task<string> RunGit(string args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = args,
+            WorkingDirectory = _gitRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        SetPath(psi);
+
+        using var process = Process.Start(psi)!;
+        var output = await process.StandardOutput.ReadToEndAsync();
+        var error = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"git {args} failed: {error}");
+
+        return output;
+    }
+
+    private Task Relaunch()
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "/bin/bash",
+            Arguments = "relaunch.sh",
+            WorkingDirectory = _projectDir,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        SetPath(psi);
+
+        Process.Start(psi);
+        return Task.CompletedTask;
+    }
+
+    private static void SetPath(ProcessStartInfo psi)
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        psi.Environment["PATH"] =
+            $"{home}/.dotnet:/usr/local/share/dotnet:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+        psi.Environment["HOME"] = home;
+    }
+
+    private void NotifyChanged()
+    {
+        if (_syncCtx != null)
+            _syncCtx.Post(_ => OnStateChanged?.Invoke(), null);
+        else
+            OnStateChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+    }
+}


### PR DESCRIPTION
When running from source on the main branch, PolyPilot can now watch `origin/main` for new commits and automatically pull, rebuild, and relaunch itself.

## How it works
- **GitAutoUpdateService** polls `origin/main` every 30 seconds
- Detects it's running from source by walking up from `AppContext.BaseDirectory` to find `relaunch.sh`
 `bash relaunch.sh` (build + seamless handoff)
- Skips update if working tree is dirty or not on main branch
- Setting persisted as `AutoUpdateFromMain` in PolyPilot-settings.json

## UI
- New **Developer** section in Settings (only visible when running from source)
- Toggle switch to enable/disable
- Live status showing current state (up to date, watching, updating, error)

## Safety
- Uses `--ff- won't attempt mergesonly` 
- Checks for uncommitted changes before pulling
- Only activates on `main` branch
- Opt-in via Settings toggle (default: off)