### PR TITLE
Fix copilot process startup crash and model selector not applying selection

### DIFF
--- a/PolyPilot/Components/ModelSelector.razor
+++ b/PolyPilot/Components/ModelSelector.razor
@@ -11,7 +11,7 @@
     </div>
     @if (isOpen)
     {
-        <div class="model-selector-dropdown">
+        <div class="model-selector-dropdown" @onmousedown:preventDefault="true">
             @foreach (var model in Models)
             {
                 var info = GetDisplayInfo(model);

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -380,7 +380,8 @@ public partial class CopilotService : IAsyncDisposable
         // Remote mode is handled by InitializeRemoteAsync, not here.
         var options = new CopilotClientOptions
         {
-            CliPath = "copilot"
+            CliPath = "copilot",
+            Cwd = ProjectDir
         };
 
         // Pass additional MCP server configs via CLI args.


### PR DESCRIPTION
CopilotService: Set explicit Cwd on CopilotClientOptions

When PolyPilot is launched from the staging directory via relaunch.sh, the process working directory resolves to the .app bundle path (/Users/.../bin/staging/PolyPilot.app). The SDK's CopilotClient uses this as the working directory when spawning the 'copilot' CLI process, which fails with 'No such file or directory' because .app bundles are not valid working directories for child processes on macOS.

Fix: Set CopilotClientOptions.Cwd = ProjectDir so the copilot CLI process always starts with the project source directory as its working directory, regardless of where the .app bundle is running from.

ModelSelector: Fix dropdown selection being ignored (focusout race)

The ModelSelector component had @onfocusout="Close" on the parent div and @onclick handlers on dropdown options. When clicking a model option, the browser's focus-change sequence fires focusout before the click event. This caused Close() to set isOpen=false, triggering a Blazor re-render that removed the dropdown from the DOM before the Select() click handler could execute. The result was that the dropdown closed without applying the selection, snapping back to the default model.

Fix: Add @onmousedown:preventDefault="true" on the dropdown container. This prevents the browser's default mousedown behavior (moving focus away from the currently focused element), so focusout does not fire before the click event. The click on the model option now fires normally, Select() executes, and the chosen model is applied.