### PR TITLE
Fix sidebar layout: prevent text wrapping and set min-width

### DIFF
--- a/PolyPilot/Components/Layout/MainLayout.razor.css
+++ b/PolyPilot/Components/Layout/MainLayout.razor.css
@@ -99,7 +99,7 @@ main {
 
     .sidebar {
         width: 17.5rem;
-        min-width: 200px;
+        min-width: 240px;
         max-width: 600px;
         height: 100vh;
         position: sticky;

--- a/PolyPilot/Components/Layout/SessionSidebar.razor.css
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor.css
@@ -99,6 +99,8 @@
     cursor: pointer;
     font-size: var(--type-title3);
     font-weight: bold;
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .new-session button:hover:not(:disabled) {


### PR DESCRIPTION
- Increase sidebar min-width from 200px to 240px to prevent cramped layout
- Add white-space: nowrap and flex-shrink: 0 to new-session button text