### PR TITLE
Fix direct sharing auto-start when tunnel login fails

### DIFF
--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -272,21 +272,29 @@
             {
                 _ = Task.Run(async () =>
                 {
-                    try { await DevTunnelService.HostAsync(connSettings.Port); }
-                    catch (Exception ex) { Console.WriteLine($"[AutoStart] Tunnel failed: {ex.Message}"); }
+                    try
+                    {
+                        var success = await DevTunnelService.HostAsync(connSettings.Port);
+                        if (!success)
+                        {
+                            Console.WriteLine("[AutoStart] Tunnel failed, falling back to direct sharing");
+                            StartDirectSharingIfEnabled(connSettings);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"[AutoStart] Tunnel error: {ex.Message}");
+                        StartDirectSharingIfEnabled(connSettings);
+                    }
                 });
+            }
+            else
+            {
+                // No tunnel auto-start — try direct sharing
+                StartDirectSharingIfEnabled(connSettings);
             }
 
             GitAutoUpdate.Initialize();
-
-            // Auto-start direct sharing if previously enabled
-            if (connSettings.DirectSharingEnabled && !string.IsNullOrEmpty(connSettings.ServerPassword)
-                && !WsBridgeServer.IsRunning && DevTunnelService.State != TunnelState.Running)
-            {
-                WsBridgeServer.ServerPassword = connSettings.ServerPassword;
-                WsBridgeServer.SetCopilotService(CopilotService);
-                WsBridgeServer.Start(DevTunnelService.BridgePort, connSettings.Port);
-            }
         }
         catch (Exception ex)
         {
@@ -295,6 +303,17 @@
         }
 
         RefreshState();
+    }
+
+    private void StartDirectSharingIfEnabled(ConnectionSettings connSettings)
+    {
+        if (connSettings.DirectSharingEnabled && !string.IsNullOrEmpty(connSettings.ServerPassword)
+            && !WsBridgeServer.IsRunning && DevTunnelService.State != TunnelState.Running)
+        {
+            WsBridgeServer.ServerPassword = connSettings.ServerPassword;
+            WsBridgeServer.SetCopilotService(CopilotService);
+            WsBridgeServer.Start(DevTunnelService.BridgePort, connSettings.Port);
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/PolyPilot/Components/Pages/Settings.razor
+++ b/PolyPilot/Components/Pages/Settings.razor
@@ -114,7 +114,7 @@
         </div>
     }
 
-    @if (PlatformHelper.IsDesktop && (settings.Mode == ConnectionMode.Embedded || (settings.Mode == ConnectionMode.Persistent && serverAlive)))
+    @if (PlatformHelper.IsDesktop && (settings.Mode == ConnectionMode.Embedded || settings.Mode == ConnectionMode.Persistent))
     {
         <div class="settings-section @(SectionVisible("devtunnel share tunnel remote mobile qr") ? "" : "search-hidden")">
             <h3>Share via DevTunnel</h3>
@@ -193,7 +193,7 @@
             </div>
         }
 
-    @if (PlatformHelper.IsDesktop && (settings.Mode == ConnectionMode.Embedded || (settings.Mode == ConnectionMode.Persistent && serverAlive)))
+    @if (PlatformHelper.IsDesktop && (settings.Mode == ConnectionMode.Embedded || settings.Mode == ConnectionMode.Persistent))
     {
         <div class="settings-section @(SectionVisible("direct connection sharing tailscale lan password qr") ? "" : "search-hidden")">
             <h3>Direct Connection</h3>
@@ -615,6 +615,11 @@
         tunnelBusy = true;
         StateHasChanged();
         await DevTunnelService.HostAsync(settings.Port);
+        if (DevTunnelService.State == TunnelState.Running)
+        {
+            settings.AutoStartTunnel = true;
+            settings.Save();
+        }
         tunnelBusy = false;
         StateHasChanged();
     }


### PR DESCRIPTION
- Check HostAsync return value (not just exceptions) to detect tunnel failure
- Fall back to direct sharing when tunnel returns false
- Direct sharing now reliably auto-starts on app launch when enabled in settings