### PR TITLE
Show streaming messages only while processing

### DIFF
--- a/PolyPilot/Components/ChatMessageList.razor
+++ b/PolyPilot/Components/ChatMessageList.razor
@@ -58,8 +58,8 @@
             }
         }
 
-        @* Streaming content *@
-        @if (!string.IsNullOrEmpty(StreamingContent))
+        @* Streaming content — only show while actively processing to avoid overlap with finalized History *@
+        @if (!string.IsNullOrEmpty(StreamingContent) && IsProcessing)
         {
             <div class="chat-msg assistant streaming">
                 @if (!Compact)


### PR DESCRIPTION
Limit rendering of StreamingContent to when IsProcessing is true to avoid overlap with finalized history. Updated inline comment and conditional check in ChatMessageList.razor to only display the streaming assistant message while the component is actively processing, improving UI consistency.