### PR TITLE
Repo management improvements

### DIFF
--- a/PolyPilot/Components/Layout/CreateSessionForm.razor
+++ b/PolyPilot/Components/Layout/CreateSessionForm.razor
@@ -155,6 +155,30 @@ else
     private bool isCreatingWorktree;
 
     private void Expand() => isExpanded = true;
+    public void ExpandForRepo(string repoId)
+    {
+        isExpanded = true;
+        showOptions = true;
+        worktreeError = null;
+
+        // If worktrees exist for this repo, auto-select the first one
+        var existingWorktrees = RepoManager.Worktrees.Where(w => w.RepoId == repoId).ToList();
+        if (existingWorktrees.Count > 0)
+        {
+            SelectWorktree(existingWorktrees[0]);
+            showWorktreePicker = true;
+        }
+        else
+        {
+            // No worktrees yet — open new worktree form prefilled with "main"
+            showWorktreePicker = true;
+            newWorktreeRepoId = repoId;
+            newWorktreeBranch = "main";
+            newWorktreePr = "";
+            newWorktreeMode = "branch";
+        }
+        StateHasChanged();
+    }
     private void Collapse()
     {
         isExpanded = false;
@@ -187,6 +211,12 @@ else
         selectedWorktreeBranch = wt.Branch;
         showWorktreePicker = false;
         newWorktreeRepoId = null;
+
+        if (string.IsNullOrWhiteSpace(SessionName))
+        {
+            SessionName = wt.Branch;
+            _ = SessionNameChanged.InvokeAsync(SessionName);
+        }
     }
 
     private void ClearWorktree()

--- a/PolyPilot/Components/Layout/SessionListItem.razor
+++ b/PolyPilot/Components/Layout/SessionListItem.razor
@@ -1,9 +1,12 @@
 @using PolyPilot.Services
 @using PolyPilot.Models
+@using System.Diagnostics
 @inject CopilotService CopilotService
+@inject RepoManager RepoManager
 
 @{
     var isPinned = Meta?.IsPinned ?? false;
+    var sessionDir = GetSessionDirectory();
     var cssClass = IsActive ? "active" : 
                    IsCompleted ? "completed" :
                    Session.IsProcessing ? "busy" : "";
@@ -73,6 +76,16 @@
                     </button>
                 }
                 <div class="menu-separator"></div>
+                @if (!string.IsNullOrEmpty(sessionDir))
+                {
+                    <button class="menu-item" @onclick="() => { OnCloseMenu.InvokeAsync(); OpenInTerminal(); }">
+                        >_ Terminal
+                    </button>
+                    <button class="menu-item" @onclick="() => { OnCloseMenu.InvokeAsync(); OpenInVSCode(); }">
+                        ⌨ VS Code
+                    </button>
+                    <div class="menu-separator"></div>
+                }
                 <button class="menu-item destructive" @onclick="() => { OnCloseMenu.InvokeAsync(); OnClose.InvokeAsync(); }">
                     🗑 Close Session
                 </button>
@@ -111,5 +124,50 @@
         var parts = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         if (parts.Length <= 2) return path;
         return "…/" + parts[^1];
+    }
+
+    private string? GetSessionDirectory()
+    {
+        if (!string.IsNullOrEmpty(Session.WorkingDirectory))
+            return Session.WorkingDirectory;
+        // Fallback: resolve from worktree metadata
+        if (Meta?.WorktreeId != null)
+        {
+            var wt = RepoManager.Worktrees.FirstOrDefault(w => w.Id == Meta.WorktreeId);
+            if (wt != null) return wt.Path;
+        }
+        return null;
+    }
+
+    private void OpenInTerminal()
+    {
+        var dir = GetSessionDirectory();
+        if (string.IsNullOrEmpty(dir)) return;
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "open",
+                ArgumentList = { "-a", "Terminal", dir },
+                UseShellExecute = false
+            });
+        }
+        catch { }
+    }
+
+    private void OpenInVSCode()
+    {
+        var dir = GetSessionDirectory();
+        if (string.IsNullOrEmpty(dir)) return;
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "code",
+                ArgumentList = { dir },
+                UseShellExecute = false
+            });
+        }
+        catch { }
     }
 }

--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -30,7 +30,7 @@ else if (IsFlyoutPanel)
         </div>
 
         <div class="new-session-wrapper">
-            <CreateSessionForm @bind-SessionName="newSessionName"
+            <CreateSessionForm @ref="createSessionFormRef" @bind-SessionName="newSessionName"
                                @bind-SelectedModel="selectedModel"
                                AvailableModels="availableModels.ToList()"
                                IsCreating="isCreating"
@@ -65,7 +65,7 @@ else
         </div>
 
         <div class="new-session-wrapper">
-            <CreateSessionForm @bind-SessionName="newSessionName"
+            <CreateSessionForm @ref="createSessionFormRef" @bind-SessionName="newSessionName"
                                @bind-SelectedModel="selectedModel"
                                AvailableModels="availableModels.ToList()"
                                IsCreating="isCreating"
@@ -114,13 +114,30 @@ else
         @if (showAddRepo)
         {
             <div class="add-repo-form">
-                <input type="text" @bind="newRepoUrl" placeholder="Repository URL (https://github.com/...)" class="repo-url-input" />
-                <div class="add-repo-actions">
-                    <button class="btn-repo-add" @onclick="AddRepository" disabled="@(isAddingRepo || string.IsNullOrWhiteSpace(newRepoUrl))">
-                        @(isAddingRepo ? "Cloning..." : "Add")
-                    </button>
-                    <button class="btn-repo-cancel" @onclick="() => { showAddRepo = false; addRepoError = null; }">Cancel</button>
-                </div>
+                <input type="text" @bind="newRepoUrl" placeholder="owner/repo or full URL" class="repo-url-input" />
+                @if (confirmRepoReplace)
+                {
+                    <div class="repo-confirm">
+                        <span>@confirmRepoName already exists. Re-fetch?</span>
+                        <div class="repo-confirm-actions">
+                            <button class="btn-repo-add" @onclick="ConfirmAddRepository">Yes</button>
+                            <button class="btn-repo-cancel" @onclick="() => { confirmRepoReplace = false; confirmRepoName = null; }">No</button>
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <div class="add-repo-actions">
+                        <button class="btn-repo-add" @onclick="AddRepository" disabled="@(isAddingRepo || string.IsNullOrWhiteSpace(newRepoUrl))">
+                            @(isAddingRepo ? "Cloning..." : "Add")
+                        </button>
+                        <button class="btn-repo-cancel" @onclick="() => { showAddRepo = false; addRepoError = null; }">Cancel</button>
+                    </div>
+                }
+                @if (isAddingRepo && !string.IsNullOrEmpty(addRepoProgress))
+                {
+                    <div class="repo-progress">@addRepoProgress</div>
+                }
                 @if (!string.IsNullOrEmpty(addRepoError))
                 {
                     <div class="repo-error">⚠ @addRepoError</div>
@@ -135,12 +152,13 @@ else
                 var sessionIndex = 0;
             }
 
-            @if (!sessions.Any())
+            @if (!sessions.Any() && !CopilotService.HasMultipleGroups)
             {
                 <div class="section-header"><span class="section-header-label">Active Sessions</span></div>
                 <p class="no-sessions">No active sessions.<br/>Create one above or resume below.</p>
             }
-            else
+
+            @if (sessions.Any() || CopilotService.HasMultipleGroups)
             {
                 @if (!showGroupHeaders)
                 {
@@ -152,7 +170,10 @@ else
                     @if (showGroupHeaders)
                     {
                         var isRepoGroup = !string.IsNullOrEmpty(group.RepoId);
+                        var repoForGroup = isRepoGroup ? RepoManager.Repositories.FirstOrDefault(r => r.Id == group.RepoId) : null;
+                        var groupTitle = repoForGroup != null ? $"{repoForGroup.Url}\n{repoForGroup.BareClonePath}" : "";
                         <div class="group-header @(group.IsCollapsed ? "collapsed" : "") @(isRepoGroup ? "repo-group" : "")"
+                             title="@groupTitle"
                              @onclick="() => CopilotService.ToggleGroupCollapsed(group.Id)">
                             <span class="group-chevron">@(group.IsCollapsed ? "▶" : "▼")</span>
                             @if (isRepoGroup)
@@ -167,9 +188,33 @@ else
                             }
                             @if (group.Id != SessionGroup.DefaultId)
                             {
-                                <button class="group-delete-btn" title="Delete group"
-                                        @onclick="() => CopilotService.DeleteGroup(group.Id)"
-                                        @onclick:stopPropagation="true">×</button>
+                                @if (isRepoGroup && confirmRemoveRepoId == group.RepoId)
+                                {
+                                    var rId = group.RepoId!;
+                                    var gId = group.Id;
+                                    <span class="repo-remove-confirm" @onclick:stopPropagation="true">
+                                        <span class="repo-remove-label">Delete folder?</span>
+                                        <button class="btn-repo-rm" @onclick="() => RemoveRepo(rId, gId, true)">Yes</button>
+                                        <button class="btn-repo-rm" @onclick="() => RemoveRepo(rId, gId, false)">No</button>
+                                        <button class="btn-repo-rm cancel" @onclick="() => { confirmRemoveRepoId = null; }">Cancel</button>
+                                    </span>
+                                }
+                                else if (isRepoGroup)
+                                {
+                                    var rId = group.RepoId!;
+                                    <button class="group-add-btn" title="New session for this repo"
+                                            @onclick="() => createSessionFormRef?.ExpandForRepo(rId)"
+                                            @onclick:stopPropagation="true">+</button>
+                                    <button class="group-delete-btn" title="Remove repository"
+                                            @onclick="() => { confirmRemoveRepoId = rId; }"
+                                            @onclick:stopPropagation="true">×</button>
+                                }
+                                else
+                                {
+                                    <button class="group-delete-btn" title="Delete group"
+                                            @onclick="() => CopilotService.DeleteGroup(group.Id)"
+                                            @onclick:stopPropagation="true">×</button>
+                                }
                             }
                         </div>
                     }
@@ -278,12 +323,17 @@ else
     private string currentPage = "/";
     private bool isAddingGroup = false;
     private string? openMenuSession = null;
+    private CreateSessionForm? createSessionFormRef;
     private List<AgentSessionInfo> sessions = new();
     private List<PersistedSessionInfo> persistedSessions = new();
     private bool showAddRepo = false;
     private string newRepoUrl = "";
     private string? addRepoError = null;
     private bool isAddingRepo = false;
+    private string? addRepoProgress = null;
+    private bool confirmRepoReplace = false;
+    private string? confirmRepoName = null;
+    private string? confirmRemoveRepoId = null;
 
     private async Task ToggleFlyout()
     {
@@ -646,11 +696,40 @@ else
     private async Task AddRepository()
     {
         if (isAddingRepo || string.IsNullOrWhiteSpace(newRepoUrl)) return;
-        isAddingRepo = true;
         addRepoError = null;
+
+        // Check if repo already exists
+        var normalizedUrl = RepoManager.NormalizeRepoUrl(newRepoUrl.Trim());
+        var id = RepoManager.RepoIdFromUrl(normalizedUrl);
+        var existing = RepoManager.Repositories.FirstOrDefault(r => r.Id == id);
+        if (existing != null)
+        {
+            confirmRepoReplace = true;
+            confirmRepoName = existing.Name;
+            return;
+        }
+
+        await DoAddRepository();
+    }
+
+    private async Task ConfirmAddRepository()
+    {
+        confirmRepoReplace = false;
+        confirmRepoName = null;
+        await DoAddRepository();
+    }
+
+    private async Task DoAddRepository()
+    {
+        isAddingRepo = true;
+        addRepoProgress = null;
         try
         {
-            var repo = await RepoManager.AddRepositoryAsync(newRepoUrl.Trim());
+            var repo = await RepoManager.AddRepositoryAsync(newRepoUrl.Trim(), progress =>
+            {
+                addRepoProgress = progress;
+                InvokeAsync(StateHasChanged);
+            });
             CopilotService.GetOrCreateRepoGroup(repo.Id, repo.Name);
             showAddRepo = false;
             newRepoUrl = "";
@@ -662,6 +741,21 @@ else
         finally
         {
             isAddingRepo = false;
+            addRepoProgress = null;
+        }
+    }
+
+    private async Task RemoveRepo(string repoId, string groupId, bool deleteFromDisk)
+    {
+        confirmRemoveRepoId = null;
+        try
+        {
+            await RepoManager.RemoveRepositoryAsync(repoId, deleteFromDisk);
+            CopilotService.DeleteGroup(groupId);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error removing repo: {ex.Message}");
         }
     }
 

--- a/PolyPilot/Components/Layout/SessionSidebar.razor.css
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor.css
@@ -262,8 +262,55 @@
     opacity: 0;
     transition: opacity 0.15s;
 }
+
+.group-add-btn {
+    all: unset;
+    margin-left: auto;
+    font-size: var(--type-callout);
+    color: var(--control-border);
+    cursor: pointer;
+    padding: 0 0.3rem;
+    border-radius: 3px;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+
+.group-header:hover .group-add-btn { opacity: 1; }
+.group-add-btn:hover { color: var(--accent-primary); background: var(--control-border); }
 .group-header:hover .group-delete-btn { opacity: 1; }
 .group-delete-btn:hover { color: var(--accent-primary); background: var(--control-border); }
+
+.repo-remove-confirm {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-left: auto;
+    font-size: 0.65rem;
+}
+
+.repo-remove-label {
+    color: var(--text-secondary);
+}
+
+.btn-repo-rm {
+    all: unset;
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    font-size: 0.65rem;
+    cursor: pointer;
+    background: var(--control-bg);
+    color: var(--text-primary);
+}
+
+.btn-repo-rm:hover {
+    background: var(--accent-primary);
+    color: #fff;
+}
+
+.btn-repo-rm.cancel:hover {
+    background: var(--control-border);
+    color: var(--text-primary);
+}
 
 .group-repo-icon {
     font-size: 0.7rem;
@@ -331,6 +378,28 @@
 .repo-error {
     color: #ff6b6b;
     font-size: var(--type-caption1);
+    margin-top: 0.25rem;
+}
+
+.repo-progress {
+    color: var(--text-secondary);
+    font-size: 0.65rem;
+    margin-top: 0.25rem;
+    font-family: var(--font-mono, monospace);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.repo-confirm {
+    margin-top: 0.35rem;
+    font-size: var(--type-caption1);
+    color: var(--text-secondary);
+}
+
+.repo-confirm-actions {
+    display: flex;
+    gap: 0.25rem;
     margin-top: 0.25rem;
 }
 

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -678,7 +678,7 @@ public partial class CopilotService : IAsyncDisposable
             throw new InvalidOperationException($"Session '{name}' already exists.");
 
         var sessionModel = model ?? DefaultModel;
-        var sessionDir = workingDirectory ?? ProjectDir;
+        var sessionDir = string.IsNullOrWhiteSpace(workingDirectory) ? ProjectDir : workingDirectory;
 
         // Build system message with critical relaunch instructions
         var systemContent = new StringBuilder();


### PR DESCRIPTION
## Changes

- **Shorthand repo input**: Accept `owner/repo` (e.g. `dotnet/maui`) instead of full URL
- **Clone progress**: Show real-time git clone/fetch progress in the sidebar
- **Duplicate detection**: Detect existing repos and prompt to re-fetch instead of failing
- **Stale directory handling**: Re-use existing bare clone directories not tracked in state
- **Remove repo**: × button with confirmation to delete folder from disk or just untrack
- **Repo hover tooltip**: Show URL and bare clone path on hover over group headers
- **"+" button on repo groups**: Opens create session form pre-configured for that repo
- **Auto-fill session name**: Selecting a worktree auto-fills session name with branch name
- **Open in Terminal / VS Code**: Session context menu items to open working directory
- **Empty directory fix**: Treat empty string working directory as null (falls back to ProjectDir)
- **Show repos when no sessions**: Repo groups visible in sidebar even with zero active sessions