### PR TITLE
Pin reset and chat_history.db path fix

### DIFF
--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -659,7 +659,10 @@ public partial class CopilotService : IAsyncDisposable
             // Set up optimistic state BEFORE sending bridge message to prevent race with SyncRemoteSessions
             _pendingRemoteSessions[name] = 0;
             _sessions[name] = new SessionState { Session = null!, Info = remoteInfo };
-            if (!Organization.Sessions.Any(m => m.SessionName == name))
+            var existingMeta = Organization.Sessions.FirstOrDefault(m => m.SessionName == name);
+            if (existingMeta != null)
+                existingMeta.IsPinned = false;
+            else
                 Organization.Sessions.Add(new SessionMeta { SessionName = name, GroupId = SessionGroup.DefaultId });
             _activeSessionName = name;
             OnStateChanged?.Invoke();
@@ -745,6 +748,12 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
         }
 
         _activeSessionName ??= name;
+
+        // Reset stale pin from a previous session with the same name
+        var staleMeta = Organization.Sessions.FirstOrDefault(m => m.SessionName == name);
+        if (staleMeta != null)
+            staleMeta.IsPinned = false;
+
         SaveActiveSessionsToDisk();
         ReconcileOrganization();
         OnStateChanged?.Invoke();


### PR DESCRIPTION
## Changes

- **Fix pin-by-name bug**: When a pinned session is deleted and a new session with the same name is created, the pin no longer carries over. Resets `IsPinned` on stale `SessionMeta` in both remote and local mode paths of `CreateSessionAsync`.
- **Move chat_history.db**: Relocated from `~/Documents/PolyPilot/` (via `LocalApplicationData`) to `~/.polypilot/chat_history.db` to be consistent with all other PolyPilot data files. Uses lazy property pattern per project conventions.