### PR TITLE
Add premium quota display to session title bar and fix SDK numeric type casting

### DIFF
--- a/PolyPilot/Components/ChatMessageList.razor
+++ b/PolyPilot/Components/ChatMessageList.razor
@@ -10,7 +10,7 @@
     }
     else
     {
-        @foreach (var msg in Messages)
+        @foreach (var msg in Messages.ToList())
         {
             <ChatMessageItem Message="msg" Compact="Compact" UserAvatarUrl="@UserAvatarUrl" />
         }

--- a/PolyPilot/Components/ExpandedSessionView.razor
+++ b/PolyPilot/Components/ExpandedSessionView.razor
@@ -29,6 +29,11 @@
             {
                 <span class="context-badge branch-badge"> @Session.GitBranch</span>
             }
+            @if (UsageInfo?.PremiumQuota != null)
+            {
+                var q = UsageInfo.PremiumQuota;
+                <span class="context-badge premium-badge" title="@(q.IsUnlimited ? "Unlimited premium requests" : $"{q.EntitlementRequests - q.UsedRequests} of {q.EntitlementRequests} remaining (resets {q.ResetDate?[..10]})")">⚡ @(q.IsUnlimited ? "∞" : $"{q.EntitlementRequests - q.UsedRequests}/{q.EntitlementRequests}") premium</span>
+            }
             <button class="collapse-card-btn" @onclick="OnCollapse" title="Back to grid (Esc / ⌘E)">⊟ Grid</button>
         </div>
     </div>

--- a/PolyPilot/Components/ExpandedSessionView.razor.css
+++ b/PolyPilot/Components/ExpandedSessionView.razor.css
@@ -25,6 +25,7 @@
 .chat-header-context { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
 .context-badge { font-size: var(--type-caption1, 0.6rem); color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 300px; }
 .branch-badge { color: var(--accent-primary); font-weight: 500; }
+.premium-badge { color: #e0a040; font-weight: 500; }
 .model-badge { padding: 0.2rem 0.5rem; background: var(--hover-bg); border: 1px solid var(--border-accent); border-radius: 4px; font-size: var(--type-body); color: var(--accent-primary); line-height: 1.2; }
 .session-id-badge { padding: 0.2rem 0.5rem; background: rgba(251,191,36,0.2); border: 1px solid rgba(251,191,36,0.3); border-radius: 4px; font-size: var(--type-body); color: #fbbf24; font-family: monospace; cursor: pointer; }
 .session-id-badge:hover { background: rgba(251,191,36,0.3); }

--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -644,7 +644,8 @@
                 info.CurrentTokens ?? current.CurrentTokens,
                 info.TokenLimit ?? current.TokenLimit,
                 info.InputTokens ?? current.InputTokens,
-                info.OutputTokens ?? current.OutputTokens);
+                info.OutputTokens ?? current.OutputTokens,
+                info.PremiumQuota ?? current.PremiumQuota);
         }
         else
         {

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -1031,5 +1031,14 @@ public record SessionUsageInfo(
     int? CurrentTokens,
     int? TokenLimit,
     int? InputTokens,
-    int? OutputTokens
+    int? OutputTokens,
+    QuotaInfo? PremiumQuota = null
+);
+
+public record QuotaInfo(
+    bool IsUnlimited,
+    int EntitlementRequests,
+    int UsedRequests,
+    int RemainingPercentage,
+    string? ResetDate
 );


### PR DESCRIPTION
Display Copilot premium request quota in session header

Extract quota information from the SDK's AssistantUsageEvent via the QuotaSnapshots dictionary. The 'premium_interactions' entry contains a JsonElement with entitlement details: isUnlimitedEntitlement, entitlementRequests, usedRequests, remainingPercentage, and resetDate.

A new QuotaInfo record stores this data and flows through SessionUsageInfo to the ExpandedSessionView title bar, which displays:
- '⚡ ∞ premium' for unlimited entitlement plans
- '⚡ X/Y premium' for limited plans (remaining/total)
- Hover tooltip shows the billing period reset date

Fix SDK numeric property extraction (Double vs int)

The SDK's AssistantUsageData exposes InputTokens, OutputTokens, CacheReadTokens etc. as Nullable<Double>, not Nullable<Int32>. SessionUsageInfoData likewise uses Double for CurrentTokens and TokenLimit. The previous code used 'as int?' to extract these from boxed objects returned by reflection, which silently returns null when the boxed type is Double — meaning token counts were never displayed in the UI.

Replaced all 'as int?' casts with Convert.ToInt32() to correctly unbox the Double values. This fixes the input/output token display (↑Xk ↓Yk) and context window usage (X/Y ctx) in the status bar.

Also simplified the SessionUsageInfoEvent handler to only extract properties that actually exist on SessionUsageInfoData (CurrentTokens, TokenLimit) rather than Model/InputTokens/OutputTokens which are not present on that type.

Fix collection-modified-during-enumeration in ChatMessageList

Snapshot the Messages list with .ToList() before iterating in the Blazor render tree to prevent InvalidOperationException when SDK background threads add messages during a render cycle.