### PR TITLE
Use locale-aware time formatting for all timestamps

### DIFF
--- a/PolyPilot/Components/ChatMessageItem.razor
+++ b/PolyPilot/Components/ChatMessageItem.razor
@@ -28,7 +28,7 @@
                 <div class="chat-msg-text">@((MarkupString)ChatMessageList.FormatUserMessage(Message.Content))</div>
                 @if (!Compact)
                 {
-                    <div class="chat-msg-time">@Message.Timestamp.ToString("HH:mm")</div>
+                    <div class="chat-msg-time">@Message.Timestamp.ToShortTimeString()</div>
                 }
             </div>
         </div>
@@ -48,7 +48,7 @@
                 <div class="chat-msg-text markdown-body">@((MarkupString)ChatMessageList.RenderMarkdown(Message.Content))</div>
                 @if (!Compact && !IsStreaming)
                 {
-                    <div class="chat-msg-time">@Message.Timestamp.ToString("HH:mm")</div>
+                    <div class="chat-msg-time">@Message.Timestamp.ToShortTimeString()</div>
                 }
             </div>
         </div>

--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -273,7 +273,7 @@ else
                                 <span class="session-name persisted-name">@(persisted.Title ?? "Untitled")</span>
                                 <div class="session-meta-row">
                                     <div class="session-meta-left">
-                                        <span class="session-meta-time">@persisted.LastModified.ToString("MMM dd h:mm tt")</span>
+                                        <span class="session-meta-time">@persisted.LastModified.ToString("MMM dd") @persisted.LastModified.ToShortTimeString()</span>
                                         @if (!string.IsNullOrEmpty(persisted.WorkingDirectory))
                                         {
                                             <span class="session-meta-dir">@GetShortPath(persisted.WorkingDirectory)</span>

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -509,7 +509,7 @@ public partial class CopilotService : IAsyncDisposable
         }
 
         // Add reconnection indicator with status context
-        var reconnectMsg = $"🔄 Session reconnected at {DateTime.Now:h:mm tt}";
+        var reconnectMsg = $"🔄 Session reconnected at {DateTime.Now.ToShortTimeString()}";
         var isStillProcessing = IsSessionStillProcessing(sessionId);
         if (isStillProcessing)
         {


### PR DESCRIPTION
Replace hardcoded time format strings (`"HH:mm"`, `"h:mm tt"`, `"MMM dd h:mm tt"`) with `ToShortTimeString()` so times display according to the user's locale (e.g. `14:40` instead of `2:40 PM`).

### Changes
- **ChatMessageItem.razor**: user and assistant message timestamps
- **SessionSidebar.razor**: session last-modified time  
- **CopilotService.cs**: session reconnection message