### PR TITLE
Fix second collection-modified crash in ChatMessageList.GetNewActivities

### DIFF
--- a/PolyPilot/Components/ChatMessageList.razor
+++ b/PolyPilot/Components/ChatMessageList.razor
@@ -118,7 +118,7 @@
 
     private IEnumerable<ToolActivity> GetNewActivities()
     {
-        var historyCallIds = Messages.Where(m => m.ToolCallId != null).Select(m => m.ToolCallId).ToHashSet();
+        var historyCallIds = Messages.ToList().Where(m => m.ToolCallId != null).Select(m => m.ToolCallId).ToHashSet();
         return ToolActivities.Where(a => !historyCallIds.Contains(a.CallId));
     }
 


### PR DESCRIPTION
The GetNewActivities() method iterates the Messages list via a LINQ chain (Where → Select → ToHashSet) to build a set of tool call IDs already present in chat history. When the SDK's background thread adds a new ChatMessage to the list concurrently, the enumerator throws InvalidOperationException: 'Collection was modified'.

This is the same race condition fixed earlier for the foreach loop in BuildRenderTree (line 13), but occurring in a different code path: GetNewActivities() is called during render to filter tool activities that haven't yet been finalized into the message history.

Fix: Snapshot the Messages list with .ToList() before the LINQ chain to iterate over a stable copy, consistent with the existing fix on the render loop.