### PR TITLE
Polish session header UI: improve hover states and simplify directory badge

### DIFF
--- a/PolyPilot/Components/ExpandedSessionView.razor
+++ b/PolyPilot/Components/ExpandedSessionView.razor
@@ -23,7 +23,7 @@
             }
             @if (!string.IsNullOrEmpty(Session.WorkingDirectory))
             {
-                <span class="context-badge dir-badge" title="@Session.WorkingDirectory">📁 @ShortenPath(Session.WorkingDirectory)</span>
+                <span class="context-badge dir-badge" title="@Session.WorkingDirectory">@ShortenPath(Session.WorkingDirectory)</span>
             }
             @if (!string.IsNullOrEmpty(Session.GitBranch))
             {

--- a/PolyPilot/Components/ExpandedSessionView.razor.css
+++ b/PolyPilot/Components/ExpandedSessionView.razor.css
@@ -30,7 +30,7 @@
 .session-id-badge { padding: 0.2rem 0.5rem; background: rgba(251,191,36,0.2); border: 1px solid rgba(251,191,36,0.3); border-radius: 4px; font-size: var(--type-body); color: #fbbf24; font-family: monospace; cursor: pointer; }
 .session-id-badge:hover { background: rgba(251,191,36,0.3); }
 .folder-btn { background: var(--hover-bg); border: 1px solid var(--hover-bg); border-radius: 6px; color: var(--text-secondary); cursor: pointer; padding: 0.2rem 0.4rem; display: flex; align-items: center; transition: all 0.15s; }
-.folder-btn:hover { background: var(--hover-bg); color: var(--text-primary); }
+.folder-btn:hover { background: var(--active-bg); color: var(--text-primary); border-color: var(--active-bg); }
 .processing-dot { width: 8px; height: 8px; border-radius: 50%; background: #f59e0b; box-shadow: 0 0 8px rgba(245,158,11,0.6); animation: pulse-glow 1.5s ease-in-out infinite; flex-shrink: 0; }
 @keyframes pulse-glow { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
@@ -46,8 +46,9 @@
 }
 
 .collapse-card-btn:hover {
-    background: var(--hover-bg);
+    background: var(--active-bg);
     color: var(--accent-primary);
+    border-color: var(--active-bg);
 }
 
 /* Messages area (expanded) */

--- a/PolyPilot/Components/Pages/Dashboard.razor.css
+++ b/PolyPilot/Components/Pages/Dashboard.razor.css
@@ -443,7 +443,7 @@
 .session-id-badge { padding: 0.2rem 0.5rem; background: rgba(251,191,36,0.2); border: 1px solid rgba(251,191,36,0.3); border-radius: 4px; font-size: var(--type-body); color: #fbbf24; font-family: monospace; cursor: pointer; }
 .session-id-badge:hover { background: rgba(251,191,36,0.3); }
 .folder-btn { background: var(--hover-bg); border: 1px solid var(--hover-bg); border-radius: 6px; color: var(--text-secondary); cursor: pointer; padding: 0.2rem 0.4rem; display: flex; align-items: center; transition: all 0.15s; }
-.folder-btn:hover { background: var(--hover-bg); color: var(--text-primary); }
+.folder-btn:hover { background: var(--active-bg); color: var(--text-primary); border-color: var(--active-bg); }
 .processing-dot { width: 8px; height: 8px; border-radius: 50%; background: #f59e0b; box-shadow: 0 0 8px rgba(245,158,11,0.6); animation: pulse-glow 1.5s ease-in-out infinite; flex-shrink: 0; }
 @keyframes pulse-glow { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
@@ -717,8 +717,9 @@
 }
 
 .collapse-card-btn:hover {
-    background: var(--hover-bg);
+    background: var(--active-bg);
     color: var(--accent-primary);
+    border-color: var(--active-bg);
 }
 
 .card-title {


### PR DESCRIPTION
Improve button hover visibility

The folder button and collapse/grid button hover states used --hover-bg for their background, which was identical to their default background, making the hover effect invisible. Changed both to use --active-bg with matching border-color for a clear visual feedback on hover.

Simplify directory badge display

Removed the 📁 emoji prefix from the working directory badge in the expanded session view. The folder button already sits adjacent to the path, making the emoji redundant and cluttering the header.