### PR TITLE
Add remote directory browser for mobile session creation

### DIFF
--- a/PolyPilot.Tests/RemoteModeTests.cs
+++ b/PolyPilot.Tests/RemoteModeTests.cs
@@ -47,6 +47,7 @@ public class RemoteModeTests
             BridgeMessageTypes.CloseSession,
             BridgeMessageTypes.AbortSession,
             BridgeMessageTypes.OrganizationCommand,
+            BridgeMessageTypes.ListDirectories,
         };
         Assert.Equal(types.Length, types.Distinct().Count());
     }
@@ -71,6 +72,7 @@ public class RemoteModeTests
             BridgeMessageTypes.TurnEnd,
             BridgeMessageTypes.SessionComplete,
             BridgeMessageTypes.ErrorEvent,
+            BridgeMessageTypes.DirectoriesList,
         };
         Assert.Equal(types.Length, types.Distinct().Count());
     }

--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -39,7 +39,8 @@ else if (IsFlyoutPanel)
                                AvailableModels="availableModels.ToList()"
                                IsCreating="isCreating"
                                CreateError="@createError"
-                               OnCreate="HandleCreateSession" />
+                               OnCreate="HandleCreateSession"
+                               OnBrowseDirectory="OpenDirectoryPicker" />
         </div>
 
         <div class="sidebar-divider"></div>
@@ -74,13 +75,19 @@ else
                                AvailableModels="availableModels.ToList()"
                                IsCreating="isCreating"
                                CreateError="@createError"
-                               OnCreate="HandleCreateSession" />
+                               OnCreate="HandleCreateSession"
+                               OnBrowseDirectory="OpenDirectoryPicker" />
         </div>
 
         <div class="sidebar-divider"></div>
         @RenderSortToolbar
         @RenderSessionList
     </div>
+}
+
+@if (showDirectoryPicker)
+{
+    <RemoteDirectoryPicker OnSelected="OnDirectorySelected" OnCancelled="OnDirectoryPickerCancelled" />
 }
 
 @code {
@@ -343,6 +350,7 @@ else
     private bool isAddingGroup = false;
     private string? openMenuSession = null;
     private CreateSessionForm? createSessionFormRef;
+    private bool showDirectoryPicker;
     private List<AgentSessionInfo> sessions = new();
     private List<PersistedSessionInfo> persistedSessions = new();
     private bool showAddRepo = false;
@@ -796,6 +804,25 @@ else
         {
             Console.WriteLine($"Error removing repo: {ex.Message}");
         }
+    }
+
+    private void OpenDirectoryPicker()
+    {
+        showDirectoryPicker = true;
+        StateHasChanged();
+    }
+
+    private void OnDirectorySelected(string path)
+    {
+        showDirectoryPicker = false;
+        createSessionFormRef?.SetDirectory(path);
+        StateHasChanged();
+    }
+
+    private void OnDirectoryPickerCancelled()
+    {
+        showDirectoryPicker = false;
+        StateHasChanged();
     }
 
     public void Dispose()

--- a/PolyPilot/Components/RemoteDirectoryPicker.razor
+++ b/PolyPilot/Components/RemoteDirectoryPicker.razor
@@ -1,0 +1,166 @@
+@using PolyPilot.Models
+@using PolyPilot.Services
+
+<div class="dir-picker-overlay" @onclick="Cancel">
+    <div class="dir-picker" @onclick:stopPropagation="true">
+        <div class="dir-picker-header">
+            <h3>Browse Remote Directory</h3>
+            <button class="dir-close-btn" @onclick="Cancel">✕</button>
+        </div>
+
+        <div class="dir-breadcrumb">
+            @if (pathSegments.Count > 0)
+            {
+                <button class="crumb" @onclick='() => NavigateTo(pathRoot)'>@pathRoot</button>
+                @foreach (var (segment, fullPath) in pathSegments)
+                {
+                    <span class="crumb-sep">/</span>
+                    <button class="crumb" @onclick="() => NavigateTo(fullPath)">@segment</button>
+                }
+            }
+        </div>
+
+        @if (isLoading)
+        {
+            <div class="dir-loading">Loading…</div>
+        }
+        else if (error != null)
+        {
+            <div class="dir-error">@error</div>
+        }
+        else
+        {
+            <div class="dir-list">
+                @if (currentPath != pathRoot)
+                {
+                    <button class="dir-item" @onclick="NavigateUp">
+                        <span class="dir-icon">📁</span>
+                        <span class="dir-name">..</span>
+                    </button>
+                }
+                @if (directories.Count == 0)
+                {
+                    <div class="dir-empty">No subdirectories</div>
+                }
+                @foreach (var dir in directories)
+                {
+                    <button class="dir-item @(dir.IsGitRepo ? "git-repo" : "")" @onclick="() => NavigateTo(CombinePath(currentPath, dir.Name))">
+                        <span class="dir-icon">@(dir.IsGitRepo ? "📦" : "📁")</span>
+                        <span class="dir-name">@dir.Name</span>
+                        @if (dir.IsGitRepo)
+                        {
+                            <span class="dir-badge">repo</span>
+                        }
+                    </button>
+                }
+            </div>
+        }
+
+        <div class="dir-picker-footer">
+            <div class="dir-selected-path">@currentPath</div>
+            <div class="dir-actions">
+                <button class="dir-cancel-btn" @onclick="Cancel">Cancel</button>
+                <button class="dir-select-btn" @onclick="Select" disabled="@isLoading">Select</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback<string> OnSelected { get; set; }
+    [Parameter] public EventCallback OnCancelled { get; set; }
+    [Inject] private CopilotService CopilotService { get; set; } = default!;
+
+    private string currentPath = "";
+    private string pathRoot = "/";
+    private List<(string segment, string fullPath)> pathSegments = new();
+    private List<DirectoryEntry> directories = new();
+    private bool isLoading;
+    private string? error;
+    private bool isCurrentGitRepo;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await NavigateTo(null);
+    }
+
+    private async Task NavigateTo(string? path)
+    {
+        isLoading = true;
+        error = null;
+        StateHasChanged();
+
+        try
+        {
+            var result = await CopilotService.ListRemoteDirectoriesAsync(path);
+            if (result == null)
+            {
+                error = "Not connected to remote server";
+            }
+            else if (result.Error != null)
+            {
+                error = result.Error;
+            }
+            else
+            {
+                currentPath = result.Path;
+                directories = result.Directories;
+                isCurrentGitRepo = result.IsGitRepo;
+                BuildBreadcrumb();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            error = "Request timed out";
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+
+        isLoading = false;
+        StateHasChanged();
+    }
+
+    private void BuildBreadcrumb()
+    {
+        pathSegments.Clear();
+        if (string.IsNullOrEmpty(currentPath)) return;
+
+        // Determine root (e.g., "/" on Unix, "C:\" on Windows)
+        pathRoot = Path.GetPathRoot(currentPath) ?? "/";
+
+        var relative = currentPath[pathRoot.Length..];
+        if (string.IsNullOrEmpty(relative)) return;
+
+        var parts = relative.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+        var accumulated = pathRoot;
+        foreach (var part in parts)
+        {
+            accumulated = CombinePath(accumulated, part);
+            pathSegments.Add((part, accumulated));
+        }
+    }
+
+    private async Task NavigateUp()
+    {
+        var parent = Path.GetDirectoryName(currentPath);
+        if (!string.IsNullOrEmpty(parent))
+            await NavigateTo(parent);
+    }
+
+    private static string CombinePath(string basePath, string child)
+    {
+        return Path.Combine(basePath, child);
+    }
+
+    private async Task Select()
+    {
+        await OnSelected.InvokeAsync(currentPath);
+    }
+
+    private async Task Cancel()
+    {
+        await OnCancelled.InvokeAsync();
+    }
+}

--- a/PolyPilot/Components/RemoteDirectoryPicker.razor.css
+++ b/PolyPilot/Components/RemoteDirectoryPicker.razor.css
@@ -1,0 +1,193 @@
+.dir-picker-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.6);
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+}
+
+.dir-picker {
+    background: var(--bg-secondary);
+    border: 1px solid var(--control-border);
+    border-radius: 12px;
+    width: 100%;
+    max-width: 500px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.dir-picker-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--control-border);
+}
+
+.dir-picker-header h3 {
+    margin: 0;
+    font-size: var(--type-body);
+}
+
+.dir-close-btn {
+    background: none;
+    border: none;
+    color: var(--text-dim);
+    font-size: 1.2rem;
+    cursor: pointer;
+    padding: 0.2rem 0.4rem;
+}
+
+.dir-breadcrumb {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    gap: 0.15rem;
+    overflow-x: auto;
+    white-space: nowrap;
+    border-bottom: 1px solid var(--hover-bg);
+    font-size: var(--type-callout);
+    -webkit-overflow-scrolling: touch;
+}
+
+.crumb {
+    background: none;
+    border: none;
+    color: var(--accent-primary);
+    cursor: pointer;
+    padding: 0.1rem 0.2rem;
+    border-radius: 4px;
+    font-size: inherit;
+    flex-shrink: 0;
+}
+
+.crumb:hover {
+    background: var(--hover-bg);
+}
+
+.crumb-sep {
+    color: var(--text-dim);
+    flex-shrink: 0;
+}
+
+.dir-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.25rem 0;
+    -webkit-overflow-scrolling: touch;
+}
+
+.dir-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.6rem 1rem;
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    font-size: var(--type-callout);
+    cursor: pointer;
+    text-align: left;
+}
+
+.dir-item:hover {
+    background: var(--hover-bg);
+}
+
+.dir-item.git-repo {
+    color: var(--accent-primary);
+}
+
+.dir-icon {
+    flex-shrink: 0;
+    font-size: 1rem;
+}
+
+.dir-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dir-badge {
+    font-size: var(--type-caption1, 0.6rem);
+    background: rgba(78,168,209,0.15);
+    color: var(--accent-primary);
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    flex-shrink: 0;
+}
+
+.dir-empty {
+    padding: 2rem 1rem;
+    text-align: center;
+    color: var(--text-dim);
+    font-size: var(--type-callout);
+}
+
+.dir-loading {
+    padding: 2rem 1rem;
+    text-align: center;
+    color: var(--text-dim);
+}
+
+.dir-error {
+    padding: 1rem;
+    color: #e74c3c;
+    font-size: var(--type-callout);
+}
+
+.dir-picker-footer {
+    border-top: 1px solid var(--control-border);
+    padding: 0.5rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.dir-selected-path {
+    font-size: var(--type-caption1, 0.6rem);
+    color: var(--text-dim);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dir-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+}
+
+.dir-cancel-btn {
+    padding: 0.4rem 1rem;
+    border: 1px solid var(--control-border);
+    border-radius: 8px;
+    background: transparent;
+    color: var(--text-primary);
+    cursor: pointer;
+    font-size: var(--type-callout);
+}
+
+.dir-select-btn {
+    padding: 0.4rem 1rem;
+    border: none;
+    border-radius: 8px;
+    background: var(--accent-primary);
+    color: #fff;
+    cursor: pointer;
+    font-size: var(--type-callout);
+}
+
+.dir-select-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}

--- a/PolyPilot/Models/BridgeMessages.cs
+++ b/PolyPilot/Models/BridgeMessages.cs
@@ -79,6 +79,10 @@ public static class BridgeMessageTypes
     public const string CloseSession = "close_session";
     public const string AbortSession = "abort_session";
     public const string OrganizationCommand = "organization_command";
+    public const string ListDirectories = "list_directories";
+
+    // Server → Client (response)
+    public const string DirectoriesList = "directories_list";
 }
 
 // --- Server → Client payloads ---
@@ -230,4 +234,25 @@ public class OrganizationCommandPayload
     public string? GroupId { get; set; }
     public string? Name { get; set; }
     public string? SortMode { get; set; }
+}
+
+// --- Directory browsing payloads ---
+
+public class ListDirectoriesPayload
+{
+    public string? Path { get; set; }
+}
+
+public class DirectoriesListPayload
+{
+    public string Path { get; set; } = "";
+    public List<DirectoryEntry> Directories { get; set; } = new();
+    public bool IsGitRepo { get; set; }
+    public string? Error { get; set; }
+}
+
+public class DirectoryEntry
+{
+    public string Name { get; set; } = "";
+    public bool IsGitRepo { get; set; }
 }

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -1102,6 +1102,13 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
         OnStateChanged?.Invoke();
     }
 
+    public async Task<DirectoriesListPayload?> ListRemoteDirectoriesAsync(string? path = null, CancellationToken ct = default)
+    {
+        if (!IsRemoteMode || !_bridgeClient.IsConnected)
+            return null;
+        return await _bridgeClient.ListDirectoriesAsync(path, ct);
+    }
+
     public void RemoveQueuedMessage(string sessionName, int index)
     {
         if (!_sessions.TryGetValue(sessionName, out var state))


### PR DESCRIPTION
## Summary
Enables mobile users to browse the remote desktop's filesystem when creating a new session, instead of typing paths manually.

## Changes

### Bridge Protocol
- New `list_directories` (client→server) and `directories_list` (server→client) message types
- `ListDirectoriesPayload`: request with optional path (defaults to home directory)
- `DirectoriesListPayload`: response with subdirectories, git repo flags, and error handling

### Server (`WsBridgeServer`)
- New handler validates paths (absolute only, no `..`, must exist)
- Enumerates non-hidden subdirectories sorted alphabetically
- Detects git repos (`.git` directory) for both current path and each subdirectory
- Handles `UnauthorizedAccessException` gracefully

### Client (`WsBridgeClient`)
- `ListDirectoriesAsync(path)` with `TaskCompletionSource` for request/response correlation
- 10-second timeout with cancellation support

### UI (`RemoteDirectoryPicker.razor`)
- Modal overlay with breadcrumb path navigation
- Tappable directory rows with 📦 icon for git repos
- ".."/up navigation
- Select/Cancel footer with current path display
- Styled to match the app's theme variables

### Wiring
- `SessionSidebar` now passes `OnBrowseDirectory` to `CreateSessionForm`
- On mobile, the "…" browse button opens the remote picker
- Selection feeds back to `CreateSessionForm.SetDirectory()`
- `CopilotService.ListRemoteDirectoriesAsync()` delegates to bridge client in remote mode

### Tests
- Payload round-trip tests for `ListDirectoriesPayload` and `DirectoriesListPayload`
- Error payload serialization test
- Updated type constant uniqueness tests