### PR TITLE
Mobile UX optimizations

### DIFF
--- a/PolyPilot/Components/ExpandedSessionView.razor.css
+++ b/PolyPilot/Components/ExpandedSessionView.razor.css
@@ -419,6 +419,6 @@
     .expanded-card .chat-header { padding: 0.4rem 0.5rem; gap: 0.35rem; }
     .chat-header-title { font-size: var(--type-body); }
     .chat-header-badges { gap: 0.3rem; }
-    .expanded-card .input-area textarea { font-size: var(--type-callout, 0.8rem); }
+    .expanded-card .input-area textarea { font-size: var(--type-callout, 0.8rem); max-height: 30dvh; }
     .input-status-bar { gap: 0.4rem; }
 }

--- a/PolyPilot/Components/Layout/MainLayout.razor.css
+++ b/PolyPilot/Components/Layout/MainLayout.razor.css
@@ -3,6 +3,7 @@
     display: flex;
     flex-direction: column;
     height: 100vh;
+    height: 100dvh;
     overflow: hidden;
 }
 
@@ -102,8 +103,8 @@ main {
         min-width: 240px;
         max-width: 600px;
         height: 100vh;
-        position: sticky;
-        top: 0;
+        height: 100dvh;
+        position: sticky;        top: 0;
         flex-shrink: 0;
         overflow: hidden;
     }

--- a/PolyPilot/Components/Layout/NavMenu.razor.css
+++ b/PolyPilot/Components/Layout/NavMenu.razor.css
@@ -100,6 +100,7 @@
 
         /* Allow sidebar to scroll for tall menus */
         height: calc(100vh - 3.5rem);
+        height: calc(100dvh - 3.5rem);
         overflow-y: auto;
     }
 }

--- a/PolyPilot/Components/Layout/SessionSidebar.razor.css
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor.css
@@ -1084,3 +1084,34 @@
         padding: 0.5rem 0.25rem;
     }
 }
+
+/* Touch devices: show action buttons always, increase tap targets, add active states */
+@media (hover: none) {
+    .close-btn, .resume-btn, .rename-btn {
+        opacity: 1;
+        min-width: 2.75rem;
+        min-height: 2.75rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .close-btn:active {
+        background: rgba(239, 68, 68, 0.3);
+        color: var(--accent-primary);
+    }
+
+    .rename-btn:active,
+    .resume-btn:active {
+        background: rgba(59, 130, 246, 0.3);
+        color: var(--accent-primary);
+    }
+
+    .session-item:active {
+        background: var(--hover-bg);
+    }
+
+    .hamburger-btn:active {
+        background: var(--hover-bg);
+    }
+}

--- a/PolyPilot/Components/Pages/Dashboard.razor.css
+++ b/PolyPilot/Components/Pages/Dashboard.razor.css
@@ -1169,5 +1169,5 @@
     .collapse-card-btn { font-size: var(--type-callout, 0.8rem); padding: 0.15rem 0.35rem; }
     .expanded-card .chat-header { padding: 0.4rem 0.5rem; gap: 0.4rem; }
     .chat-header-title { font-size: var(--type-body); }
-    .expanded-card .input-area textarea { font-size: var(--type-callout, 0.8rem); }
+    .expanded-card .input-area textarea { font-size: var(--type-callout, 0.8rem); max-height: 30dvh; }
 }

--- a/PolyPilot/Components/Pages/Settings.razor.css
+++ b/PolyPilot/Components/Pages/Settings.razor.css
@@ -785,6 +785,10 @@
         flex-wrap: wrap;
     }
 
+    .shortcuts-popover-wrap {
+        display: none;
+    }
+
     .connection-badge {
         font-size: var(--type-footnote);
         padding: 0.25rem 0.6rem;


### PR DESCRIPTION
## Changes

### Fix iOS keyboard viewport overflow
- Replace `100vh` with `100dvh` (dynamic viewport height) in MainLayout and NavMenu
- Keeps `100vh` as fallback for older browsers
- Prevents content being cut off when the on-screen keyboard appears

### Show action buttons on touch devices
- Session close/resume/rename buttons had `opacity: 0` with only `:hover` to  invisible on touchreveal 
- Added `@media (hover: none)` block to always show them on touch devices
- Increased minimum tap target to `2.75rem` (~44px) for comfortable touch interaction

### Touch feedback
- Added `:active` pseudo-class styles on buttons and session items
- Matches existing `:hover` colors for consistent visual language

### Chat textarea height
- Increased `max-height` from `150px` to `30dvh` on mobile
- Better use of screen real estate on tall phones

### Hide keyboard shortcuts on mobile
- Hidden the shortcuts popover trigger on 640pxscreens 
- Keyboard shortcuts aren't useful on touch devices