### PR TITLE
Replace + and × buttons with … menu in group headers

### DIFF
--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -228,21 +228,37 @@ else
                                         <button class="btn-repo-rm cancel" @onclick="() => { confirmRemoveRepoId = null; }">Cancel</button>
                                     </span>
                                 }
-                                else if (isRepoGroup)
-                                {
-                                    var rId = group.RepoId!;
-                                    <button class="group-add-btn" title="New session for this repo"
-                                            @onclick="() => createSessionFormRef?.ExpandForRepo(rId)"
-                                            @onclick:stopPropagation="true">+</button>
-                                    <button class="group-delete-btn" title="Remove repository"
-                                            @onclick="() => { confirmRemoveRepoId = rId; }"
-                                            @onclick:stopPropagation="true">×</button>
-                                }
                                 else
                                 {
-                                    <button class="group-delete-btn" title="Delete group"
-                                            @onclick="() => CopilotService.DeleteGroup(group.Id)"
-                                            @onclick:stopPropagation="true">×</button>
+                                    var gId = group.Id;
+                                    <div class="group-menu-wrapper">
+                                        <button class="group-more-btn" title="More actions"
+                                                @onclick="() => { openGroupMenuId = openGroupMenuId == gId ? null : gId; }"
+                                                @onclick:stopPropagation="true">…</button>
+                                        @if (openGroupMenuId == group.Id)
+                                        {
+                                            <div class="group-menu-overlay" @onclick="() => { openGroupMenuId = null; }" @onclick:stopPropagation="true"></div>
+                                            <div class="group-menu" @onclick:stopPropagation="true">
+                                                @if (isRepoGroup)
+                                                {
+                                                    var rId = group.RepoId!;
+                                                    <button class="group-menu-item" @onclick="() => { openGroupMenuId = null; createSessionFormRef?.ExpandForRepo(rId); }">
+                                                        ➕ New Session
+                                                    </button>
+                                                    <div class="group-menu-separator"></div>
+                                                    <button class="group-menu-item destructive" @onclick="() => { openGroupMenuId = null; confirmRemoveRepoId = rId; }">
+                                                        🗑 Remove Repo
+                                                    </button>
+                                                }
+                                                else
+                                                {
+                                                    <button class="group-menu-item destructive" @onclick="() => { openGroupMenuId = null; CopilotService.DeleteGroup(gId); }">
+                                                        🗑 Delete Group
+                                                    </button>
+                                                }
+                                            </div>
+                                        }
+                                    </div>
                                 }
                             }
                         </div>
@@ -353,6 +369,7 @@ else
     private string currentPage = "/";
     private bool isAddingGroup = false;
     private string? openMenuSession = null;
+    private string? openGroupMenuId = null;
     private CreateSessionForm? createSessionFormRef;
     private bool showDirectoryPicker;
     private List<AgentSessionInfo> sessions = new();

--- a/PolyPilot/Components/Layout/SessionSidebar.razor.css
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor.css
@@ -258,34 +258,71 @@
 }
 @keyframes pulse-dot { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
-.group-delete-btn {
-    all: unset;
+/* Group menu */
+.group-menu-wrapper {
+    position: relative;
     margin-left: auto;
-    font-size: var(--type-callout);
+}
+
+.group-more-btn {
+    all: unset;
+    font-size: var(--type-body);
     color: var(--control-border);
     cursor: pointer;
     padding: 0 0.3rem;
     border-radius: 3px;
     opacity: 0;
     transition: opacity 0.15s;
+    line-height: 1;
+}
+.group-header:hover .group-more-btn { opacity: 1; }
+.group-more-btn:hover { color: var(--text-on-surface); background: var(--hover-bg); }
+
+.group-menu-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 99;
 }
 
-.group-add-btn {
+.group-menu {
+    position: absolute;
+    right: 0;
+    top: 100%;
+    z-index: 100;
+    min-width: 140px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--hover-bg);
+    border-radius: 8px;
+    padding: 0.25rem 0;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+    display: flex;
+    flex-direction: column;
+}
+
+.group-menu-item {
     all: unset;
-    margin-left: auto;
+    display: block;
+    width: 100%;
+    padding: 0.35rem 0.65rem;
     font-size: var(--type-callout);
-    color: var(--control-border);
+    color: var(--text-on-surface);
     cursor: pointer;
-    padding: 0 0.3rem;
-    border-radius: 3px;
-    opacity: 0;
-    transition: opacity 0.15s;
+    white-space: nowrap;
+    box-sizing: border-box;
+}
+.group-menu-item:hover { background: var(--control-border); color: #fff; }
+
+.group-menu-separator {
+    height: 1px;
+    background: var(--hover-bg);
+    margin: 0.2rem 0.5rem;
 }
 
-.group-header:hover .group-add-btn { opacity: 1; }
-.group-add-btn:hover { color: var(--accent-primary); background: var(--control-border); }
-.group-header:hover .group-delete-btn { opacity: 1; }
-.group-delete-btn:hover { color: var(--accent-primary); background: var(--control-border); }
+.group-menu-item.destructive { color: var(--accent-primary); }
+.group-menu-item.destructive:hover { background: var(--control-border); color: var(--accent-primary); }
 
 .repo-remove-confirm {
     display: flex;


### PR DESCRIPTION
## Summary
Replaces the separate `+` (new session) and `×` (delete) buttons in group headers with a single `…` button that opens a dropdown menu.

## Changes
- Replace two action buttons with a unified menu pattern
- Add dropdown menu with 'New Session' and 'Remove Repo/Delete Group' options  
- Match the existing menu pattern used in SessionListItem component
- Add CSS styles for the new group menu

## Before
Two separate buttons: `+` and `×`

## After
Single `…` button that reveals a menu with the same actions