### PR TITLE
Fix Windows CI: create artifacts directory before Compress-Archive

### DIFF
--- a/PolyPilot/PolyPilot.csproj
+++ b/PolyPilot/PolyPilot.csproj
@@ -1,142 +1,138 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
-	<PropertyGroup>
-		<TargetFrameworks>net10.0-android</TargetFrameworks>
-		<TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
+    <PropertyGroup>
+        <TargetFrameworks>net10.0-android</TargetFrameworks>
+        <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 
-		<!-- Note for MacCatalyst:
+        <!-- Note for MacCatalyst:
             The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
             When specifying both architectures, use the plural <RuntimeIdentifiers> instead of the singular <RuntimeIdentifier>.
             The Mac App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;
             either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
-		<!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
+        <!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
 
-		<OutputType>Exe</OutputType>
-		<RootNamespace>PolyPilot</RootNamespace>
-		<UseMaui>true</UseMaui>
-		<MauiVersion>10.0.31</MauiVersion>
-		<SingleProject>true</SingleProject>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<EnableDefaultCssItems>false</EnableDefaultCssItems>
-		<Nullable>enable</Nullable>
+        <OutputType>Exe</OutputType>
+        <RootNamespace>PolyPilot</RootNamespace>
+        <UseMaui>true</UseMaui>
+        <MauiVersion>10.0.31</MauiVersion>
+        <SingleProject>true</SingleProject>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <EnableDefaultCssItems>false</EnableDefaultCssItems>
+        <Nullable>enable</Nullable>
 
-		<!-- Enable XAML source generation for faster build times and improved performance.
+        <!-- Enable XAML source generation for faster build times and improved performance.
              This generates C# code from XAML at compile time instead of runtime inflation.
              To disable, remove this line.
              For individual files, you can override by setting Inflator metadata:
                <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
                <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
-		<MauiXamlInflator>SourceGen</MauiXamlInflator>
+        <MauiXamlInflator>SourceGen</MauiXamlInflator>
 
-		<!-- Display name -->
-		<ApplicationTitle>PolyPilot</ApplicationTitle>
+        <!-- Display name -->
+        <ApplicationTitle>PolyPilot</ApplicationTitle>
 
-		<!-- App Identifier -->
-		<ApplicationId>com.microsoft.PolyPilot</ApplicationId>
+        <!-- App Identifier -->
+        <ApplicationId>com.microsoft.PolyPilot</ApplicationId>
 
-		<!-- Versions -->
-		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-		<ApplicationVersion>1</ApplicationVersion>
+        <!-- Versions -->
+        <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+        <ApplicationVersion>1</ApplicationVersion>
 
-		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
-		<WindowsPackageType>None</WindowsPackageType>
+        <!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
+        <WindowsPackageType>None</WindowsPackageType>
 
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+        <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+    </PropertyGroup>
 
+    <ItemGroup>
+        <!-- App Icon -->
+        <MauiIcon Include="Resources\AppIcon\appicon.png" Color="#0f0f23" />
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-	</PropertyGroup>
+        <!-- Splash Screen -->
+        <MauiSplashScreen Include="Resources\Splash\splash.png" Color="#0d1526" BaseSize="128,128" />
 
+        <!-- Images -->
+        <MauiImage Include="Resources\Images\*" />
+        <MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />
 
+        <!-- Custom Fonts -->
+        <MauiFont Include="Resources\Fonts\*" />
 
-	<ItemGroup>
-		<!-- App Icon -->
-		<MauiIcon Include="Resources\AppIcon\appicon.png" Color="#0f0f23" />
+        <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
+        <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+    </ItemGroup>
 
-		<!-- Splash Screen -->
-		<MauiSplashScreen Include="Resources\Splash\splash.png" Color="#0d1526" BaseSize="128,128" />
+    <ItemGroup>
+        <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.23" />
+        <PackageReference Include="Markdig" Version="0.45.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.2" />
+        <PackageReference Include="sqlite-net-pcl" Version="*" />
+        <PackageReference Include="SQLitePCLRaw.bundle_green" Version="*" />
+        <PackageReference Include="QRCoder" Version="*" />
+        <PackageReference Include="ZXing.Net.Maui.Controls" Version="*" />
+        <PackageReference Include="Redth.MauiDevFlow.Agent" Version="*" />
+        <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="*" />
+    </ItemGroup>
 
-		<!-- Images -->
-		<MauiImage Include="Resources\Images\*" />
-		<MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />
+    <!-- Prevent linker from trimming SDK event types needed for pattern matching -->
+    <ItemGroup>
+        <TrimmerRootAssembly Include="GitHub.Copilot.SDK" RootMode="All" />
+    </ItemGroup>
 
-		<!-- Custom Fonts -->
-		<MauiFont Include="Resources\Fonts\*" />
-
-		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="GitHub.Copilot.SDK" Version="0.1.23" />
-		<PackageReference Include="Markdig" Version="0.45.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.2" />
-		<PackageReference Include="sqlite-net-pcl" Version="*" />
-		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="*" />
-		<PackageReference Include="QRCoder" Version="*" />
-		<PackageReference Include="ZXing.Net.Maui.Controls" Version="*" />
-		<PackageReference Include="Redth.MauiDevFlow.Agent" Version="*" />
-		<PackageReference Include="Redth.MauiDevFlow.Blazor" Version="*" />
-	</ItemGroup>
-
-	<!-- Prevent linker from trimming SDK event types needed for pattern matching -->
-	<ItemGroup>
-		<TrimmerRootAssembly Include="GitHub.Copilot.SDK" RootMode="All" />
-	</ItemGroup>
-
-	<!-- The SDK only maps standard RIDs (osx-arm64, etc.) to download the copilot CLI.
+    <!-- The SDK only maps standard RIDs (osx-arm64, etc.) to download the copilot CLI.
          Mac Catalyst uses maccatalyst-arm64 which the SDK doesn't recognize, so the
          download is silently skipped. Map it to the darwin-arm64 npm package. -->
-	<Target Name="_FixCopilotRidForMacCatalyst" BeforeTargets="_DownloadCopilotCli">
-		<PropertyGroup Condition="'$(_CopilotPlatform)' == '' And $(_CopilotRid.StartsWith('maccatalyst-arm64'))">
-			<_CopilotPlatform>darwin-arm64</_CopilotPlatform>
-			<_CopilotBinary>copilot</_CopilotBinary>
-			<_CopilotOriginalRid>$(_CopilotRid)</_CopilotOriginalRid>
-			<_CopilotRid>osx-arm64</_CopilotRid>
-		</PropertyGroup>
-		<PropertyGroup Condition="'$(_CopilotPlatform)' == '' And '$(_CopilotRid)' == 'maccatalyst-x64'">
-			<_CopilotPlatform>darwin-x64</_CopilotPlatform>
-			<_CopilotBinary>copilot</_CopilotBinary>
-			<_CopilotOriginalRid>$(_CopilotRid)</_CopilotOriginalRid>
-			<_CopilotRid>osx-x64</_CopilotRid>
-		</PropertyGroup>
-	</Target>
+    <Target Name="_FixCopilotRidForMacCatalyst" BeforeTargets="_DownloadCopilotCli">
+        <PropertyGroup Condition="'$(_CopilotPlatform)' == '' And $(_CopilotRid.StartsWith('maccatalyst-arm64'))">
+            <_CopilotPlatform>darwin-arm64</_CopilotPlatform>
+            <_CopilotBinary>copilot</_CopilotBinary>
+            <_CopilotOriginalRid>$(_CopilotRid)</_CopilotOriginalRid>
+            <_CopilotRid>osx-arm64</_CopilotRid>
+        </PropertyGroup>
+        <PropertyGroup Condition="'$(_CopilotPlatform)' == '' And '$(_CopilotRid)' == 'maccatalyst-x64'">
+            <_CopilotPlatform>darwin-x64</_CopilotPlatform>
+            <_CopilotBinary>copilot</_CopilotBinary>
+            <_CopilotOriginalRid>$(_CopilotRid)</_CopilotOriginalRid>
+            <_CopilotRid>osx-x64</_CopilotRid>
+        </PropertyGroup>
+    </Target>
 
-	<!-- The SDK at runtime uses RuntimeInformation.RuntimeIdentifier (maccatalyst-arm64)
+    <!-- The SDK at runtime uses RuntimeInformation.RuntimeIdentifier (maccatalyst-arm64)
          to locate the binary, so also copy it to that path. -->
-	<Target Name="_CopyCopilotCliForMacCatalyst" AfterTargets="_CopyCopilotCliToOutput"
+    <Target Name="_CopyCopilotCliForMacCatalyst" AfterTargets="_CopyCopilotCliToOutput"
             Condition="'$(_CopilotOriginalRid)' != ''">
-		<PropertyGroup>
-			<_CopilotMacCatalystOutputDir>$(OutDir)runtimes/$(_CopilotOriginalRid)/native</_CopilotMacCatalystOutputDir>
-			<_CopilotCacheDir>$(IntermediateOutputPath)copilot-cli/$(CopilotCliVersion)/$(_CopilotPlatform)</_CopilotCacheDir>
-		</PropertyGroup>
-		<MakeDir Directories="$(_CopilotMacCatalystOutputDir)" />
-		<Copy SourceFiles="$(_CopilotCacheDir)/$(_CopilotBinary)"
+        <PropertyGroup>
+            <_CopilotMacCatalystOutputDir>$(OutDir)runtimes/$(_CopilotOriginalRid)/native</_CopilotMacCatalystOutputDir>
+            <_CopilotCacheDir>$(IntermediateOutputPath)copilot-cli/$(CopilotCliVersion)/$(_CopilotPlatform)</_CopilotCacheDir>
+        </PropertyGroup>
+        <MakeDir Directories="$(_CopilotMacCatalystOutputDir)" />
+        <Copy SourceFiles="$(_CopilotCacheDir)/$(_CopilotBinary)"
               DestinationFolder="$(_CopilotMacCatalystOutputDir)"
               SkipUnchangedFiles="true" />
-	</Target>
+    </Target>
 
-	<!-- Ensure the copilot CLI binary is included in the Mac Catalyst .app bundle.
+    <!-- Ensure the copilot CLI binary is included in the Mac Catalyst .app bundle.
          MAUI flattens everything into MonoBundle, so runtimes/ paths don't work.
          Copy the binary directly into the .app bundle's MonoBundle. -->
-	<Target Name="_IncludeCopilotCliInBundle" AfterTargets="Build"
+    <Target Name="_IncludeCopilotCliInBundle" AfterTargets="Build"
             Condition="'$(_CopilotOriginalRid)' != ''">
-		<PropertyGroup>
-			<_CopilotCacheDir>$(IntermediateOutputPath)copilot-cli/$(CopilotCliVersion)/$(_CopilotPlatform)</_CopilotCacheDir>
-			<_AppBundleMonoBundle>$(OutDir)PolyPilot.app/Contents/MonoBundle</_AppBundleMonoBundle>
-		</PropertyGroup>
-		<Copy SourceFiles="$(_CopilotCacheDir)/$(_CopilotBinary)"
+        <PropertyGroup>
+            <_CopilotCacheDir>$(IntermediateOutputPath)copilot-cli/$(CopilotCliVersion)/$(_CopilotPlatform)</_CopilotCacheDir>
+            <_AppBundleMonoBundle>$(OutDir)PolyPilot.app/Contents/MonoBundle</_AppBundleMonoBundle>
+        </PropertyGroup>
+        <Copy SourceFiles="$(_CopilotCacheDir)/$(_CopilotBinary)"
               DestinationFolder="$(_AppBundleMonoBundle)"
               SkipUnchangedFiles="true"
               Condition="Exists('$(_AppBundleMonoBundle)')" />
-		<Message Importance="high" Text="Copied copilot CLI binary to app bundle MonoBundle"
+        <Message Importance="high" Text="Copied copilot CLI binary to app bundle MonoBundle"
                  Condition="Exists('$(_AppBundleMonoBundle)')" />
-	</Target>
+    </Target>
 
 </Project>


### PR DESCRIPTION
## Summary
- Uncomments the Windows CI job
- Fixes the 'Create ZIP archive' step by adding \New-Item -ItemType Directory -Force -Path ./artifacts\ before \Compress-Archive\
- Re-enables Windows artifact in release workflow

## Root Cause
The previous CI failure was because \Compress-Archive\ doesn't auto-create parent directories, and \./artifacts\ didn't exist.