### PR TITLE
Add mode-linked panel markup and styles

### DIFF
--- a/PolyPilot/Components/Pages/Settings.razor
+++ b/PolyPilot/Components/Pages/Settings.razor
@@ -51,7 +51,7 @@
 
     @if (PlatformHelper.AvailableModes.Length > 1)
     {
-        <div class="settings-section @(SectionVisible("transport mode embedded persistent remote") ? "" : "search-hidden")">
+        <div class="settings-section @(SectionVisible("transport mode embedded persistent remote") ? "" : "search-hidden") @((settings.Mode == ConnectionMode.Remote || (PlatformHelper.IsDesktop && (settings.Mode == ConnectionMode.Embedded || settings.Mode == ConnectionMode.Persistent))) ? "mode-linked-root" : "")">
             <h3>Transport Mode</h3>
             <div class="mode-cards">
                 @foreach (var mode in PlatformHelper.AvailableModes)
@@ -69,7 +69,7 @@
 
     @if (settings.Mode == ConnectionMode.Persistent)
     {
-        <div class="settings-section @(SectionVisible("persistent server port start stop pid") ? "" : "search-hidden")">
+        <div class="mode-linked-panel @(SectionVisible("persistent server port start stop pid") ? "" : "search-hidden")">
             <h3>Persistent Server</h3>
             <div class="server-controls">
                 <div class="server-status">
@@ -103,7 +103,7 @@
 
     @if (PlatformHelper.IsDesktop && (settings.Mode == ConnectionMode.Embedded || settings.Mode == ConnectionMode.Persistent))
     {
-        <div class="settings-section @(SectionVisible("devtunnel share tunnel remote mobile qr") ? "" : "search-hidden")">
+        <div class="mode-linked-panel @(SectionVisible("devtunnel share tunnel remote mobile qr") ? "" : "search-hidden")">
             <h3>Share via DevTunnel</h3>
                 @if (!devTunnelAvailable)
                 {
@@ -182,7 +182,7 @@
 
     @if (PlatformHelper.IsDesktop && (settings.Mode == ConnectionMode.Embedded || settings.Mode == ConnectionMode.Persistent))
     {
-        <div class="settings-section @(SectionVisible("direct connection sharing tailscale lan password qr") ? "" : "search-hidden")">
+        <div class="mode-linked-panel mode-linked-last @(SectionVisible("direct connection sharing tailscale lan password qr") ? "" : "search-hidden")">
             <h3>Direct Connection</h3>
             <div class="tunnel-controls">
                 <p class="mode-hint">Share your server directly over LAN, Tailscale, or VPN — no DevTunnel needed.</p>
@@ -244,7 +244,7 @@
 
     @if (settings.Mode == ConnectionMode.Remote)
     {
-        <div class="settings-section @(SectionVisible("remote server url token connect") ? "" : "search-hidden")">
+        <div class="mode-linked-panel mode-linked-last @(SectionVisible("remote server url token connect") ? "" : "search-hidden")">
             <h3>Remote Server</h3>
             <div class="remote-controls">
                 <p class="mode-hint">Connect to a Copilot server running on another machine (via DevTunnel URL).</p>

--- a/PolyPilot/Components/Pages/Settings.razor.css
+++ b/PolyPilot/Components/Pages/Settings.razor.css
@@ -148,6 +148,34 @@
     word-break: break-word;
 }
 
+.settings-section.mode-linked-root {
+    margin-bottom: 0;
+    border-radius: 12px 12px 0 0;
+    border-bottom: none;
+}
+
+.mode-linked-panel {
+    background: var(--bg-input);
+    border: 1px solid var(--control-bg);
+    border-top: none;
+    border-radius: 0;
+    padding: 1.1rem 1.25rem 1.25rem;
+    margin-bottom: 0;
+    overflow: hidden;
+    word-break: break-word;
+}
+
+.mode-linked-panel.mode-linked-last {
+    border-radius: 0 0 12px 12px;
+    margin-bottom: 1rem;
+}
+
+.mode-linked-panel h3 {
+    margin: 0 0 1rem 0;
+    font-size: var(--type-title2);
+    color: var(--text-bright);
+}
+
 .settings-section h3 {
     margin: 0 0 1rem 0;
     font-size: var(--type-title2);
@@ -866,7 +894,28 @@
         border-radius: 10px;
     }
 
+    .settings-section.mode-linked-root {
+        margin-bottom: 0;
+        border-radius: 10px 10px 0 0;
+    }
+
+    .mode-linked-panel {
+        padding: 0.75rem;
+        margin-bottom: 0;
+        border-radius: 0;
+    }
+
+    .mode-linked-panel.mode-linked-last {
+        margin-bottom: 0.6rem;
+        border-radius: 0 0 10px 10px;
+    }
+
     .settings-section h3 {
+        font-size: var(--type-body);
+        margin-bottom: 0.6rem;
+    }
+
+    .mode-linked-panel h3 {
         font-size: var(--type-body);
         margin-bottom: 0.6rem;
     }


### PR DESCRIPTION
Visually group transport-related settings when modes are linked. Update Settings.razor to add a conditional "mode-linked-root" class on the Transport Mode section and replace several settings-section wrappers with "mode-linked-panel" (and "mode-linked-last" where appropriate). Add corresponding CSS rules for .mode-linked-root, .mode-linked-panel, and .mode-linked-panel.mode-linked-last, including desktop responsive variants, to control borders, padding, and rounded corners so linked panels appear as a single cohesive block.