### PR TITLE
Improve Settings panel first-render latency

### DIFF
--- a/PolyPilot/Components/Pages/Settings.razor
+++ b/PolyPilot/Components/Pages/Settings.razor
@@ -479,10 +479,7 @@
     protected override void OnInitialized()
     {
         settings = ConnectionSettings.Load();
-        cliInfo = CopilotService.GetCliSourceInfo();
         _initialCliSource = settings.CliSource;
-        serverAlive = ServerManager.CheckServerRunning("localhost", settings.Port);
-        devTunnelAvailable = DevTunnelService.IsCliAvailable();
         DevTunnelService.OnStateChanged += OnTunnelStateChanged;
         GitAutoUpdate.OnStateChanged += OnAutoUpdateStateChanged;
 
@@ -504,11 +501,6 @@
 
     private async Task InitializeAfterRenderAsync()
     {
-        if (devTunnelAvailable)
-        {
-            tunnelLoggedIn = await DevTunnelService.IsLoggedInAsync();
-            await InvokeAsync(StateHasChanged);
-        }
         _selfRef = DotNetObjectReference.Create(this);
         await JS.InvokeVoidAsync("eval", "window.__setSettingsRef = function(ref) { window.__settingsRef = ref; };");
         await JS.InvokeVoidAsync("__setSettingsRef", _selfRef);
@@ -527,13 +519,15 @@
                 });
             })()");
 
-        // Run slow detection tasks in parallel
+        // Run slow detection tasks in parallel (after first paint)
+        var cliInfoTask = Task.Run(CopilotService.GetCliSourceInfo);
         var tasks = new List<Task>();
         tasks.Add(Task.Run(() => { serverAlive = ServerManager.CheckServerRunning("localhost", settings.Port); }));
         tasks.Add(Task.Run(() => { devTunnelAvailable = DevTunnelService.IsCliAvailable(); }));
         tasks.Add(Task.Run(() => { DiscoverLocalIps(); }));
         tasks.Add(TailscaleService.DetectAsync());
         await Task.WhenAll(tasks);
+        cliInfo = await cliInfoTask;
 
         if (devTunnelAvailable)
             tunnelLoggedIn = await DevTunnelService.IsLoggedInAsync();


### PR DESCRIPTION
Reduce perceived load time of the Settings page by removing synchronous startup checks from OnInitialized and deferring them until after first paint.

Changes made:\n- Removed blocking calls from OnInitialized: CopilotService.GetCliSourceInfo(), ServerManager.CheckServerRunning(), and DevTunnelService.IsCliAvailable().\n- Kept event subscriptions and existing state wiring in place.\n- Updated InitializeAfterRenderAsync to run the expensive checks asynchronously after first render.\n- Added cliInfoTask to run CLI source/version probing in parallel with other detection tasks, then applied the result once tasks complete.\n- Preserved existing behavior for tunnel login checks and UI state refreshes after async initialization.

Validation:\n- dotnet build -f net10.0-maccatalyst\n- dotnet test (PolyPilot.Tests): 214 passed, 0 failed