### PR TITLE
Fix popup readability on light themes and update shortcuts list

### DIFF
--- a/PolyPilot/Components/ExpandedSessionView.razor.css
+++ b/PolyPilot/Components/ExpandedSessionView.razor.css
@@ -39,14 +39,14 @@
     position: absolute;
     top: calc(100% + 4px);
     right: -0.5rem;
-    background: var(--bg-elevated, #1e1e2e);
-    border: 1px solid var(--control-border, #45475a);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--control-border);
     border-radius: 8px;
     padding: 0.5rem 0;
     min-width: 220px;
     max-width: 400px;
     z-index: 200;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+    box-shadow: 0 8px 24px rgba(0,0,0,0.25);
     opacity: 0;
     pointer-events: none;
     transform: translateY(-4px);
@@ -73,22 +73,22 @@
     padding: 0.3rem 0.75rem;
     font-size: 0.72rem;
 }
-.info-label { color: var(--text-muted, #6c7086); white-space: nowrap; }
-.info-value { color: var(--text-primary, #cdd6f4); text-align: right; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 260px; }
+.info-label { color: var(--text-muted); white-space: nowrap; }
+.info-value { color: var(--text-primary); text-align: right; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 260px; }
 .info-action {
     display: block;
     width: calc(100% - 1rem);
     margin: 0.3rem 0.5rem 0.15rem;
     padding: 0.3rem 0.5rem;
     font-size: 0.72rem;
-    background: var(--hover-bg, rgba(255,255,255,0.05));
+    background: var(--hover-bg);
     border: none;
     border-radius: 4px;
-    color: var(--text-secondary, #a6adc8);
+    color: var(--text-secondary);
     cursor: pointer;
     text-align: left;
 }
-.info-action:hover { background: var(--active-bg, rgba(255,255,255,0.1)); color: var(--text-primary); }
+.info-action:hover { background: var(--control-bg); color: var(--text-primary); }
 
 /* Icon-only badges with hover tooltip */
 .icon-badge {
@@ -107,9 +107,9 @@
     left: auto;
     right: 0;
     transform: none;
-    background: var(--bg-elevated, #1e1e2e);
-    color: var(--text-primary, #cdd6f4);
-    border: 1px solid var(--control-border, #45475a);
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--control-border);
     border-radius: 6px;
     padding: 0.35rem 0.6rem;
     font-size: 0.7rem;
@@ -118,7 +118,7 @@
     opacity: 0;
     transition: opacity 0.15s;
     z-index: 100;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
 }
 .icon-badge:hover::after { opacity: 1; }
 .model-badge { padding: 0.2rem 0.5rem; background: var(--hover-bg); border: 1px solid var(--border-accent); border-radius: 4px; font-size: var(--type-body); color: var(--accent-primary); line-height: 1.2; }

--- a/PolyPilot/Components/Pages/Dashboard.razor.css
+++ b/PolyPilot/Components/Pages/Dashboard.razor.css
@@ -1209,10 +1209,10 @@
         align-items: stretch;
         gap: 0.35rem;
         background: var(--bg-tertiary);
-        border: 1px solid var(--hover-bg);
+        border: 1px solid var(--control-border);
         border-radius: 8px;
         padding: 0.5rem;
-        box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+        box-shadow: 0 4px 16px rgba(0,0,0,0.25);
         z-index: 100;
         min-width: 160px;
     }

--- a/PolyPilot/Components/Pages/Settings.razor
+++ b/PolyPilot/Components/Pages/Settings.razor
@@ -35,10 +35,13 @@
                         @if (PlatformHelper.IsDesktop)
                         {
                             <div class="info-divider"></div>
+                            <div class="info-row"><span class="info-label">⌘1-9</span><span class="info-value">Switch session</span></div>
                             <div class="info-row"><span class="info-label">⌘E</span><span class="info-value">Expand/collapse</span></div>
                             <div class="info-row"><span class="info-label">Esc</span><span class="info-value">Collapse to grid</span></div>
                             <div class="info-row"><span class="info-label">Tab</span><span class="info-value">Next session</span></div>
-                            <div class="info-row"><span class="info-label">A−/A+</span><span class="info-value">Font size</span></div>
+                            <div class="info-row"><span class="info-label">⌘+/−/0</span><span class="info-value">Font size</span></div>
+                            <div class="info-row"><span class="info-label">Ctrl+C</span><span class="info-value">Interrupt</span></div>
+                            <div class="info-row"><span class="info-label">↑/↓</span><span class="info-value">History</span></div>
                         }
                     </div>
                 </div>

--- a/PolyPilot/Components/Pages/Settings.razor.css
+++ b/PolyPilot/Components/Pages/Settings.razor.css
@@ -87,13 +87,13 @@
     position: absolute;
     top: calc(100% + 4px);
     right: 0;
-    background: var(--bg-elevated, #1e1e2e);
-    border: 1px solid var(--control-border, #45475a);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--control-border);
     border-radius: 8px;
     padding: 0.5rem 0;
     min-width: 180px;
     z-index: 200;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+    box-shadow: 0 8px 24px rgba(0,0,0,0.25);
     opacity: 0;
     pointer-events: none;
     transform: translateY(-4px);
@@ -119,9 +119,9 @@
     padding: 0.3rem 0.75rem;
     font-size: 0.72rem;
 }
-.info-label { color: var(--text-muted, #6c7086); white-space: nowrap; }
-.info-value { color: var(--text-primary, #cdd6f4); }
-.info-divider { height: 1px; background: var(--control-border, #45475a); margin: 0.25rem 0.75rem; }
+.info-label { color: var(--text-muted); white-space: nowrap; }
+.info-value { color: var(--text-primary); }
+.info-divider { height: 1px; background: var(--control-border); margin: 0.25rem 0.75rem; }
 
 .badge-dot {
     width: 8px;


### PR DESCRIPTION
## Summary
Fixes popup/tooltip colors that were unreadable on light themes, and updates the keyboard shortcuts list to be complete.

## Changes

### Light Theme Fixes
- **Settings.razor.css**: Replace hardcoded dark colors (`#1e1e2e`, `#45475a`, etc.) with CSS variables (`var(--bg-tertiary)`, `var(--control-border)`, etc.)
- **ExpandedSessionView.razor.css**: Fix info-panel and icon-badge tooltip colors
- **Dashboard.razor.css**: Fix toolbar-controls border color

### Shortcuts List Update
Updated Settings page shortcuts from 4 to 7 items:
- ⌘1-9 → Switch session
- ⌘E → Expand/collapse
- Esc → Collapse to grid
- Tab → Next session
- ⌘+/−/0 → Font size
- Ctrl+C → Interrupt
- ↑/↓ → History