### PR TITLE
Add agent discovery and agents popup

### DIFF
--- a/PolyPilot/Components/ExpandedSessionView.razor
+++ b/PolyPilot/Components/ExpandedSessionView.razor
@@ -141,6 +141,11 @@
                 <span class="status-sep">·</span>
                 <span class="skills-trigger" @onclick="ShowSkillsPopup">@availableSkills.Count skills</span>
             }
+            @if (availableAgents?.Count > 0)
+            {
+                <span class="status-sep">·</span>
+                <span class="skills-trigger" @onclick="ShowAgentsPopup">@availableAgents.Count agents</span>
+            }
             <span class="status-sep">·</span>
             <select class="inline-model-select" value="@CurrentModel" @onchange="e => OnSetModel.InvokeAsync(e.Value?.ToString())" disabled="@Session.IsProcessing" title="@(Session.IsProcessing ? "Wait for response to complete" : "Switch model")">
                 @if (!AvailableModels.Contains(CurrentModel))
@@ -258,6 +263,7 @@
         name.Length <= maxLen ? name : name[..maxLen] + "…";
 
     private List<SkillInfo>? availableSkills;
+    private List<AgentInfo>? availableAgents;
     private string? _lastSkillSessionName;
 
     protected override void OnParametersSet()
@@ -266,6 +272,7 @@
         {
             _lastSkillSessionName = Session.Name;
             availableSkills = CopilotService.DiscoverAvailableSkills(Session.WorkingDirectory);
+            availableAgents = CopilotService.DiscoverAvailableAgents(Session.WorkingDirectory);
         }
     }
 
@@ -290,6 +297,44 @@
                 if(old) old.remove();
                 var trigger = document.querySelector('[class*=""skills-trigger""]');
                 var rect = trigger ? trigger.getBoundingClientRect() : {{left:20,bottom:60}};
+                var ov = document.createElement('div');
+                ov.id = 'skills-popup-overlay';
+                ov.style.cssText = 'position:fixed;inset:0;z-index:9998;background:rgba(0,0,0,0.3)';
+                ov.onclick = function(){{ ov.remove(); }};
+                var popup = document.createElement('div');
+                var left = Math.max(8, Math.min(rect.left, window.innerWidth - 368));
+                var bottom = window.innerHeight - rect.top + 8;
+                popup.style.cssText = 'position:fixed;bottom:'+bottom+'px;left:'+left+'px;z-index:9999;background:#1e1e2e;border:1px solid #45475a;border-radius:10px;padding:6px 0;min-width:240px;max-width:360px;max-height:50vh;overflow-y:auto;box-shadow:0 -4px 20px rgba(0,0,0,0.5)';
+                popup.innerHTML = '{headerHtml}{jsHtml}';
+                popup.onclick = function(e){{ e.stopPropagation(); }};
+                ov.appendChild(popup);
+                document.body.appendChild(ov);
+            }})()
+        ");
+    }
+
+    private async Task ShowAgentsPopup()
+    {
+        if (availableAgents == null || availableAgents.Count == 0) return;
+        var rows = string.Join("", availableAgents.Select(a =>
+        {
+            var desc = string.IsNullOrWhiteSpace(a.Description) ? "" :
+                $"<div style=\"font-size:13px;color:#a6adc8;margin-top:3px;line-height:1.4\">{EscapeHtml(TruncateDesc(a.Description))}</div>";
+            return $"<div style=\"padding:8px 14px;border-bottom:1px solid #313244\">" +
+                $"<div style=\"display:flex;justify-content:space-between;align-items:center;font-size:15px\">" +
+                $"<span style=\"color:#cdd6f4;font-weight:600\">{EscapeHtml(a.Name)}</span>" +
+                $"<span style=\"font-size:11px;color:#6c7086;background:rgba(255,255,255,0.05);padding:2px 8px;border-radius:3px;white-space:nowrap;margin-left:8px\">{EscapeHtml(a.Source)}</span></div>" +
+                desc + "</div>";
+        }));
+        var jsHtml = EscapeForJs(rows);
+        var headerHtml = EscapeForJs("<div style=\"padding:8px 14px;font-size:13px;color:#6c7086;border-bottom:1px solid #313244;font-weight:600\">Available Agents</div>");
+        await JS.InvokeVoidAsync("eval", $@"
+            (function(){{
+                var old = document.getElementById('skills-popup-overlay');
+                if(old) old.remove();
+                var trigger = document.querySelectorAll('[class*=""skills-trigger""]');
+                var el = trigger.length > 1 ? trigger[1] : trigger[0];
+                var rect = el ? el.getBoundingClientRect() : {{left:20,bottom:60}};
                 var ov = document.createElement('div');
                 ov.id = 'skills-popup-overlay';
                 ov.style.cssText = 'position:fixed;inset:0;z-index:9998;background:rgba(0,0,0,0.3)';


### PR DESCRIPTION
Show available agents in the expanded session UI and add backend discovery logic. ExpandedSessionView now displays an agents count next to skills and provides a ShowAgentsPopup that renders a styled popup with agent name, source and truncated description. CopilotService gains DiscoverAvailableAgents which scans project agent directories (.github/agents, .claude/agents, .copilot/agents) for Markdown files, reusing the existing frontmatter parser and populating AgentInfo records while deduplicating names and catching errors. Adds AgentInfo record and safe directory/file handling.