### PR TITLE
Update NuGet packages: Copilot SDK, MauiDevFlow, coverlet

### DIFF
--- a/PolyPilot.Console/PolyPilot.csproj
+++ b/PolyPilot.Console/PolyPilot.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.23" />
+    <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.24-preview.0" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />
   </ItemGroup>
 

--- a/PolyPilot.Tests/PolyPilot.Tests.csproj
+++ b/PolyPilot.Tests/PolyPilot.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/PolyPilot/PolyPilot.csproj
+++ b/PolyPilot/PolyPilot.csproj
@@ -68,7 +68,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.23" />
+        <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.24-preview.0" />
         <PackageReference Include="Markdig" Version="0.45.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
@@ -77,8 +77,8 @@
         <PackageReference Include="SQLitePCLRaw.bundle_green" Version="*" />
         <PackageReference Include="QRCoder" Version="*" />
         <PackageReference Include="ZXing.Net.Maui.Controls" Version="*" />
-        <PackageReference Include="Redth.MauiDevFlow.Agent" Version="0.8.0" />
-        <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="0.8.0" />
+        <PackageReference Include="Redth.MauiDevFlow.Agent" Version="0.8.1" />
+        <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="0.8.1" />
     </ItemGroup>
 
     <!-- Prevent linker from trimming SDK event types needed for pattern matching -->


### PR DESCRIPTION
## NuGet Package Updates

| Package | From | To |
|---------|------|----|
| GitHub.Copilot.SDK (PolyPilot + Console) | 0.1.23 | 0.1.24-preview.0 |
| Redth.MauiDevFlow.Agent | 0.8.0 | 0.8.1 |
| Redth.MauiDevFlow.Blazor | 0.8.0 | 0.8.1 |
| coverlet.collector (Tests) | 6.0.4 | 8.0.0 |

Build succeeds and all 237 tests pass.