### PR TITLE
Add Image viewer overlay and fix max-width of images in chat

### DIFF
--- a/PolyPilot/Components/ChatMessageList.razor.css
+++ b/PolyPilot/Components/ChatMessageList.razor.css
@@ -320,6 +320,7 @@
     max-width: 100%;
     max-height: 400px;
     border-radius: 6px;
+    cursor: pointer;
 }
 
 /* === Action Box (unified command + output container) === */
@@ -463,6 +464,7 @@
     max-width: 100%;
     max-height: 300px;
     border-radius: 4px;
+    cursor: pointer;
 }
 
 /* Legacy action-item styles kept for backwards compatibility */
@@ -547,6 +549,7 @@
     max-width: 100%;
     max-height: 300px;
     border-radius: 4px;
+    cursor: pointer;
 }
 
 ::deep .task-complete-card {
@@ -614,6 +617,7 @@
     max-width: 100%;
     height: auto;
     border-radius: 6px;
+    cursor: pointer;
 }
 
 ::deep .markdown-body a { color: var(--accent-primary); }

--- a/PolyPilot/wwwroot/app.css
+++ b/PolyPilot/wwwroot/app.css
@@ -437,3 +437,54 @@ h1:focus {
         transform: translateY(0);
     }
 }
+
+/* === Full-screen image viewer overlay === */
+.image-viewer-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    background: rgba(0,0,0,0.88);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: zoom-out;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    -webkit-user-select: none;
+    user-select: none;
+    touch-action: none;
+}
+.image-viewer-overlay.visible { opacity: 1; }
+.image-viewer-overlay img {
+    max-width: 90vw;
+    max-height: 90vh;
+    object-fit: contain;
+    border-radius: 4px;
+    cursor: grab;
+    transform-origin: 0 0;
+    transition: none;
+    will-change: transform;
+    pointer-events: auto;
+}
+.image-viewer-overlay img.grabbing { cursor: grabbing; }
+.image-viewer-close {
+    position: absolute;
+    top: env(safe-area-inset-top, 12px);
+    right: 16px;
+    margin-top: 12px;
+    width: 36px;
+    height: 36px;
+    border: none;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.15);
+    color: #fff;
+    font-size: 1.25rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    z-index: 10001;
+}
+.image-viewer-close:hover { background: rgba(255,255,255,0.3); }

--- a/PolyPilot/wwwroot/index.html
+++ b/PolyPilot/wwwroot/index.html
@@ -606,6 +606,136 @@
         };
 
         window.ensureFiestaMentionAutocomplete();
+
+        // === Full-screen image viewer with zoom/pan ===
+        (function() {
+            var overlay, img, closeBtn;
+            var scale = 1, panX = 0, panY = 0, dragging = false, startX, startY, startPanX, startPanY;
+            var pinchStartDist = 0, pinchStartScale = 1;
+
+            function create() {
+                overlay = document.createElement('div');
+                overlay.className = 'image-viewer-overlay';
+                closeBtn = document.createElement('button');
+                closeBtn.className = 'image-viewer-close';
+                closeBtn.innerHTML = '✕';
+                closeBtn.addEventListener('click', function(e) { e.stopPropagation(); close(); });
+                img = document.createElement('img');
+                overlay.appendChild(closeBtn);
+                overlay.appendChild(img);
+                overlay.addEventListener('click', function(e) { if (e.target === overlay) close(); });
+                img.addEventListener('click', function(e) { e.stopPropagation(); });
+
+                // Mouse zoom
+                overlay.addEventListener('wheel', function(e) {
+                    e.preventDefault();
+                    var rect = img.getBoundingClientRect();
+                    var mx = e.clientX - rect.left, my = e.clientY - rect.top;
+                    var oldScale = scale;
+                    scale *= e.deltaY < 0 ? 1.15 : 1/1.15;
+                    scale = Math.max(0.5, Math.min(scale, 20));
+                    panX -= mx * (scale - oldScale);
+                    panY -= my * (scale - oldScale);
+                    applyTransform();
+                }, { passive: false });
+
+                // Mouse drag
+                img.addEventListener('mousedown', function(e) {
+                    if (e.button !== 0) return;
+                    e.preventDefault();
+                    dragging = true; startX = e.clientX; startY = e.clientY;
+                    startPanX = panX; startPanY = panY;
+                    img.classList.add('grabbing');
+                });
+                document.addEventListener('mousemove', function(e) {
+                    if (!dragging) return;
+                    panX = startPanX + (e.clientX - startX);
+                    panY = startPanY + (e.clientY - startY);
+                    applyTransform();
+                });
+                document.addEventListener('mouseup', function() {
+                    dragging = false;
+                    if (img) img.classList.remove('grabbing');
+                });
+
+                // Touch pinch-to-zoom + pan
+                overlay.addEventListener('touchstart', function(e) {
+                    if (e.touches.length === 2) {
+                        e.preventDefault();
+                        pinchStartDist = getTouchDist(e.touches);
+                        pinchStartScale = scale;
+                    } else if (e.touches.length === 1 && e.target === img) {
+                        dragging = true;
+                        startX = e.touches[0].clientX; startY = e.touches[0].clientY;
+                        startPanX = panX; startPanY = panY;
+                    }
+                }, { passive: false });
+                overlay.addEventListener('touchmove', function(e) {
+                    if (e.touches.length === 2) {
+                        e.preventDefault();
+                        var dist = getTouchDist(e.touches);
+                        scale = pinchStartScale * (dist / pinchStartDist);
+                        scale = Math.max(0.5, Math.min(scale, 20));
+                        applyTransform();
+                    } else if (e.touches.length === 1 && dragging) {
+                        e.preventDefault();
+                        panX = startPanX + (e.touches[0].clientX - startX);
+                        panY = startPanY + (e.touches[0].clientY - startY);
+                        applyTransform();
+                    }
+                }, { passive: false });
+                overlay.addEventListener('touchend', function(e) {
+                    if (e.touches.length < 2) { pinchStartDist = 0; }
+                    if (e.touches.length === 0) { dragging = false; }
+                });
+
+                document.body.appendChild(overlay);
+            }
+
+            function getTouchDist(touches) {
+                var dx = touches[0].clientX - touches[1].clientX;
+                var dy = touches[0].clientY - touches[1].clientY;
+                return Math.sqrt(dx*dx + dy*dy);
+            }
+
+            function applyTransform() {
+                img.style.transform = 'translate(' + panX + 'px,' + panY + 'px) scale(' + scale + ')';
+            }
+
+            function open(src) {
+                if (!overlay) create();
+                scale = 1; panX = 0; panY = 0;
+                img.style.transform = '';
+                img.src = src;
+                overlay.style.display = 'flex';
+                requestAnimationFrame(function() { overlay.classList.add('visible'); });
+            }
+
+            function close() {
+                if (!overlay) return;
+                overlay.classList.remove('visible');
+                setTimeout(function() { overlay.style.display = 'none'; img.src = ''; }, 200);
+            }
+
+            // Escape key to close
+            document.addEventListener('keydown', function(e) {
+                if (e.key === 'Escape' && overlay && overlay.style.display === 'flex') {
+                    e.preventDefault(); e.stopPropagation(); close();
+                }
+            }, true);
+
+            // Delegated click on chat images
+            document.addEventListener('click', function(e) {
+                var t = e.target;
+                if (t.tagName !== 'IMG') return;
+                if (t.closest('.markdown-body') || t.closest('.tool-image-result') || t.closest('.action-output') || t.closest('.action-expanded-result')) {
+                    e.preventDefault(); e.stopPropagation();
+                    open(t.src);
+                }
+            });
+
+            window.__imageViewer = { open: open, close: close };
+        })();
     </script>
 
 </body>


### PR DESCRIPTION
This pull request introduces a full-screen image viewer with zoom and pan capabilities for images within chat messages. It includes both the necessary JavaScript logic and supporting CSS, as well as minor style adjustments to improve image interactivity in the chat interface.

**New full-screen image viewer:**

* Added a JavaScript module in `index.html` that enables users to click images in chat messages to open them in a full-screen overlay with support for zoom (mouse wheel or pinch), pan (drag), and keyboard escape to close.
* Added CSS styles in `app.css` for the `.image-viewer-overlay` and related elements to provide proper overlay appearance, transitions, and controls for the image viewer.

**Chat image interactivity and styling improvements:**

* Updated `ChatMessageList.razor.css` to add `cursor: pointer` to images and image containers, signaling interactivity and matching the new viewer behavior. [[1]](diffhunk://#diff-b767b7376b12684a306856211c367504c8d6b3d5d8957be467a8bc86626cd6daR323) [[2]](diffhunk://#diff-b767b7376b12684a306856211c367504c8d6b3d5d8957be467a8bc86626cd6daR467) [[3]](diffhunk://#diff-b767b7376b12684a306856211c367504c8d6b3d5d8957be467a8bc86626cd6daR552)
* Enhanced `.markdown-body img` styles to ensure images are responsive, have rounded corners, and display a pointer cursor, improving both aesthetics and usability.