### PR TITLE
Increase avatar size and update chat styles

### DIFF
--- a/PolyPilot/Components/ChatMessageItem.razor
+++ b/PolyPilot/Components/ChatMessageItem.razor
@@ -12,7 +12,7 @@
                 <div class="chat-msg-avatar">
                     @if (!string.IsNullOrEmpty(UserAvatarUrl))
                     {
-                        <img src="@UserAvatarUrl" width="22" height="22" alt="You" class="user-avatar-img" />
+                        <img src="@UserAvatarUrl" width="36" height="36" alt="You" class="user-avatar-img" />
                     }
                     else
                     {
@@ -38,7 +38,7 @@
         <div class="chat-msg assistant @(IsStreaming ? "streaming" : "")">
             @if (!Compact)
             {
-                <div class="chat-msg-avatar"><img src="PolyPilot_logo.png" width="22" height="22" alt="PolyPilot" /></div>
+                <div class="chat-msg-avatar"><img src="PolyPilot_logo.png" width="36" height="36" alt="PolyPilot" /></div>
             }
             <div class="chat-msg-content">
                 @if (Compact)

--- a/PolyPilot/Components/ChatMessageList.razor.css
+++ b/PolyPilot/Components/ChatMessageList.razor.css
@@ -88,20 +88,19 @@
     flex-shrink: 0;
     max-width: 100%;
     padding: 0.8rem 1rem;
-    align-items: flex-start;
+    align-items: flex-end;
 }
 
 .chat-message-list.full ::deep .chat-msg.user {
-    justify-content: flex-start;
-    background: rgba(255, 255, 255, 0.03);
+    justify-content: flex-end;
 }
 
 .chat-message-list.full ::deep .chat-msg.user .chat-msg-content {
-    background: none;
-    border: none;
-    border-radius: 0;
-    padding: 0;
-    max-width: 100%;
+    background: rgba(78, 168, 209, 0.12);
+    border: 1px solid rgba(78, 168, 209, 0.2);
+    border-radius: 12px 12px 0 12px;
+    padding: 0.75rem 1rem 0.35rem;
+    max-width: 80%;
 }
 
 ::deep .chat-msg.user .chat-msg-text p {
@@ -113,11 +112,11 @@
 }
 
 .chat-message-list.full ::deep .chat-msg.assistant .chat-msg-content {
-    background: none;
-    border: none;
-    border-radius: 0;
-    padding: 0;
-    max-width: 100%;
+    background: rgba(0, 195, 91, 0.06);
+    border: 1px solid rgba(0, 195, 91, 0.12);
+    border-radius: 12px 12px 12px 0;
+    padding: 0.75rem 1rem 0.35rem;
+    max-width: 80%;
 }
 
 ::deep .chat-msg.assistant .chat-msg-text p {
@@ -129,8 +128,8 @@
 }
 
 .chat-message-list.full ::deep .chat-msg-avatar {
-    width: 24px;
-    height: 24px;
+    width: 36px;
+    height: 36px;
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -140,12 +139,12 @@
 }
 
 .chat-message-list.full ::deep .chat-msg.user .chat-msg-avatar {
-    order: 0;
+    order: 1;
     background: rgba(78, 168, 209, 0.25);
-    width: 24px;
-    height: 24px;
+    width: 36px;
+    height: 36px;
     overflow: hidden;
-    font-size: 12px;
+    font-size: 16px;
 }
 
 .chat-message-list.full ::deep .chat-msg.user .chat-msg-avatar .user-avatar-img {
@@ -158,8 +157,8 @@
 .chat-message-list.full ::deep .chat-msg.assistant .chat-msg-avatar {
     background: transparent;
     overflow: hidden;
-    width: 24px;
-    height: 24px;
+    width: 36px;
+    height: 36px;
 }
 
 .chat-message-list.full ::deep .chat-msg.assistant .chat-msg-avatar img {
@@ -194,10 +193,10 @@
 }
 
 .chat-message-list.full ::deep .chat-msg-time {
-    font-size: 10px;
+    font-size: 16px;
     color: var(--text-muted);
     margin-top: 0.1rem;
-    opacity: 0.6;
+    opacity: 0.8;
 }
 
 .chat-message-list.full ::deep .chat-msg.system {
@@ -744,9 +743,11 @@
     padding: 0.8rem 1rem;
 }
 .chat-message-list.full.style-minimal ::deep .chat-msg.user {
+    justify-content: flex-start;
     background: rgba(255, 255, 255, 0.03);
 }
 .chat-message-list.full.style-minimal ::deep .chat-msg.user .chat-msg-avatar {
+    order: 0;
     width: 32px;
     height: 32px;
 }
@@ -783,4 +784,8 @@
     text-align: center;
     padding: 0.2rem 0.5rem;
     opacity: 0.7;
+}
+.chat-message-list.full.style-minimal ::deep .chat-msg-time {
+    font-size: 16px;
+    opacity: 0.8;
 }

--- a/PolyPilot/Components/Pages/Settings.razor
+++ b/PolyPilot/Components/Pages/Settings.razor
@@ -875,6 +875,7 @@
         settings.ChatLayout = layout;
         settings.Save();
         CopilotService.ChatLayout = layout;
+        CopilotService.NotifyStateChanged();
         ShowStatus("Layout updated", "success");
     }
 
@@ -883,6 +884,7 @@
         settings.ChatStyle = style;
         settings.Save();
         CopilotService.ChatStyle = style;
+        CopilotService.NotifyStateChanged();
         ShowStatus("Style updated", "success");
     }
 

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -168,6 +168,7 @@ public partial class CopilotService : IAsyncDisposable
     public OrganizationState Organization { get; private set; } = new();
 
     public event Action? OnStateChanged;
+    public void NotifyStateChanged() => OnStateChanged?.Invoke();
     public event Action<string, string>? OnContentReceived; // sessionName, content
     public event Action<string, string>? OnError; // sessionName, error
     public event Action<string, string>? OnSessionComplete; // sessionName, summary


### PR DESCRIPTION
UI tweaks to improve chat readability and spacing: enlarge user/assistant avatars from ~22/24px to 36px, adjust avatar ordering, font sizes and opacities, and refine message bubble styling (background colors, borders, radii, padding, and max-width) for both full and minimal chat layouts. Also added CopilotService.NotifyStateChanged() and invoked it from Settings when the chat layout or style is changed so the UI can react to those updates.