### PR TITLE
Fix Windows 'Fix/feature' launch: quote prompt argument to copilot CLI

### DIFF
--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -1165,7 +1165,8 @@ Important conventions:
                 $"Write-Host \"📋 Prompt loaded from: {promptFile}\"\n" +
                 $"Write-Host \"─────────────────────────────────────────\"\n" +
                 $"Write-Host \"\"\n" +
-                $"copilot --yolo -i (Get-Content '{promptFile}' -Raw)\n");
+                $"$prompt = Get-Content '{promptFile}' -Raw\n" +
+                $"copilot --yolo -i \"$prompt\"\n");
 
             // Launch in a new Windows Terminal / cmd window
             var psi = new System.Diagnostics.ProcessStartInfo("powershell.exe",


### PR DESCRIPTION
## Problem

When using **Fix / feature on Windows**, the copilot CLI failed with:

\\\
error: too many arguments. Expected 0 arguments but got 1.
\\\

The PowerShell subexpression \(Get-Content '...' -Raw)\ was passed unquoted to \copilot -i\, causing the multi-line prompt content to be split into multiple arguments by PowerShell.

## Fix

Store the file content in a \\\ variable first, then pass it double-quoted (\\"\"\) so copilot receives it as a single \-i\ argument.

## Testing

- Verified build succeeds on Windows (0 errors)
- Manually tested the Fix/feature flow — copilot launches correctly with the prompt