### PR TITLE
Add package source mapping and Essentials.AI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build & Release
 on:
   push:
     tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 env:

--- a/PolyPilot/PolyPilot.csproj
+++ b/PolyPilot/PolyPilot.csproj
@@ -73,6 +73,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.2" />
+        <PackageReference Include="Microsoft.Maui.Essentials.AI" Version="10.0.50-ci.main.26117.2" />
         <PackageReference Include="sqlite-net-pcl" Version="*" />
         <PackageReference Include="SQLitePCLRaw.bundle_green" Version="*" />
         <PackageReference Include="QRCoder" Version="*" />

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet10">
+      <package pattern="Microsoft.Maui.Essentials.AI" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
This pull request introduces support for the `Microsoft.Maui.Essentials.AI` package by updating project dependencies and configuring NuGet package sources. It also updates the build workflow to trigger on pull requests to the `main` branch, improving CI coverage.

Dependency management and configuration:

* Added a `nuget.config` file to specify package sources, including `nuget.org` and the Azure DevOps `dotnet10` feed, and mapped the `Microsoft.Maui.Essentials.AI` package to the correct source.
* Updated `PolyPilot.csproj` to include a reference to `Microsoft.Maui.Essentials.AI` version `10.0.50-ci.main.26117.2`.

Continuous Integration improvements:

* Modified `.github/workflows/build.yml` to trigger builds on pull requests targeting the `main` branch, in addition to existing tag and manual triggers.