### PR TITLE
Add Android APK build to release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -412,10 +412,93 @@ jobs:
             -f description="$DESC" \
             -f context="PolyPilot / Download Windows App"
 
+  publish-android:
+    name: Publish Android APK
+    runs-on: ubuntu-latest
+    needs: build-test
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    permissions:
+      statuses: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Install MAUI workload
+        run: dotnet workload install maui-android
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: '17'
+
+      - name: Determine version
+        id: version
+        run: |
+          SHA="${GITHUB_SHA::8}"
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VER="${GITHUB_REF#refs/tags/v}"
+          else
+            VER="1.0"
+          fi
+          echo "app_version=$VER" >> $GITHUB_OUTPUT
+          echo "commit_sha=$SHA" >> $GITHUB_OUTPUT
+          echo "Version: $VER+$SHA"
+
+      - name: Publish Android APK
+        run: |
+          dotnet publish PolyPilot/PolyPilot.csproj \
+            -f net10.0-android \
+            -c Release \
+            -p:ApplicationDisplayVersion=${{ steps.version.outputs.app_version }}
+
+      - name: Collect APK artifacts
+        run: |
+          mkdir -p ./artifacts
+          find PolyPilot/bin/Release/net10.0-android -name "*-Signed.apk" -exec cp {} ./artifacts/PolyPilot-Android.apk \;
+          if [ ! -f ./artifacts/PolyPilot-Android.apk ]; then
+            # Fallback: look for any APK
+            find PolyPilot/bin/Release/net10.0-android -name "*.apk" | head -1 | xargs -I{} cp {} ./artifacts/PolyPilot-Android.apk
+          fi
+          ls -lh ./artifacts/
+
+      - name: Upload Android APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: PolyPilot-Android
+          path: ./artifacts/PolyPilot-Android.apk
+          retention-days: 30
+
+      - name: Set commit status with artifact link
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ARTIFACT_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ -f "./artifacts/PolyPilot-Android.apk" ]; then
+            STATE="success"
+            DESC="PolyPilot Android APK built successfully"
+          else
+            STATE="failure"
+            DESC="PolyPilot Android APK build failed"
+          fi
+          gh api repos/${{ github.repository }}/statuses/${{ github.sha }} \
+            -f state="$STATE" \
+            -f target_url="$ARTIFACT_URL" \
+            -f description="$DESC" \
+            -f context="PolyPilot / Download Android APK"
+
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [notarize-maccatalyst, publish-windows]
+    needs: [notarize-maccatalyst, publish-windows, publish-android]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
@@ -433,12 +516,19 @@ jobs:
           name: PolyPilot-Windows
           path: ./release
 
+      - name: Download Android artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: PolyPilot-Android
+          path: ./release
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             ./release/PolyPilot.zip
             ./release/PolyPilot-Windows.zip
+            ./release/PolyPilot-Android.apk
           generate_release_notes: false
           draft: false
           prerelease: ${{ contains(github.ref, '-') }}


### PR DESCRIPTION
## Summary
Adds a `publish-android` job to the CI workflow that builds an Android APK and includes it in GitHub Releases.

## Changes
- **New `publish-android` job**: Runs on `ubuntu-latest`, installs `maui-android` workload + Java 17, publishes the APK via `dotnet publish`
- **Updated `create-release` job**: Now depends on `publish-android` and includes `PolyPilot-Android.apk` in the release assets

## How users install the APK
1. Go to the **GitHub Releases** page (or Actions artifacts for non-release builds)
2. Download `PolyPilot-Android.apk`
3. On Android, enable **Settings → Install unknown apps** for your browser
4. Open the downloaded APK to install

The APK is debug-signed (default .NET keystore). For Play Store distribution, a signing key would need to be added as a secret.