### PR TITLE
Add build version info for debugging stale binaries

### DIFF
--- a/PolyPilot.Tests/BuildInfoTests.cs
+++ b/PolyPilot.Tests/BuildInfoTests.cs
@@ -1,0 +1,90 @@
+using PolyPilot;
+
+namespace PolyPilot.Tests;
+
+/// <summary>
+/// Tests for BuildInfo which provides build-time metadata for debugging version mismatches.
+/// This helps identify when a running app binary doesn't match the expected source code.
+/// </summary>
+public class BuildInfoTests
+{
+    [Fact]
+    public void BuildTimestamp_IsNotEmpty()
+    {
+        // BuildTimestamp should always return something, even if fallback
+        Assert.False(string.IsNullOrWhiteSpace(BuildInfo.BuildTimestamp),
+            "BuildTimestamp should not be empty");
+    }
+
+    [Fact]
+    public void BuildTimestamp_IsNotNull()
+    {
+        Assert.NotNull(BuildInfo.BuildTimestamp);
+    }
+
+    [Fact]
+    public void ShortBuildId_IsNotEmpty()
+    {
+        // ShortBuildId should always return something
+        Assert.False(string.IsNullOrWhiteSpace(BuildInfo.ShortBuildId),
+            "ShortBuildId should not be empty");
+    }
+
+    [Fact]
+    public void ShortBuildId_FormatIsCorrectWhenTimestampAvailable()
+    {
+        // If BuildTimestamp is in the expected format (yyyy-MM-dd HH:mm:ss), ShortBuildId should be MMdd-HHmm
+        // If it's a version string with commit hash (e.g., "1.0.0+abc123"), ShortBuildId may vary
+        var timestamp = BuildInfo.BuildTimestamp;
+        
+        if (timestamp.Length >= 16 && timestamp != "unknown" && !timestamp.Contains("+"))
+        {
+            // Standard timestamp format - ShortBuildId should be "MMdd-HHmm"
+            Assert.Matches(@"^\d{4}-\d{4}$", BuildInfo.ShortBuildId);
+        }
+        else
+        {
+            // Version or unknown format - just verify it's not empty
+            Assert.False(string.IsNullOrWhiteSpace(BuildInfo.ShortBuildId));
+        }
+    }
+
+    [Fact]
+    public void BuildTimestamp_ContainsYearOrVersionInfo()
+    {
+        // Should either contain a year (from timestamp) or version info (from InformationalVersion)
+        var timestamp = BuildInfo.BuildTimestamp;
+        var hasYear = timestamp.Contains("202") || timestamp.Contains("203"); // Years 2020-2039
+        var hasVersionFormat = timestamp.Contains("+") || timestamp.Contains(".");
+        var isUnknown = timestamp == "unknown";
+
+        Assert.True(hasYear || hasVersionFormat || isUnknown,
+            $"BuildTimestamp should contain year, version info, or be 'unknown'. Got: {timestamp}");
+    }
+
+    [Fact]
+    public void BuildInfo_IsStatic()
+    {
+        // BuildInfo should be a static class - verify by checking type attributes
+        var type = typeof(BuildInfo);
+        Assert.True(type.IsAbstract && type.IsSealed,
+            "BuildInfo should be a static class (abstract and sealed)");
+    }
+
+    [Fact]
+    public void BuildTimestamp_IsDeterministic()
+    {
+        // Multiple accesses should return the same value (it's computed once)
+        var first = BuildInfo.BuildTimestamp;
+        var second = BuildInfo.BuildTimestamp;
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void ShortBuildId_IsDeterministic()
+    {
+        var first = BuildInfo.ShortBuildId;
+        var second = BuildInfo.ShortBuildId;
+        Assert.Equal(first, second);
+    }
+}

--- a/PolyPilot.Tests/PolyPilot.Tests.csproj
+++ b/PolyPilot.Tests/PolyPilot.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="../PolyPilot/Services/DevTunnelService.cs" Link="Shared/DevTunnelService.cs" />
     <Compile Include="../PolyPilot/Services/FiestaService.cs" Link="Shared/FiestaService.cs" />
     <Compile Include="../PolyPilot/Models/ReflectionCycle.cs" Link="Shared/ReflectionCycle.cs" />
+    <Compile Include="../PolyPilot/BuildInfo.cs" Link="Shared/BuildInfo.cs" />
   </ItemGroup>
 
 </Project>

--- a/PolyPilot/BuildInfo.cs
+++ b/PolyPilot/BuildInfo.cs
@@ -1,0 +1,75 @@
+namespace PolyPilot;
+
+/// <summary>
+/// Provides build-time information for debugging version mismatches.
+/// The BuildTimestamp is set during compilation to help identify stale binaries.
+/// </summary>
+public static class BuildInfo
+{
+    /// <summary>
+    /// UTC timestamp when this assembly was compiled, or version+commit hash.
+    /// Format: "yyyy-MM-dd HH:mm:ss UTC" or "1.0.0+abc1234"
+    /// </summary>
+    public static string BuildTimestamp { get; } = GetBuildTimestamp();
+
+    /// <summary>
+    /// Short identifier derived from build timestamp for quick version checks.
+    /// For timestamps: MMdd-HHmm (e.g., "0218-1430" for Feb 18 at 14:30)
+    /// For versions: commit hash (e.g., "abc1234")
+    /// </summary>
+    public static string ShortBuildId => GetShortBuildId();
+
+    private static string GetShortBuildId()
+    {
+        var ts = BuildTimestamp;
+        
+        // If version string with commit hash (e.g., "1.0.0+abc1234")
+        if (ts.Contains('+'))
+        {
+            var plusIndex = ts.IndexOf('+');
+            return ts.Length > plusIndex + 1 ? ts[(plusIndex + 1)..] : "unknown";
+        }
+        
+        // If standard timestamp format (yyyy-MM-dd HH:mm:ss)
+        if (ts.Length >= 16 && ts != "unknown")
+        {
+            return $"{ts[5..7]}{ts[8..10]}-{ts[11..13]}{ts[14..16]}";
+        }
+        
+        return "unknown";
+    }
+
+    private static string GetBuildTimestamp()
+    {
+        // Use assembly metadata if available, otherwise fall back to file timestamp
+        var assembly = typeof(BuildInfo).Assembly;
+        
+        // Try to get InformationalVersion which may contain git commit info
+        var infoVersion = assembly.GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
+            .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
+            .FirstOrDefault()?.InformationalVersion;
+        
+        if (!string.IsNullOrEmpty(infoVersion) && infoVersion.Contains('+'))
+        {
+            // Return version with commit hash like "1.0.0+abc1234"
+            return infoVersion;
+        }
+
+        // Fall back to assembly file write time
+        try
+        {
+            var location = assembly.Location;
+            if (!string.IsNullOrEmpty(location) && File.Exists(location))
+            {
+                var writeTime = File.GetLastWriteTimeUtc(location);
+                return writeTime.ToString("yyyy-MM-dd HH:mm:ss") + " UTC";
+            }
+        }
+        catch
+        {
+            // Ignore file access errors
+        }
+
+        return "unknown";
+    }
+}

--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -975,6 +975,7 @@ else
         sb.AppendLine($"IsRestoring: {CopilotService.IsRestoring}");
         sb.AppendLine($"IsRemoteMode: {CopilotService.IsRemoteMode}");
         sb.AppendLine($"Sessions: {CopilotService.GetAllSessions().Count()}");
+        sb.AppendLine($"Build: {BuildInfo.BuildTimestamp}");
         sb.AppendLine($"Platform: {System.Runtime.InteropServices.RuntimeInformation.OSDescription}");
         sb.AppendLine($"Arch: {System.Runtime.InteropServices.RuntimeInformation.OSArchitecture}");
         sb.AppendLine($"Runtime: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");

--- a/PolyPilot/Components/Pages/Settings.razor
+++ b/PolyPilot/Components/Pages/Settings.razor
@@ -34,6 +34,7 @@
                     <div class="info-panel">
                         <div class="info-row"><span class="info-label">Mode</span><span class="info-value">@CopilotService.CurrentMode</span></div>
                         <div class="info-row"><span class="info-label">Status</span><span class="info-value">@(CopilotService.IsInitialized ? "Connected" : "Disconnected")</span></div>
+                        <div class="info-row"><span class="info-label">Build</span><span class="info-value" title="@BuildInfo.BuildTimestamp">@BuildInfo.ShortBuildId</span></div>
                         @if (PlatformHelper.IsDesktop)
                         {
                             <div class="info-divider"></div>


### PR DESCRIPTION
## Summary

Adds BuildInfo class that exposes build timestamp/commit hash to help identify version mismatches when debugging stuck sessions or crashes.

## Problem

When debugging issues like stuck sessions or component parameter crashes, it's difficult to verify if the running app binary matches the expected source code. This is especially problematic after hot-reload, incomplete deployments, or when multiple worktrees are in use.

## Solution

- **BuildInfo.BuildTimestamp**: Full version string (e.g., \1.0.0+abc1234\) or UTC timestamp
- **BuildInfo.ShortBuildId**: Short identifier for quick comparison (e.g., commit hash \bc1234\ or \