### PR TITLE
Fix Android UI cut-off by using injected safe-area CSS variables

### DIFF
--- a/PolyPilot/Components/ExpandedSessionView.razor.css
+++ b/PolyPilot/Components/ExpandedSessionView.razor.css
@@ -426,7 +426,7 @@
     flex-direction: column;
     gap: 0.4rem;
     padding: 0.5rem 0.75rem;
-    padding-bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px));
+    padding-bottom: calc(0.5rem + var(--nav-bar-height, env(safe-area-inset-bottom, 0px)));
     background: rgba(var(--accent-rgb, 78,168,209),0.06);
     border-top: 1px solid var(--control-border);
     flex-shrink: 0;

--- a/PolyPilot/Components/Layout/MainLayout.razor.css
+++ b/PolyPilot/Components/Layout/MainLayout.razor.css
@@ -64,7 +64,7 @@ main {
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     overscroll-behavior: contain;
-    padding-top: env(safe-area-inset-top, 0px);
+    padding-top: var(--status-bar-height, env(safe-area-inset-top, 0px));
 }
 
 .flyout-panel.open {

--- a/PolyPilot/Components/Layout/SessionSidebar.razor.css
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor.css
@@ -927,7 +927,7 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    padding: calc(env(safe-area-inset-top, 0px) + 0.5rem) 0.75rem 0.5rem;
+    padding: calc(var(--status-bar-height, env(safe-area-inset-top, 0px)) + 0.5rem) 0.75rem 0.5rem;
     color: var(--text-primary);
     overflow: hidden;
     max-width: 100vw;

--- a/PolyPilot/Components/Pages/Dashboard.razor.css
+++ b/PolyPilot/Components/Pages/Dashboard.razor.css
@@ -614,7 +614,7 @@
     flex-direction: column;
     gap: 0.4rem;
     padding: 0.5rem 0.75rem;
-    padding-bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px));
+    padding-bottom: calc(0.5rem + var(--nav-bar-height, env(safe-area-inset-bottom, 0px)));
     background: rgba(var(--accent-rgb, 78,168,209),0.06);
     border-top: 1px solid var(--control-border);
     flex-shrink: 0;

--- a/PolyPilot/wwwroot/app.css
+++ b/PolyPilot/wwwroot/app.css
@@ -484,7 +484,7 @@ h1:focus {
 .image-viewer-overlay img.grabbing { cursor: grabbing; }
 .image-viewer-close {
     position: absolute;
-    top: env(safe-area-inset-top, 12px);
+    top: var(--status-bar-height, env(safe-area-inset-top, 12px));
     right: 16px;
     margin-top: 12px;
     width: 36px;


### PR DESCRIPTION
## Problem
On Android, UI content renders behind the status bar and navigation bar (cut-off edges). The native code in `MainPage.xaml.cs` already injects `--status-bar-height` and `--nav-bar-height` CSS custom properties from `WindowInsets`, but no CSS rules referenced them. All safe-area CSS used `env(safe-area-inset-*)` which evaluates to `0` in MAUI's Android WebView.

## Fix
Updated 5 CSS rules across 5 files to use the injected Android variables with `env()` as fallback for iOS:

- **SessionSidebar.razor.css** — mobile bar top padding
- **MainLayout.razor.css** — flyout panel top padding
- **ExpandedSessionView.razor.css** — input area bottom padding
- **Dashboard.razor.css** — input area bottom padding
- **app.css** — image viewer close button top position

Pattern: `env(safe-area-inset-top, 0px)` → `var(--status-bar-height, env(safe-area-inset-top, 0px))`