### PR TITLE
Change default theme from PolyPilotDark to System

### DIFF
--- a/PolyPilot/Models/ConnectionSettings.cs
+++ b/PolyPilot/Models/ConnectionSettings.cs
@@ -53,7 +53,7 @@ public class ConnectionSettings
     public bool DirectSharingEnabled { get; set; } = false;
     public ChatLayout ChatLayout { get; set; } = ChatLayout.Default;
     public ChatStyle ChatStyle { get; set; } = ChatStyle.Normal;
-    public UiTheme Theme { get; set; } = UiTheme.PolyPilotDark;
+    public UiTheme Theme { get; set; } = UiTheme.System;
     public bool AutoUpdateFromMain { get; set; } = false;
     public CliSourceMode CliSource { get; set; } = CliSourceMode.BuiltIn;
     public List<string> DisabledMcpServers { get; set; } = new();

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -169,7 +169,7 @@ public partial class CopilotService : IAsyncDisposable
     // UI preferences
     public ChatLayout ChatLayout { get; set; } = ChatLayout.Default;
     public ChatStyle ChatStyle { get; set; } = ChatStyle.Normal;
-    public UiTheme Theme { get; set; } = UiTheme.PolyPilotDark;
+    public UiTheme Theme { get; set; } = UiTheme.System;
 
     // Session organization (groups, pinning, sorting)
     public OrganizationState Organization { get; private set; } = new();


### PR DESCRIPTION
## Summary

The app defaulted to the dark theme (`UiTheme.PolyPilotDark`) regardless of the OS preference. This changes the default to `UiTheme.System` so the app follows the OS light/dark setting out of the box.

## Changes

- **ConnectionSettings.cs** — Default `Theme` property changed from `UiTheme.PolyPilotDark` to `UiTheme.System`
- **CopilotService.cs** — Default `Theme` property changed from `UiTheme.PolyPilotDark` to `UiTheme.System`

No CSS changes needed — the `[data-theme="system"]` selector with `@media (prefers-color-scheme: light)` rules already exists in `app.css`.

Users who previously saved settings will keep their chosen theme; only new installs (or fresh settings) are affected.