### PR TITLE
Add release workflow for TestFlight & Google Play

### DIFF
--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -3,10 +3,9 @@ name: Release to TestFlight & Google Play
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'App display version (e.g. 1.0.0)'
-        required: true
-        default: '1.0.0'
+      version_override:
+        description: 'Override app version (leave empty to use APP_VERSION repo variable)'
+        required: false
       build_number_offset:
         description: 'Offset added to run number (increase if you need to jump ahead, default: repo var BUILD_NUMBER_OFFSET or 0)'
         required: false
@@ -17,7 +16,7 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   MAUI_PROJECT_PATH: 'PolyPilot/PolyPilot.csproj'
-  APP_VERSION: ${{ inputs.version || vars.APP_VERSION || '1.0.0' }}
+  APP_VERSION: ${{ inputs.version_override || vars.APP_VERSION || '1.0.0' }}
 
 jobs:
   # ─────────────────────────────────────────────


### PR DESCRIPTION
## What
Adds `release-apps.yml` — a manually-triggered GitHub Actions workflow that builds and deploys to both app stores.

## Jobs
| Job | Runner | Purpose |
|-----|--------|---------|
| `build-android` | `ubuntu-latest` | Publishes signed AAB |
| `deploy-android` | `ubuntu-latest` | Uploads AAB to Google Play Internal Testing |
| `build-ios` | `macos-26` | Publishes signed IPA |
| `deploy-ios` | `macos-26` | Uploads IPA to TestFlight |

## Environments
Uses GitHub environments `android-release` and `ios-release` for deployment protection rules.

## Required Secrets

### Android
| Secret | Description | How to create |
|--------|-------------|---------------|
| `ANDROID_KEYSTORE_BASE64` | Base64-encoded `.jks` keystore | `base64 -i your.keystore \| pbcopy` |
| `ANDROID_KEY_ALIAS` | Key alias in the keystore | Plain text |
| `ANDROID_KEY_PASSWORD` | Password for the key | Plain text |
| `ANDROID_KEYSTORE_PASSWORD` | Password for the keystore | Plain text |
| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Google Play Console service account JSON | Create in Google Cloud Console → IAM → Service Accounts, grant `Service Account User` role, then in Play Console → API access, link the service account and grant `Release manager` permission |

### iOS / TestFlight
| Secret | Description | How to create |
|--------|-------------|---------------|
| `IOS_CERTIFICATE_BASE64` | Base64-encoded .p12 distribution certificate | Export from Keychain Access as .p12, then `base64 -i cert.p12 \| pbcopy` |
| `IOS_CERTIFICATE_PASSWORD` | Password set when exporting .p12 | Plain text |
| `IOS_CODESIGN_KEY` | Codesign identity name | e.g. `Apple Distribution: Your Name (TEAMID)` |
| `IOS_PROVISIONING_PROFILE_NAME` | Name of the provisioning profile | Exact name as shown in Apple Developer portal |
| `APPSTORE_ISSUER_ID` | App Store Connect API issuer ID | App Store Connect → Users and Access → Integrations → App Store Connect API |
| `APPSTORE_KEY_ID` | App Store Connect API key ID | Same page, create a new key with `App Manager` role |
| `APPSTORE_PRIVATE_KEY` | App Store Connect API private key (.p8 contents) | Download the .p8 file when creating the key (one-time download), paste the full contents including BEGIN/END lines |

## No csproj changes
All signing and versioning config is passed via `-p:` MSBuild properties from the workflow.