### PR TITLE
Replace trash icon with close icon on Close Session button

### DIFF
--- a/PolyPilot.Tests/CloseSessionIconTests.cs
+++ b/PolyPilot.Tests/CloseSessionIconTests.cs
@@ -1,0 +1,55 @@
+using Xunit;
+
+namespace PolyPilot.Tests;
+
+/// <summary>
+/// Ensures the "Close Session" button uses a non-destructive icon (not trash/wastebasket).
+/// The trash icon (🗑) implies permanent deletion, but closing a session is reversible.
+/// </summary>
+public class CloseSessionIconTests
+{
+    private static string GetRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "PolyPilot.slnx")))
+            dir = Directory.GetParent(dir)?.FullName;
+        return dir ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+
+    [Fact]
+    public void SessionCard_CloseButton_DoesNotUseTrashIcon()
+    {
+        var file = Path.Combine(GetRepoRoot(), "PolyPilot", "Components", "SessionCard.razor");
+        var content = File.ReadAllText(file);
+
+        // The close session button must not use the trash/wastebasket emoji
+        Assert.DoesNotContain("🗑", content.Substring(content.IndexOf("Close Session") - 5, 10));
+    }
+
+    [Fact]
+    public void SessionListItem_CloseButton_DoesNotUseTrashIcon()
+    {
+        var file = Path.Combine(GetRepoRoot(), "PolyPilot", "Components", "Layout", "SessionListItem.razor");
+        var content = File.ReadAllText(file);
+
+        Assert.DoesNotContain("🗑", content.Substring(content.IndexOf("Close Session") - 5, 10));
+    }
+
+    [Fact]
+    public void SessionCard_CloseButton_UsesCloseIcon()
+    {
+        var file = Path.Combine(GetRepoRoot(), "PolyPilot", "Components", "SessionCard.razor");
+        var content = File.ReadAllText(file);
+
+        Assert.Contains("✕ Close Session", content);
+    }
+
+    [Fact]
+    public void SessionListItem_CloseButton_UsesCloseIcon()
+    {
+        var file = Path.Combine(GetRepoRoot(), "PolyPilot", "Components", "Layout", "SessionListItem.razor");
+        var content = File.ReadAllText(file);
+
+        Assert.Contains("✕ Close Session", content);
+    }
+}

--- a/PolyPilot/Components/Layout/SessionListItem.razor
+++ b/PolyPilot/Components/Layout/SessionListItem.razor
@@ -144,7 +144,7 @@
                     <div class="menu-separator"></div>
                 }
                 <button class="menu-item destructive" @onclick="() => { OnCloseMenu.InvokeAsync(); OnClose.InvokeAsync(); }">
-                    🗑 Close Session
+                    ✕ Close Session
                 </button>
             </div>
         }

--- a/PolyPilot/Components/SessionCard.razor
+++ b/PolyPilot/Components/SessionCard.razor
@@ -51,7 +51,7 @@
                 }
                 <div class="card-menu-separator"></div>
                 <button class="card-menu-item destructive" @onclick="async () => { await OnCloseMenu.InvokeAsync(); _ = CopilotService.CloseSessionAsync(Session.Name); }">
-                    🗑 Close Session
+                    ✕ Close Session
                 </button>
             </div>
             }


### PR DESCRIPTION
## Problem
The Close Session button used a 🗑 (wastebasket/trash) emoji icon, which implies permanent deletion. However, closing a session is a reversible action — the session can be restored later.

## Fix
Replaced the 🗑 icon with ✕ (multiplication sign/close mark) in both:
- `SessionCard.razor` (Dashboard card context menu)
- `SessionListItem.razor` (Sidebar session list context menu)

The trash icon is still used for actual destructive actions (Remove Repo, Delete Group) where it remains appropriate.

## Tests
Added `CloseSessionIconTests.cs` with 4 tests to prevent regression:
- Verifies both components don't use the trash icon for Close Session
- Verifies both components use the ✕ close icon

All 688 tests pass. Mac Catalyst build succeeds.