### PR TITLE
Fix QR scanner not detecting barcodes on iOS

### DIFF
--- a/PolyPilot/QrScannerPage.xaml
+++ b/PolyPilot/QrScannerPage.xaml
@@ -11,7 +11,7 @@
         <!-- Full-screen camera -->
         <zxing:CameraBarcodeReaderView
             x:Name="barcodeReader"
-            IsDetecting="True"
+            IsDetecting="False"
             CameraLocation="Rear"
             BarcodesDetected="OnBarcodesDetected" />
 


### PR DESCRIPTION
## Bug
On iOS the QR scanner camera opens but never detects anything — it just stays open with a live preview.

## Root Cause
`IsDetecting="True"` in XAML starts barcode detection during `InitializeComponent()`, **before** `Options` is set in the constructor. On iOS, ZXing.Net.MAUI's native decoder snapshots the options when detection starts and doesn't pick up later changes. So `FrameReady` fires (camera works) but `BarcodesDetected` never does (decoder running with default/empty options).

## Fix
Set `IsDetecting="False"` in XAML. Detection now only starts in `OnAppearing()` — after `Options` is configured in the constructor and camera permissions are granted. This was the original intent of the 500ms delay + `IsDetecting = true` in `OnAppearing`, but the XAML attribute was pre-empting it.