### PR TITLE
fix: improve hamburger and settings icon visibility in light mode

### DIFF
--- a/PolyPilot/Components/Layout/SessionSidebar.razor.css
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor.css
@@ -936,7 +936,7 @@
 .hamburger-btn {
     background: none;
     border: none;
-    color: rgba(200,216,240,0.6);
+    color: var(--text-dim);
     cursor: pointer;
     padding: 0.3rem;
     display: flex;
@@ -966,7 +966,7 @@
     padding: 0.35rem;
     border-radius: 6px;
     background: transparent;
-    color: rgba(200,216,240,0.4);
+    color: var(--text-dim);
     text-decoration: none;
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Problem
The hamburger menu (☰) and settings/tab icons are barely visible in light mode — hardcoded to `rgba(200,216,240,0.6)` and `rgba(200,216,240,0.4)` which have near-zero contrast against the light background.

## Fix
Replaced both with `var(--text-dim)` which is theme-aware:
- Dark mode: light text → visible ✅
- Light mode: `rgba(0,0,0,0.4)` → visible ✅

## Files Changed
- `SessionSidebar.razor.css` — 2 color values (lines 939, 969)