### PR TITLE
feat: enable repo management from mobile via bridge protocol

### DIFF
--- a/PolyPilot.Tests/DevTunnelServiceTests.cs
+++ b/PolyPilot.Tests/DevTunnelServiceTests.cs
@@ -58,7 +58,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
 
         Assert.Equal(TunnelState.NotStarted, service.State);
         Assert.Null(service.TunnelUrl);
@@ -179,7 +179,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         InvokeTryExtractInfo(service, "Connect via browser: https://my-tunnel.devtunnels.ms", tcs);
@@ -194,7 +194,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         InvokeTryExtractInfo(service, "Ready at https://abc.devtunnels.ms", tcs);
@@ -209,7 +209,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         InvokeTryExtractInfo(service, "Tunnel ID: my-cool-tunnel", tcs);
@@ -224,7 +224,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         InvokeTryExtractInfo(service, "Hosting port for tunnel: alt-id-123", tcs);
@@ -237,7 +237,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         // First line: tunnel ID
@@ -257,7 +257,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         InvokeTryExtractInfo(service, "Connect via browser: https://first.devtunnels.ms", tcs);
@@ -274,7 +274,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         InvokeTryExtractInfo(service, "Tunnel ID: first-id", tcs);
@@ -289,7 +289,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         InvokeTryExtractInfo(service, "Just some random log output", tcs);
@@ -304,7 +304,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         InvokeTryExtractInfo(service, "Connect via browser: https://trimtest.devtunnels.ms/", tcs);
@@ -319,7 +319,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
 
         // Simulate some state via TryExtractInfo
         var tcs = new TaskCompletionSource<bool>();
@@ -340,7 +340,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
 
         int stateChangedCount = 0;
         service.OnStateChanged += () => stateChangedCount++;
@@ -358,7 +358,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
 
         int stateChangedCount = 0;
         service.OnStateChanged += () => stateChangedCount++;
@@ -534,7 +534,7 @@ public class DevTunnelServiceTests
 
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         foreach (var line in lines)
@@ -550,7 +550,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         InvokeTryExtractInfo(service,
@@ -627,7 +627,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
 
         // Set state to Running via reflection
         SetState(service, TunnelState.Running);
@@ -645,7 +645,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         // This line matches both ConnectUrlRegex and TunnelUrlRegex
@@ -663,7 +663,7 @@ public class DevTunnelServiceTests
     {
         var bridge = new WsBridgeServer();
         var copilot = CreateTestCopilotService();
-        var service = new DevTunnelService(bridge, copilot);
+        var service = new DevTunnelService(bridge, copilot, new RepoManager());
         var tcs = new TaskCompletionSource<bool>();
 
         // This matches TunnelIdRegex directly

--- a/PolyPilot.Tests/RemoteRepoTests.cs
+++ b/PolyPilot.Tests/RemoteRepoTests.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using PolyPilot.Models;
+
+namespace PolyPilot.Tests;
+
+public class RemoteRepoTests
+{
+    [Fact]
+    public void BridgeMessageTypes_RepoConstants_Defined()
+    {
+        Assert.Equal("add_repo", BridgeMessageTypes.AddRepo);
+        Assert.Equal("remove_repo", BridgeMessageTypes.RemoveRepo);
+        Assert.Equal("list_repos", BridgeMessageTypes.ListRepos);
+        Assert.Equal("repos_list", BridgeMessageTypes.ReposList);
+        Assert.Equal("repo_added", BridgeMessageTypes.RepoAdded);
+        Assert.Equal("repo_progress", BridgeMessageTypes.RepoProgress);
+        Assert.Equal("repo_error", BridgeMessageTypes.RepoError);
+    }
+
+    [Fact]
+    public void AddRepoPayload_RoundTrip()
+    {
+        var payload = new AddRepoPayload { Url = "https://github.com/PureWeen/PolyPilot", RequestId = "abc123" };
+        var msg = BridgeMessage.Create(BridgeMessageTypes.AddRepo, payload);
+        var json = msg.Serialize();
+        var restored = BridgeMessage.Deserialize(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(BridgeMessageTypes.AddRepo, restored!.Type);
+
+        var p = restored.GetPayload<AddRepoPayload>();
+        Assert.NotNull(p);
+        Assert.Equal("https://github.com/PureWeen/PolyPilot", p!.Url);
+        Assert.Equal("abc123", p.RequestId);
+    }
+
+    [Fact]
+    public void RemoveRepoPayload_RoundTrip()
+    {
+        var payload = new RemoveRepoPayload { RepoId = "PureWeen-PolyPilot", DeleteFromDisk = true, GroupId = "group1" };
+        var msg = BridgeMessage.Create(BridgeMessageTypes.RemoveRepo, payload);
+        var json = msg.Serialize();
+        var restored = BridgeMessage.Deserialize(json);
+
+        var p = restored!.GetPayload<RemoveRepoPayload>();
+        Assert.NotNull(p);
+        Assert.Equal("PureWeen-PolyPilot", p!.RepoId);
+        Assert.True(p.DeleteFromDisk);
+        Assert.Equal("group1", p.GroupId);
+    }
+
+    [Fact]
+    public void ReposListPayload_RoundTrip()
+    {
+        var payload = new ReposListPayload
+        {
+            RequestId = "req1",
+            Repos = new()
+            {
+                new RepoSummary { Id = "PureWeen-PolyPilot", Name = "PolyPilot", Url = "https://github.com/PureWeen/PolyPilot" },
+                new RepoSummary { Id = "dotnet-maui", Name = "maui", Url = "https://github.com/dotnet/maui" }
+            }
+        };
+        var msg = BridgeMessage.Create(BridgeMessageTypes.ReposList, payload);
+        var json = msg.Serialize();
+        var restored = BridgeMessage.Deserialize(json);
+
+        var p = restored!.GetPayload<ReposListPayload>();
+        Assert.NotNull(p);
+        Assert.Equal(2, p!.Repos.Count);
+        Assert.Equal("PureWeen-PolyPilot", p.Repos[0].Id);
+        Assert.Equal("maui", p.Repos[1].Name);
+    }
+
+    [Fact]
+    public void RepoAddedPayload_RoundTrip()
+    {
+        var payload = new RepoAddedPayload
+        {
+            RequestId = "req1",
+            RepoId = "PureWeen-PolyPilot",
+            RepoName = "PolyPilot",
+            Url = "https://github.com/PureWeen/PolyPilot"
+        };
+        var msg = BridgeMessage.Create(BridgeMessageTypes.RepoAdded, payload);
+        var json = msg.Serialize();
+        var restored = BridgeMessage.Deserialize(json);
+
+        var p = restored!.GetPayload<RepoAddedPayload>();
+        Assert.NotNull(p);
+        Assert.Equal("req1", p!.RequestId);
+        Assert.Equal("PureWeen-PolyPilot", p.RepoId);
+        Assert.Equal("PolyPilot", p.RepoName);
+    }
+
+    [Fact]
+    public void RepoProgressPayload_RoundTrip()
+    {
+        var payload = new RepoProgressPayload { RequestId = "req1", Message = "Cloning 45%..." };
+        var msg = BridgeMessage.Create(BridgeMessageTypes.RepoProgress, payload);
+        var json = msg.Serialize();
+        var restored = BridgeMessage.Deserialize(json);
+
+        var p = restored!.GetPayload<RepoProgressPayload>();
+        Assert.NotNull(p);
+        Assert.Equal("req1", p!.RequestId);
+        Assert.Equal("Cloning 45%...", p.Message);
+    }
+
+    [Fact]
+    public void RepoErrorPayload_RoundTrip()
+    {
+        var payload = new RepoErrorPayload { RequestId = "req1", Error = "Authentication failed" };
+        var msg = BridgeMessage.Create(BridgeMessageTypes.RepoError, payload);
+        var json = msg.Serialize();
+        var restored = BridgeMessage.Deserialize(json);
+
+        var p = restored!.GetPayload<RepoErrorPayload>();
+        Assert.NotNull(p);
+        Assert.Equal("req1", p!.RequestId);
+        Assert.Equal("Authentication failed", p.Error);
+    }
+
+    [Fact]
+    public void ListReposPayload_RoundTrip()
+    {
+        var payload = new ListReposPayload { RequestId = "req1" };
+        var msg = BridgeMessage.Create(BridgeMessageTypes.ListRepos, payload);
+        var json = msg.Serialize();
+        var restored = BridgeMessage.Deserialize(json);
+
+        Assert.Equal(BridgeMessageTypes.ListRepos, restored!.Type);
+        var p = restored.GetPayload<ListReposPayload>();
+        Assert.NotNull(p);
+        Assert.Equal("req1", p!.RequestId);
+    }
+
+    [Fact]
+    public void RepoSummary_DefaultValues()
+    {
+        var summary = new RepoSummary();
+        Assert.Equal("", summary.Id);
+        Assert.Equal("", summary.Name);
+        Assert.Equal("", summary.Url);
+    }
+
+    [Fact]
+    public void StubBridgeClient_AddRepo_TracksCall()
+    {
+        var stub = new StubWsBridgeClient();
+        var result = stub.AddRepoAsync("https://github.com/dotnet/maui").Result;
+
+        Assert.Equal(1, stub.AddRepoCallCount);
+        Assert.Equal("https://github.com/dotnet/maui", stub.LastAddedRepoUrl);
+        Assert.Equal("maui", result.RepoId);
+    }
+
+    [Fact]
+    public void StubBridgeClient_RemoveRepo_TracksCall()
+    {
+        var stub = new StubWsBridgeClient();
+        stub.RemoveRepoAsync("dotnet-maui", true, "group1").Wait();
+
+        Assert.Equal(1, stub.RemoveRepoCallCount);
+        Assert.Equal("dotnet-maui", stub.LastRemovedRepoId);
+    }
+
+    [Fact]
+    public void StubBridgeClient_RequestRepos_TracksCall()
+    {
+        var stub = new StubWsBridgeClient();
+        stub.RequestReposAsync().Wait();
+
+        Assert.Equal(1, stub.RequestReposCallCount);
+    }
+}

--- a/PolyPilot.Tests/TestStubs.cs
+++ b/PolyPilot.Tests/TestStubs.cs
@@ -126,6 +126,32 @@ internal class StubWsBridgeClient : IWsBridgeClient
     }
     public Task<DirectoriesListPayload> ListDirectoriesAsync(string? path = null, CancellationToken ct = default)
         => Task.FromResult(new DirectoriesListPayload());
+
+    // Repo operations
+    public event Action<ReposListPayload>? OnReposListReceived;
+    public string? LastAddedRepoUrl { get; private set; }
+    public int AddRepoCallCount { get; private set; }
+    public Task<RepoAddedPayload> AddRepoAsync(string url, Action<string>? onProgress = null, CancellationToken ct = default)
+    {
+        LastAddedRepoUrl = url;
+        AddRepoCallCount++;
+        var id = url.Split('/').Last();
+        return Task.FromResult(new RepoAddedPayload { RequestId = "test", RepoId = id, RepoName = id, Url = url });
+    }
+    public string? LastRemovedRepoId { get; private set; }
+    public int RemoveRepoCallCount { get; private set; }
+    public Task RemoveRepoAsync(string repoId, bool deleteFromDisk, string? groupId = null, CancellationToken ct = default)
+    {
+        LastRemovedRepoId = repoId;
+        RemoveRepoCallCount++;
+        return Task.CompletedTask;
+    }
+    public int RequestReposCallCount { get; private set; }
+    public Task RequestReposAsync(CancellationToken ct = default)
+    {
+        RequestReposCallCount++;
+        return Task.CompletedTask;
+    }
 }
 
 internal class StubDemoService : IDemoService

--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -870,15 +870,18 @@ else
         if (isAddingRepo || string.IsNullOrWhiteSpace(newRepoUrl)) return;
         addRepoError = null;
 
-        // Check if repo already exists
-        var normalizedUrl = RepoManager.NormalizeRepoUrl(newRepoUrl.Trim());
-        var id = RepoManager.RepoIdFromUrl(normalizedUrl);
-        var existing = RepoManager.Repositories.FirstOrDefault(r => r.Id == id);
-        if (existing != null)
+        // Check if repo already exists (local mode only — in remote mode the server handles duplicates)
+        if (!CopilotService.IsRemoteMode)
         {
-            confirmRepoReplace = true;
-            confirmRepoName = existing.Name;
-            return;
+            var normalizedUrl = RepoManager.NormalizeRepoUrl(newRepoUrl.Trim());
+            var id = RepoManager.RepoIdFromUrl(normalizedUrl);
+            var existing = RepoManager.Repositories.FirstOrDefault(r => r.Id == id);
+            if (existing != null)
+            {
+                confirmRepoReplace = true;
+                confirmRepoName = existing.Name;
+                return;
+            }
         }
 
         await DoAddRepository();
@@ -897,12 +900,11 @@ else
         addRepoProgress = null;
         try
         {
-            var repo = await RepoManager.AddRepositoryAsync(newRepoUrl.Trim(), progress =>
+            await CopilotService.AddRepoRemoteAsync(newRepoUrl.Trim(), progress =>
             {
                 addRepoProgress = progress;
                 InvokeAsync(StateHasChanged);
             });
-            CopilotService.GetOrCreateRepoGroup(repo.Id, repo.Name);
             showAddRepo = false;
             newRepoUrl = "";
         }
@@ -922,8 +924,7 @@ else
         confirmRemoveRepoId = null;
         try
         {
-            await RepoManager.RemoveRepositoryAsync(repoId, deleteFromDisk);
-            CopilotService.DeleteGroup(groupId);
+            await CopilotService.RemoveRepoRemoteAsync(repoId, groupId, deleteFromDisk);
         }
         catch (Exception ex)
         {

--- a/PolyPilot/Models/BridgeMessages.cs
+++ b/PolyPilot/Models/BridgeMessages.cs
@@ -84,6 +84,17 @@ public static class BridgeMessageTypes
     public const string ChangeModel = "change_model";
     public const string RenameSession = "rename_session";
 
+    // Client → Server (repo operations)
+    public const string AddRepo = "add_repo";
+    public const string RemoveRepo = "remove_repo";
+    public const string ListRepos = "list_repos";
+
+    // Server → Client (repo responses)
+    public const string ReposList = "repos_list";
+    public const string RepoAdded = "repo_added";
+    public const string RepoProgress = "repo_progress";
+    public const string RepoError = "repo_error";
+
     // Server → Client (response)
     public const string DirectoriesList = "directories_list";
 
@@ -358,4 +369,57 @@ public class FiestaPingPayload
 public class FiestaPongPayload
 {
     public string Sender { get; set; } = "";
+}
+
+// --- Repo bridge payloads ---
+
+public class AddRepoPayload
+{
+    public string Url { get; set; } = "";
+    public string RequestId { get; set; } = "";
+}
+
+public class RemoveRepoPayload
+{
+    public string RepoId { get; set; } = "";
+    public bool DeleteFromDisk { get; set; }
+    public string? GroupId { get; set; }
+}
+
+public class ListReposPayload
+{
+    public string? RequestId { get; set; }
+}
+
+public class ReposListPayload
+{
+    public string? RequestId { get; set; }
+    public List<RepoSummary> Repos { get; set; } = new();
+}
+
+public class RepoSummary
+{
+    public string Id { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string Url { get; set; } = "";
+}
+
+public class RepoAddedPayload
+{
+    public string RequestId { get; set; } = "";
+    public string RepoId { get; set; } = "";
+    public string RepoName { get; set; } = "";
+    public string Url { get; set; } = "";
+}
+
+public class RepoProgressPayload
+{
+    public string RequestId { get; set; } = "";
+    public string Message { get; set; } = "";
+}
+
+public class RepoErrorPayload
+{
+    public string RequestId { get; set; } = "";
+    public string Error { get; set; } = "";
 }

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -1740,6 +1740,37 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
         return await _bridgeClient.ListDirectoriesAsync(path, ct);
     }
 
+    /// <summary>
+    /// Add a repository. In remote mode, delegates to bridge client; otherwise should be called via direct RepoManager access from UI.
+    /// </summary>
+    public async Task<RepoAddedPayload> AddRepositoryViaBridgeAsync(string url, Action<string>? onProgress = null, CancellationToken ct = default)
+    {
+        if (!IsRemoteMode || !_bridgeClient.IsConnected)
+            throw new InvalidOperationException("AddRepositoryViaBridgeAsync only works in remote mode with active bridge connection.");
+        return await _bridgeClient.AddRepoAsync(url, onProgress, ct);
+    }
+
+    /// <summary>
+    /// Remove a repository. In remote mode, delegates to bridge client; otherwise should be called via direct RepoManager access from UI.
+    /// </summary>
+    public async Task RemoveRepositoryViaBridgeAsync(string repoId, bool deleteFromDisk, string? groupId = null, CancellationToken ct = default)
+    {
+        if (!IsRemoteMode || !_bridgeClient.IsConnected)
+            throw new InvalidOperationException("RemoveRepositoryViaBridgeAsync only works in remote mode with active bridge connection.");
+        await _bridgeClient.RemoveRepoAsync(repoId, deleteFromDisk, groupId, ct);
+    }
+
+    /// <summary>
+    /// Request repos list from remote server.
+    /// </summary>
+    public async Task RequestReposListAsync(CancellationToken ct = default)
+    {
+        if (IsRemoteMode && _bridgeClient.IsConnected)
+        {
+            await _bridgeClient.RequestReposAsync(ct);
+        }
+    }
+
     public void RemoveQueuedMessage(string sessionName, int index)
     {
         if (!_sessions.TryGetValue(sessionName, out var state))

--- a/PolyPilot/Services/DevTunnelService.cs
+++ b/PolyPilot/Services/DevTunnelService.cs
@@ -18,6 +18,7 @@ public partial class DevTunnelService : IDisposable
 {
     private readonly WsBridgeServer _bridge;
     private readonly CopilotService _copilot;
+    private readonly RepoManager _repoManager;
     private Process? _hostProcess;
     private string? _tunnelUrl;
     private string? _tunnelId;
@@ -27,10 +28,11 @@ public partial class DevTunnelService : IDisposable
 
     public const int BridgePort = 4322;
 
-    public DevTunnelService(WsBridgeServer bridge, CopilotService copilot)
+    public DevTunnelService(WsBridgeServer bridge, CopilotService copilot, RepoManager repoManager)
     {
         _bridge = bridge;
         _copilot = copilot;
+        _repoManager = repoManager;
     }
 
     public TunnelState State => _state;
@@ -205,6 +207,7 @@ public partial class DevTunnelService : IDisposable
         {
             // Hook bridge to CopilotService for state sync
             _bridge.SetCopilotService(_copilot);
+            _bridge.SetRepoManager(_repoManager);
 
             // Start WebSocket bridge: WS on BridgePort for remote viewer clients
             _bridge.Start(BridgePort, copilotPort);

--- a/PolyPilot/Services/IWsBridgeClient.cs
+++ b/PolyPilot/Services/IWsBridgeClient.cs
@@ -48,4 +48,10 @@ public interface IWsBridgeClient
     Task RenameSessionAsync(string oldName, string newName, CancellationToken ct = default);
     Task SendOrganizationCommandAsync(OrganizationCommandPayload payload, CancellationToken ct = default);
     Task<DirectoriesListPayload> ListDirectoriesAsync(string? path = null, CancellationToken ct = default);
+
+    // Repo operations
+    event Action<ReposListPayload>? OnReposListReceived;
+    Task<RepoAddedPayload> AddRepoAsync(string url, Action<string>? onProgress = null, CancellationToken ct = default);
+    Task RemoveRepoAsync(string repoId, bool deleteFromDisk, string? groupId = null, CancellationToken ct = default);
+    Task RequestReposAsync(CancellationToken ct = default);
 }


### PR DESCRIPTION
## Problem
On mobile (remote mode), the "+ Repo" button is visible but non-functional. `RepoManager` runs `git clone` locally which does nothing useful on a phone.

## Solution
Added bridge messages for repo operations so mobile clients can manage repos on the desktop server:

### New Bridge Messages
| Type | Direction | Purpose |
|------|-----------|---------|
| `add_repo` | Client → Server | Clone/fetch a repository |
| `repo_added` | Server → Client | Clone completed successfully |
| `repo_progress` | Server → Client | Stream git clone progress |
| `repo_error` | Server → Client | Clone failed |
| `remove_repo` | Client → Server | Remove a repository |
| `list_repos` | Client → Server | Query available repos |
| `repos_list` | Server → Client | List of repos response |

### Architecture
- **Server**: `WsBridgeServer` delegates to `RepoManager`, streams progress, creates org groups
- **Client**: Request/response with 5-min timeout, progress callback support
- **UI**: Routes through `CopilotService.AddRepoRemoteAsync`/`RemoveRepoRemoteAsync`

### Tests
12 new tests in `RemoteRepoTests.cs`. All 857 existing tests pass.