### PR TITLE
fix: adapt iOS status bar text color to current theme

### DIFF
--- a/PolyPilot/Platforms/iOS/Info.plist
+++ b/PolyPilot/Platforms/iOS/Info.plist
@@ -32,9 +32,7 @@
     <string>Assets.xcassets/appicon.appiconset</string>
     <key>NSCameraUsageDescription</key>
     <string>PolyPilot uses the camera to scan QR codes for connecting to remote servers.</string>
-    <key>UIStatusBarStyle</key>
-    <string>UIStatusBarStyleLightContent</string>
     <key>UIViewControllerBasedStatusBarAppearance</key>
-    <false/>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem
In light mode on iOS, the status bar text is white-on-white (invisible) because `UIStatusBarStyle` was hardcoded to `LightContent`.

## Fix
- Removed `UIStatusBarStyle=UIStatusBarStyleLightContent` from Info.plist
- Set `UIViewControllerBasedStatusBarAppearance` to `true`

This lets iOS automatically use dark text in light mode and light text in dark mode.

## Files Changed
- `PolyPilot/Platforms/iOS/Info.plist` — 1 file, 4 lines