### PR TITLE
ci: disable PR-triggered builds to reduce costs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: Build & Release
 on:
   push:
     tags: [ 'v*' ]
-  pull_request:
     branches: [ main ]
   workflow_dispatch:
 


### PR DESCRIPTION
Removes `pull_request` trigger from `build.yml`. Builds now only run on push to main, version tags, and manual dispatch. Release workflow was already manual/schedule-only.