### PR TITLE
Fix session popup: cross-platform Copilot Console & VS Code, remove Terminal

### DIFF
--- a/PolyPilot/Components/Layout/SessionListItem.razor
+++ b/PolyPilot/Components/Layout/SessionListItem.razor
@@ -227,13 +227,17 @@
         {
             if (OperatingSystem.IsWindows())
             {
+                // Use single quotes in PS script to prevent subexpression parsing of GUIDs/parens
+                var psDir = dir.Replace("'", "''");
+                var psName = Session.Name.Replace("'", "''");
+                var psId = sessionId.Replace("'", "''");
                 var psScript = Path.Combine(Path.GetTempPath(), $"polypilot-copilot-{Guid.NewGuid():N}.ps1");
                 File.WriteAllText(psScript,
-                    $"Set-Location \"{dir}\"\n" +
-                    $"Write-Host \"🔗 Resuming session: {Session.Name} ({sessionId})\"\n" +
-                    "Write-Host \"─────────────────────────────────────────\"\n" +
-                    "Write-Host \"\"\n" +
-                    $"copilot --resume {sessionId} --yolo\n");
+                    $"Set-Location '{psDir}'\n" +
+                    $"Write-Host '🔗 Resuming session: {psName} ({psId})'\n" +
+                    "Write-Host '─────────────────────────────────────────'\n" +
+                    "Write-Host ''\n" +
+                    $"copilot --resume '{psId}' --yolo\n");
                 Process.Start(new ProcessStartInfo("powershell.exe",
                     $"-ExecutionPolicy Bypass -NoExit -File \"{psScript}\"")
                 {


### PR DESCRIPTION
## Summary

Fix three issues in the session context menu popup (SessionListItem.razor):

1. **Copilot Console** — Was macOS-only (bash script + `open -a Terminal`). Now works cross-platform: Windows writes a `.ps1` script and launches it with `powershell.exe -ExecutionPolicy Bypass -NoExit`, matching the existing `LaunchCopilotInTerminal` pattern in `SessionSidebar.razor`. Uses single-quoted strings to prevent PowerShell from interpreting `(guid)` as subexpressions.

2. **Terminal button** — Removed from the menu (no longer needed).

3. **VS Code** — Was using `UseShellExecute = false` which can't find `code.cmd` on Windows. Now uses `cmd.exe /c code` on Windows, keeping the direct `code` invocation on macOS.

## Testing

- Verified Copilot Console launches correctly on Windows with GUID session IDs (no subexpression parsing errors)
- Verified VS Code opens to the session working directory on Windows
- Build succeeds on `net10.0-windows10.0.19041.0`
- 879/883 tests pass (4 pre-existing `DiffParserTests` failures unrelated to this change)