### PR TITLE
fix: show spinner on mobile while auto-reconnecting to saved server

### DIFF
--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -44,6 +44,15 @@
             }
             @if (PlatformHelper.IsMobile && !CopilotService.IsInitialized)
             {
+                @if (mobileAutoConnecting)
+                {
+                    <div class="restoring-indicator">
+                        <div class="restoring-spinner"></div>
+                        <span>Connecting to server…</span>
+                    </div>
+                }
+                else
+                {
                 <div class="mobile-connect-card">
                     <button class="scan-qr-btn" @onclick="DashboardScanQr">
                         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>
@@ -60,6 +69,7 @@
                         <p class="mobile-connect-error">@mobileConnectError</p>
                     }
                 </div>
+                }
             }
         </div>
     }
@@ -340,6 +350,7 @@
     private string mobileRemoteUrl = "";
     private string mobileRemoteToken = "";
     private bool mobileConnecting;
+    private bool mobileAutoConnecting;
     private string? mobileConnectError;
     private bool _needsScrollToBottom;
     private volatile bool _sessionSwitching; // true during ExpandSession to skip redundant JS interop
@@ -396,6 +407,10 @@
             var cs = ConnectionSettings.Load();
             mobileRemoteUrl = cs.RemoteUrl ?? "";
             mobileRemoteToken = cs.RemoteToken ?? "";
+
+            // Show spinner instead of connect form while auto-reconnecting
+            if (cs.Mode == ConnectionMode.Remote && !string.IsNullOrWhiteSpace(cs.RemoteUrl))
+                mobileAutoConnecting = true;
         }
     }
 
@@ -519,6 +534,10 @@
             initError = Models.ErrorMessageHelper.Humanize(ex);
             Console.WriteLine($"Init error: {ex}");
             _initializationComplete = true; // Even on error, allow normal operation
+        }
+        finally
+        {
+            mobileAutoConnecting = false;
         }
 
         RefreshState();


### PR DESCRIPTION
## Problem
On mobile, when the app opens with an existing saved remote connection, the connect form (QR scan + URL input) flashes briefly before the app reconnects. This is confusing — it looks like the connection was lost.

## Fix
Added a `mobileAutoConnecting` flag that:
1. Is set to `true` in `OnInitializedAsync` when saved remote settings exist
2. Shows a "Connecting to server…" spinner (reuses existing `restoring-indicator` CSS) instead of the connect form
3. Is cleared in a `finally` block after `InitializeAsync` completes (success or failure)
4. Once cleared, either the app is connected (form hidden) or the connect form appears for manual entry

## Changes
- `Dashboard.razor` — 1 file, 19 lines added (no CSS changes needed, reuses existing spinner styles)