### PR TITLE
fix: show spinner during mobile init instead of connect form

### DIFF
--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -42,7 +42,14 @@
                     <button class="dismiss-btn" @onclick="DismissFallbackNotice">Dismiss</button>
                 </div>
             }
-            @if (PlatformHelper.IsMobile && !CopilotService.IsInitialized)
+            @if (PlatformHelper.IsMobile && !CopilotService.IsInitialized && !_initializationComplete)
+            {
+                <div class="restoring-indicator">
+                    <div class="restoring-spinner"></div>
+                    <span>Connecting…</span>
+                </div>
+            }
+            else if (PlatformHelper.IsMobile && !CopilotService.IsInitialized)
             {
                 <div class="mobile-connect-card">
                     <button class="scan-qr-btn" @onclick="DashboardScanQr">


### PR DESCRIPTION
## Problem
On mobile, the connect screen (QR scan + manual URL entry) flashed immediately on app launch, even when saved connection settings existed and the app was already connecting in the background.

## Fix
Added a check for `_initializationComplete` — while initialization is still running, a "Connecting…" spinner is shown (reusing the existing `restoring-indicator` CSS class). The connect form only appears after initialization finishes without a successful connection.

**1 file changed, 7-line addition in Dashboard.razor.**