### PR TITLE
feat: show git branch in expanded chat header

### DIFF
--- a/PolyPilot/Components/ExpandedSessionView.razor
+++ b/PolyPilot/Components/ExpandedSessionView.razor
@@ -11,6 +11,10 @@
 <div class="expanded-card @cardClass" data-session="@Session.Name">
     <div class="chat-header">
         <h2 class="chat-header-title">@Session.Name</h2>
+        @if (!string.IsNullOrEmpty(Session.GitBranch))
+        {
+            <span class="chat-header-branch" title="@Session.GitBranch">@Session.GitBranch</span>
+        }
         <div class="chat-header-badges">
             @if (Session.IsProcessing)
             {

--- a/PolyPilot/Components/ExpandedSessionView.razor.css
+++ b/PolyPilot/Components/ExpandedSessionView.razor.css
@@ -21,7 +21,8 @@
     min-width: 0;
     flex-wrap: wrap;
 }
-.chat-header-title { margin: 0; font-size: var(--type-title2); min-width: 0; flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.chat-header-title { margin: 0; font-size: var(--type-title2); min-width: 0; flex-shrink: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.chat-header-branch { font-size: 0.7rem; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 200px; flex-shrink: 2; }
 .chat-header-badges { display: flex; align-items: center; gap: 0.5rem; flex-shrink: 1; flex-wrap: wrap; min-width: 0; }
 
 /* Info popover */


### PR DESCRIPTION
## Problem
The git branch is already tracked per session (`AgentSessionInfo.GitBranch`) but only visible in the info popover (ℹ️) and session cards — not in the expanded chat view where you spend most of your time.

## Fix
Added the branch name inline in the chat header, between the session title and the badges:

```
Session Name    feature/my-branch    [processing dot] [ℹ️] [⊟]
```

- Muted text at 0.7rem, ellipsis overflow at 200px max
- Only shown when `GitBranch` is non-empty
- Title attribute shows full branch name on hover/long-press

**2 files, 6 lines added.**