### PR TITLE
Fix /help output centered instead of left-aligned

### DIFF
--- a/PolyPilot.Tests/ChatMessageTests.cs
+++ b/PolyPilot.Tests/ChatMessageTests.cs
@@ -209,6 +209,27 @@ public class ChatMessageTests
         // The truncated version should be 80 chars + ellipsis, not the full 200
         Assert.DoesNotContain(longPrompt, msg.Content);
     }
+    // --- Multiline system message detection (help output alignment) ---
+
+    [Fact]
+    public void SystemMessage_HelpOutput_IsMultiline()
+    {
+        var helpContent = "**Available commands:**\n" +
+            "- `/help` — Show this help\n" +
+            "- `/clear` — Clear chat history\n" +
+            "- `/new [name]` — Create a new session";
+        var msg = ChatMessage.SystemMessage(helpContent);
+
+        Assert.True(msg.Content.Contains("\n-"), "Help output should be detected as multiline list content");
+    }
+
+    [Fact]
+    public void SystemMessage_ShortMessage_IsNotMultiline()
+    {
+        var msg = ChatMessage.SystemMessage("Session cleared.");
+
+        Assert.False(msg.Content.Contains("\n-"), "Short system messages should not be detected as multiline");
+    }
 }
 
 public class ToolActivityTests

--- a/PolyPilot/Components/ChatMessageItem.razor
+++ b/PolyPilot/Components/ChatMessageItem.razor
@@ -177,7 +177,7 @@
         break;
 
     case ChatMessageType.System:
-        <div class="chat-msg system">
+        <div class="chat-msg system @(Message.Content.Contains("\n-") ? "system-multiline" : "")">
             <div class="system-text markdown-body">@((MarkupString)ChatMessageList.RenderMarkdown(Message.Content))</div>
         </div>
         break;

--- a/PolyPilot/Components/ChatMessageList.razor.css
+++ b/PolyPilot/Components/ChatMessageList.razor.css
@@ -213,6 +213,10 @@
     justify-content: center;
 }
 
+.chat-message-list.full ::deep .chat-msg.system.system-multiline {
+    justify-content: flex-start;
+}
+
 .chat-message-list.full ::deep .system-text {
     font-size: 12px;
     color: var(--text-muted);
@@ -220,6 +224,11 @@
     text-align: center;
     padding: 0.2rem 0.5rem;
     opacity: 0.7;
+}
+
+.chat-message-list.full ::deep .chat-msg.system.system-multiline .system-text {
+    text-align: left;
+    font-style: normal;
 }
 
 .chat-message-list.full ::deep .chat-msg.reflection {
@@ -890,11 +899,18 @@
 .chat-message-list.full.style-minimal ::deep .chat-msg.system {
     justify-content: center;
 }
+.chat-message-list.full.style-minimal ::deep .chat-msg.system.system-multiline {
+    justify-content: flex-start;
+}
 .chat-message-list.full.style-minimal ::deep .system-text {
     font-size: 12px;
     text-align: center;
     padding: 0.2rem 0.5rem;
     opacity: 0.7;
+}
+.chat-message-list.full.style-minimal ::deep .chat-msg.system.system-multiline .system-text {
+    text-align: left;
+    font-style: normal;
 }
 .chat-message-list.full.style-minimal ::deep .chat-msg-time {
     font-size: 16px;


### PR DESCRIPTION
## Problem
The `/help` command output was vertically centered (`text-align: center`, `justify-content: center`) because it renders as a system message. This made the list of commands hard to read.

## Fix
Added a `system-multiline` CSS class that is conditionally applied when a system message contains markdown list items (`\n-`). This class overrides the centering with `text-align: left` and `justify-content: flex-start`, so structured list content like `/help` output is left-aligned while short one-liner system messages remain centered.

### Changes
- **ChatMessageItem.razor**: Conditionally add `system-multiline` class to system messages with list content
- **ChatMessageList.razor.css**: Add CSS rules for `.system-multiline` in both default and minimal styles
- **ChatMessageTests.cs**: Add tests verifying multiline detection for help vs short messages