### PR TITLE
Fix DevTunnel warning flash on Settings page load

### DIFF
--- a/PolyPilot/Components/Pages/Settings.razor
+++ b/PolyPilot/Components/Pages/Settings.razor
@@ -120,7 +120,14 @@
     {
         <div class="mode-linked-panel @(SectionVisible("devtunnel share tunnel remote mobile qr") ? "" : "search-hidden")">
             <h3>Share via DevTunnel</h3>
-                @if (!devTunnelAvailable)
+                @if (devTunnelAvailable == null)
+                {
+                    <div class="tunnel-checking">
+                        <svg class="icon spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+                        <span>Checking for devtunnel CLI…</span>
+                    </div>
+                }
+                else if (devTunnelAvailable == false)
                 {
                     <div class="tunnel-warning">
                         <p><svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg> <code>devtunnel</code> CLI not found. Install it to share your server remotely.</p>
@@ -540,7 +547,7 @@
     private string statusClass = "";
     private bool serverAlive;
     private bool starting;
-    private bool devTunnelAvailable;
+    private bool? devTunnelAvailable;
     private bool tunnelLoggedIn;
     private bool tunnelBusy;
     private bool showToken;
@@ -672,7 +679,7 @@
         await Task.WhenAll(tasks);
         cliInfo = await cliInfoTask;
 
-        if (devTunnelAvailable)
+        if (devTunnelAvailable == true)
             tunnelLoggedIn = await DevTunnelService.IsLoggedInAsync();
 
         // Regenerate direct QR code now that local IPs are available

--- a/PolyPilot/Components/Pages/Settings.razor.css
+++ b/PolyPilot/Components/Pages/Settings.razor.css
@@ -600,6 +600,15 @@
     border-color: var(--accent-primary);
 }
 
+.tunnel-checking {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    color: var(--text-dim);
+    font-size: var(--type-body);
+}
+
 .tunnel-warning {
     padding: 0.75rem;
     background: rgba(251, 191, 36, 0.1);


### PR DESCRIPTION
## Problem
When navigating to Settings, a warning banner saying `devtunnel CLI not found` flashes briefly before the async CLI detection completes. This is confusing — it looks like something is broken.

## Root Cause

## Fix
- Changed `devTunnelAvailable` from `bool` to `bool?` (null = unknown/checking)
- Added a third state in the template: when `null`, show a spinner with "Checking for devtunnel CLI…"
- Warning only shows after detection confirms `false`
- Added `.tunnel-checking` CSS class for the loading state

**2 files changed, 19 additions, 3 deletions.**