### PR TITLE
Focus newly created sessions immediately

### DIFF
--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -930,9 +930,11 @@
             }
             else if (sessionSwitched && active == null)
             {
-                // Active session was closed — sync _lastActiveSession so the throttle
-                // bypass doesn't persist across subsequent refreshes.
+                // Active session was closed — clear all session-specific UI state so stale
+                // values don't linger until the next session is created.
                 _lastActiveSession = null;
+                expandedSession = null;
+                _focusedInputId = null;
             }
             
             if (_lastActiveSession == null && active != null)
@@ -944,7 +946,7 @@
                 if (!s.IsProcessing && streamingBySession.ContainsKey(s.Name))
                     streamingBySession.Remove(s.Name);
             }
-            if (sessionSwitched)
+            if (sessionSwitched && active != null)
             {
                 // _sessionSwitching stays true until SafeRefreshAsync reads it — 
                 // this skips the expensive JS draft capture round-trip during switches


### PR DESCRIPTION
## Summary
- make session switch detection work when there was no previous active session
- ensure newly created sessions get the same selection/focus behavior as resumed sessions

## Implementation
- updated `RefreshState` in `Dashboard.razor`
- changed switch detection from requiring non-null previous session to `active != _lastActiveSession`
- kept guard that `active` must exist in current sessions list before applying focus/expanded updates

## Validation
- built Mac Catalyst target successfully (`dotnet build -f net10.0-maccatalyst`)