### PR TITLE
Fix CLI source setting: allow switching back to Built-in

### DIFF
--- a/PolyPilot.Tests/Scenarios/mode-switch-scenarios.json
+++ b/PolyPilot.Tests/Scenarios/mode-switch-scenarios.json
@@ -869,7 +869,72 @@
           "expect": {
             "equals": true
           },
-          "note": "Token remains blurred — QR and token toggles are independent"
+          "note": "Token remains blurred \u2014 QR and token toggles are independent"
+        }
+      ]
+    },
+    {
+      "id": "cli-source-builtin-card-not-disabled-with-system-fallback",
+      "name": "Built-in CLI card is selectable when bundled CLI is missing but system CLI exists (fallback)",
+      "steps": [
+        {
+          "action": "click",
+          "selector": "a[href='/settings']",
+          "note": "Navigate to Settings"
+        },
+        {
+          "action": "wait",
+          "duration": 2000
+        },
+        {
+          "action": "evaluate",
+          "script": "document.querySelectorAll('.cli-card')[0].classList.contains('disabled')",
+          "expect": {
+            "equals": "false"
+          },
+          "note": "Built-in card should NOT be disabled even if bundled CLI is missing (system fallback exists)"
+        },
+        {
+          "action": "evaluate",
+          "script": "document.querySelectorAll('.cli-card')[1].click()",
+          "note": "Click System CLI card"
+        },
+        {
+          "action": "wait",
+          "duration": 500
+        },
+        {
+          "action": "evaluate",
+          "script": "document.querySelector('.cli-card.selected .cli-card-label')?.textContent",
+          "expect": {
+            "equals": "System"
+          },
+          "note": "Verify System is now selected"
+        },
+        {
+          "action": "evaluate",
+          "script": "document.querySelectorAll('.cli-card')[0].click()",
+          "note": "Click Built-in card to switch back"
+        },
+        {
+          "action": "wait",
+          "duration": 500
+        },
+        {
+          "action": "evaluate",
+          "script": "document.querySelector('.cli-card.selected .cli-card-label')?.textContent",
+          "expect": {
+            "equals": "Built-in"
+          },
+          "note": "Verify Built-in is selected again (this was the bug: could not switch back)"
+        },
+        {
+          "action": "shell",
+          "command": "cat ~/.polypilot/settings.json | python3 -c \"import sys,json; print(json.load(sys.stdin)[\\\"CliSource\\\"])\"",
+          "expect": {
+            "equals": "0"
+          },
+          "note": "Verify CliSource=0 (BuiltIn) persisted to disk after switching back"
         }
       ]
     }

--- a/PolyPilot/Components/Pages/Settings.razor
+++ b/PolyPilot/Components/Pages/Settings.razor
@@ -380,13 +380,13 @@
         <h2 class="group-title">Copilot CLI</h2>
         <div class="settings-section @(SectionVisible("cli source built-in system version binary copilot") ? "" : "search-hidden")">
             <div class="cli-cards">
-                <div class="cli-card @(settings.CliSource == CliSourceMode.BuiltIn ? "selected" : "") @(cliInfo.builtInPath == null ? "disabled" : "")"
+                <div class="cli-card @(settings.CliSource == CliSourceMode.BuiltIn ? "selected" : "") @(cliInfo.builtInPath == null && cliInfo.systemPath == null ? "disabled" : "")"
                      @onclick="() => SetCliSource(CliSourceMode.BuiltIn)">
                     <div class="cli-card-icon">📦</div>
                     <div class="cli-card-label">Built-in</div>
                     <div class="cli-card-ver">v@(cliInfo.builtInVersion ?? "—")</div>
                 </div>
-                <div class="cli-card @(settings.CliSource == CliSourceMode.System ? "selected" : "") @(cliInfo.systemPath == null ? "disabled" : "")"
+                <div class="cli-card @(settings.CliSource == CliSourceMode.System ? "selected" : "") @(cliInfo.systemPath == null && cliInfo.builtInPath == null ? "disabled" : "")"
                      @onclick="() => SetCliSource(CliSourceMode.System)">
                     <div class="cli-card-icon">💻</div>
                     <div class="cli-card-label">System</div>
@@ -396,6 +396,10 @@
             @if (cliSourceChanged)
             {
                 <div class="cli-restart-hint">⟳ Restart the app to apply the change</div>
+            }
+            @if (settings.CliSource == CliSourceMode.BuiltIn && cliInfo.builtInPath == null && cliInfo.systemPath != null)
+            {
+                <div class="cli-path-warn">⚠ No bundled CLI found — will use system CLI</div>
             }
             @if (settings.CliSource == CliSourceMode.System && cliInfo.systemPath != null)
             {
@@ -827,8 +831,8 @@
 
     private void SetCliSource(CliSourceMode source)
     {
-        if (source == CliSourceMode.BuiltIn && cliInfo.builtInPath == null) return;
-        if (source == CliSourceMode.System && cliInfo.systemPath == null) return;
+        // Only block selection if no CLI is available at all (both modes have fallback logic)
+        if (cliInfo.builtInPath == null && cliInfo.systemPath == null) return;
         settings.CliSource = source;
         cliSourceChanged = source != _initialCliSource;
         settings.Save();

--- a/PolyPilot/Models/ConnectionSettings.cs
+++ b/PolyPilot/Models/ConnectionSettings.cs
@@ -112,6 +112,10 @@ public class ConnectionSettings
         if (!PlatformHelper.AvailableModes.Contains(settings.Mode))
             settings.Mode = PlatformHelper.DefaultMode;
 
+        // Ensure CliSource is a valid enum value (guards against corrupt settings)
+        if (!Enum.IsDefined(settings.CliSource))
+            settings.CliSource = CliSourceMode.BuiltIn;
+
         return settings;
     }
 


### PR DESCRIPTION
## Bug
When the user selects **System** CLI source in Settings, they cannot switch back to **Built-in**. The Built-in card becomes disabled and unclickable.

## Root Cause
`ResolveBundledCliPath()` returns null when the bundled binary isn't at expected paths (common on Mac Catalyst where MAUI flattens the runtime layout). The UI disabled the Built-in card based solely on this, ignoring that `ResolveCopilotCliPath(BuiltIn)` has fallback logic that uses the system CLI when the bundled one is missing.

## Fix
- **Settings.razor**: Disable CLI cards only when NO CLI is available at all (both `builtInPath` and `systemPath` are null), not when just the preferred source is missing. Added fallback warning for Built-in mode ("⚠ No bundled CLI found — will use system CLI").
- **ConnectionSettings.cs**: Validate `CliSource` enum value in `Load()` to handle corrupt/invalid settings gracefully (mirrors existing Mode validation).
- **Tests**: 7 new unit tests covering guard logic, card disabled conditions, and invalid CliSource deserialization.
- **Scenarios**: New UI scenario verifying switch-back to Built-in works.