### PR TITLE
Add tooltips to all bottom-of-window buttons and labels

### DIFF
--- a/PolyPilot.Tests/BottomBarTooltipTests.cs
+++ b/PolyPilot.Tests/BottomBarTooltipTests.cs
@@ -1,0 +1,147 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace PolyPilot.Tests;
+
+/// <summary>
+/// Ensures all interactive buttons and informational labels at the bottom of the
+/// ExpandedSessionView, SessionSidebar footer, and Dashboard toolbar have
+/// title attributes (tooltip / information bubbles) for discoverability.
+/// </summary>
+public class BottomBarTooltipTests
+{
+    private static string GetRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "PolyPilot.slnx")))
+            dir = Directory.GetParent(dir)?.FullName;
+        return dir ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+
+    // --- ExpandedSessionView: input-status-bar ---
+
+    [Fact]
+    public void ExpandedSessionView_SendButton_HasTitle()
+    {
+        var content = ReadExpandedSessionView();
+        // The send button (non-stop) must have a title attribute
+        Assert.Contains(@"title=""Send message""", content);
+    }
+
+    [Fact]
+    public void ExpandedSessionView_ChatModeButton_HasTitle()
+    {
+        var content = ReadExpandedSessionView();
+        Assert.Contains(@"title=""Chat mode", content);
+    }
+
+    [Fact]
+    public void ExpandedSessionView_PlanModeButton_HasTitle()
+    {
+        var content = ReadExpandedSessionView();
+        Assert.Contains(@"title=""Plan mode", content);
+    }
+
+    [Fact]
+    public void ExpandedSessionView_AutopilotModeButton_HasTitle()
+    {
+        var content = ReadExpandedSessionView();
+        Assert.Contains(@"title=""Autopilot mode", content);
+    }
+
+    [Fact]
+    public void ExpandedSessionView_LogLabel_HasTitle()
+    {
+        var content = ReadExpandedSessionView();
+        // The "Log" label must have a title attribute
+        Assert.Matches(@"class=""log-label""[^>]*\btitle=""[^""]+""", content);
+    }
+
+    [Fact]
+    public void ExpandedSessionView_MessageCount_HasTitle()
+    {
+        var content = ReadExpandedSessionView();
+        Assert.Matches(@"class=""status-msgs""[^>]*\btitle=""[^""]+""", content);
+    }
+
+    [Fact]
+    public void ExpandedSessionView_SkillsTrigger_HasTitle()
+    {
+        var content = ReadExpandedSessionView();
+        Assert.Matches(@"data-trigger=""skills""[^>]*\btitle=""[^""]+""", content);
+    }
+
+    [Fact]
+    public void ExpandedSessionView_AgentsTrigger_HasTitle()
+    {
+        var content = ReadExpandedSessionView();
+        Assert.Matches(@"data-trigger=""agents""[^>]*\btitle=""[^""]+""", content);
+    }
+
+    [Fact]
+    public void ExpandedSessionView_PromptsTrigger_HasTitle()
+    {
+        var content = ReadExpandedSessionView();
+        Assert.Matches(@"data-trigger=""prompts""[^>]*\btitle=""[^""]+""", content);
+    }
+
+    [Fact]
+    public void ExpandedSessionView_TokenUsage_HasTitle()
+    {
+        var content = ReadExpandedSessionView();
+        Assert.Matches(@"class=""status-tokens""[^>]*\btitle=""[^""]+""", content);
+    }
+
+    [Fact]
+    public void ExpandedSessionView_ContextUsage_HasTitle()
+    {
+        var content = ReadExpandedSessionView();
+        Assert.Matches(@"class=""status-ctx""[^>]*\btitle=""[^""]+""", content);
+    }
+
+    // --- SessionSidebar: footer buttons ---
+
+    [Fact]
+    public void SessionSidebar_SubmitIssueButton_HasTitle()
+    {
+        var content = ReadSessionSidebar();
+        Assert.Matches(@"SubmitBugReport[^>]*\btitle=""[^""]+""", content);
+    }
+
+    [Fact]
+    public void SessionSidebar_LaunchCopilotButton_HasTitle()
+    {
+        var content = ReadSessionSidebar();
+        Assert.Matches(@"LaunchFixIt[^>]*\btitle=""[^""]+""", content);
+    }
+
+    // --- Dashboard: expanded toolbar ---
+
+    [Fact]
+    public void Dashboard_ExpandedToolbar_SendAllButton_HasTitle()
+    {
+        var content = ReadDashboard();
+        // The expanded toolbar Send All button (SendToExpandedMultiAgentGroup) must have a title
+        Assert.Matches(@"SendToExpandedMultiAgentGroup[^>]*\btitle=""[^""]+""", content);
+    }
+
+    // --- Helpers ---
+
+    private string ReadExpandedSessionView()
+    {
+        var file = Path.Combine(GetRepoRoot(), "PolyPilot", "Components", "ExpandedSessionView.razor");
+        return File.ReadAllText(file);
+    }
+
+    private string ReadSessionSidebar()
+    {
+        var file = Path.Combine(GetRepoRoot(), "PolyPilot", "Components", "Layout", "SessionSidebar.razor");
+        return File.ReadAllText(file);
+    }
+
+    private string ReadDashboard()
+    {
+        var file = Path.Combine(GetRepoRoot(), "PolyPilot", "Components", "Pages", "Dashboard.razor");
+        return File.ReadAllText(file);
+    }
+}

--- a/PolyPilot/Components/ExpandedSessionView.razor
+++ b/PolyPilot/Components/ExpandedSessionView.razor
@@ -205,15 +205,15 @@
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>
                 </button>
             }
-            <button class="send-btn" @onclick="() => OnSend.InvokeAsync(Session.Name)">
+            <button class="send-btn" @onclick="() => OnSend.InvokeAsync(Session.Name)" title="Send message">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M6 4l14 8-14 8V4z"/></svg>
             </button>
         </div>
         <div class="input-status-bar">
             <div class="mode-switcher">
-                <button class="mode-btn @(InputMode == "chat" ? "active" : "")" @onclick='() => OnSetInputMode.InvokeAsync("chat")'>Chat</button>
-                <button class="mode-btn @(InputMode == "plan" ? "active" : "")" @onclick='() => OnSetInputMode.InvokeAsync("plan")'>Plan</button>
-                <button class="mode-btn @(InputMode == "autopilot" ? "active" : "")" @onclick='() => OnSetInputMode.InvokeAsync("autopilot")'>Autopilot</button>
+                <button class="mode-btn @(InputMode == "chat" ? "active" : "")" @onclick='() => OnSetInputMode.InvokeAsync("chat")' title="Chat mode — interactive conversation">Chat</button>
+                <button class="mode-btn @(InputMode == "plan" ? "active" : "")" @onclick='() => OnSetInputMode.InvokeAsync("plan")' title="Plan mode — create a plan before implementing">Plan</button>
+                <button class="mode-btn @(InputMode == "autopilot" ? "active" : "")" @onclick='() => OnSetInputMode.InvokeAsync("autopilot")' title="Autopilot mode — auto-approve tool calls">Autopilot</button>
 
             </div>
             @if (Session.ReflectionCycle is null || !Session.ReflectionCycle.IsActive)
@@ -221,23 +221,23 @@
                 <button class="mode-btn" style="margin-left:8px;opacity:0.7" title="Start a reflection cycle" @onclick="InsertReflectCommand">Reflect</button>
             }
             <span class="status-sep">·</span>
-            <span class="log-label" style="font-size:var(--type-footnote)">Log</span>
+            <span class="log-label" style="font-size:var(--type-footnote)" title="View session event log">Log</span>
             <span class="status-sep">·</span>
-            <span class="status-msgs">@Session.History.Count msgs</span>
+            <span class="status-msgs" title="Total messages in this session">@Session.History.Count msgs</span>
             @if (availableSkills?.Count > 0)
             {
                 <span class="status-sep">·</span>
-                <span class="skills-trigger" data-trigger="skills" @onclick="ShowSkillsPopup">@availableSkills.Count skills</span>
+                <span class="skills-trigger" data-trigger="skills" @onclick="ShowSkillsPopup" title="View available skills">@availableSkills.Count skills</span>
             }
             @if (availableAgents?.Count > 0)
             {
                 <span class="status-sep">·</span>
-                <span class="skills-trigger" data-trigger="agents" @onclick="ShowAgentsPopup">@availableAgents.Count agents</span>
+                <span class="skills-trigger" data-trigger="agents" @onclick="ShowAgentsPopup" title="View available agents">@availableAgents.Count agents</span>
             }
             @if (availablePrompts?.Count > 0)
             {
                 <span class="status-sep">·</span>
-                <span class="skills-trigger" data-trigger="prompts" @onclick="ShowPromptsPopup">@availablePrompts.Count prompts</span>
+                <span class="skills-trigger" data-trigger="prompts" @onclick="ShowPromptsPopup" title="View saved prompts">@availablePrompts.Count prompts</span>
             }
             <span class="status-sep">·</span>
             <select class="inline-model-select" value="@CurrentModel" @onchange="e => OnSetModel.InvokeAsync(e.Value?.ToString())" disabled="@Session.IsProcessing" title="@(Session.IsProcessing ? "Wait for response to complete" : "Switch model")">
@@ -256,14 +256,14 @@
                 {
                     @if (UsageInfo.InputTokens.HasValue || UsageInfo.OutputTokens.HasValue)
                     {
-                        <span class="status-tokens">↑@FormatTokenCount(UsageInfo.InputTokens ?? 0) ↓@FormatTokenCount(UsageInfo.OutputTokens ?? 0)</span>
+                        <span class="status-tokens" title="Token usage: ↑ input tokens sent, ↓ output tokens received">↑@FormatTokenCount(UsageInfo.InputTokens ?? 0) ↓@FormatTokenCount(UsageInfo.OutputTokens ?? 0)</span>
                     }
                     @if (UsageInfo.CurrentTokens.HasValue && UsageInfo.TokenLimit.HasValue)
                     {
                         var pct = (double)UsageInfo.CurrentTokens.Value / UsageInfo.TokenLimit.Value;
                         var ctxColor = pct > 0.9 ? "#ef4444" : pct > 0.75 ? "#fbbf24" : "inherit";
                         <span class="status-sep">·</span>
-                        <span class="status-ctx" style="color:@ctxColor">@FormatTokenCount(UsageInfo.CurrentTokens.Value)/@FormatTokenCount(UsageInfo.TokenLimit.Value) ctx</span>
+                        <span class="status-ctx" style="color:@ctxColor" title="Context window usage — current tokens / maximum tokens">@FormatTokenCount(UsageInfo.CurrentTokens.Value)/@FormatTokenCount(UsageInfo.TokenLimit.Value) ctx</span>
                     }
                 }
             </span>

--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -108,7 +108,7 @@ else
                         {
                             <span class="bug-report-status @(footerStatus.StartsWith("✓") ? "success" : "error")">@footerStatus</span>
                         }
-                        <button class="bug-report-submit" @onclick="SubmitBugReport" disabled="@footerSubmitting">
+                        <button class="bug-report-submit" @onclick="SubmitBugReport" disabled="@footerSubmitting" title="Submit bug report as a GitHub issue">
                             @(footerSubmitting ? "Submitting…" : "Submit Issue")
                         </button>
                     </div>
@@ -138,7 +138,7 @@ else
                         {
                             <span class="bug-report-status @(footerStatus.StartsWith("✓") ? "success" : footerStatus.StartsWith("⏳") ? "" : "error")">@footerStatus</span>
                         }
-                        <button class="bug-report-submit" @onclick="LaunchFixIt" disabled="@footerSubmitting">
+                        <button class="bug-report-submit" @onclick="LaunchFixIt" disabled="@footerSubmitting" title="Launch a Copilot session to fix the bug or build the feature">
                             @(footerSubmitting ? "Launching…" : "Launch Copilot")
                         </button>
                     </div>

--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -102,7 +102,7 @@
                        placeholder="@GetInputPlaceholder(expandedGroup.OrchestratorMode)"
                        @onkeydown="@(async (KeyboardEventArgs e) => { if (e.Key == "Enter") await SendToExpandedMultiAgentGroup(expandedGroupId); })"
                        @onclick:stopPropagation="true" />
-                <button class="ma-send-btn" @onclick="() => SendToExpandedMultiAgentGroup(expandedGroupId)" @onclick:stopPropagation="true">
+                <button class="ma-send-btn" @onclick="() => SendToExpandedMultiAgentGroup(expandedGroupId)" @onclick:stopPropagation="true" title="Send message to all sessions in this group">
                     📡 Send All
                 </button>
                 }


### PR DESCRIPTION
## Problem
Buttons and labels at the bottom of the window (input status bar, sidebar footer, dashboard toolbar) lacked title attributes, so users got no hover tooltips / information bubbles when hovering over them.

## Changes
Added `title` attributes to all interactive elements missing them:

### ExpandedSessionView (input status bar)
- **Send button** — `Send message`
- **Chat/Plan/Autopilot mode buttons** — describes each mode
- **Log label** — `View session event log`
- **Message count** — `Total messages in this session`
- **Skills/Agents/Prompts triggers** — `View available ...`
- **Token usage** — `Token usage: ↑ input tokens sent, ↓ output tokens received`
- **Context usage** — `Context window usage — current tokens / maximum tokens`

### SessionSidebar (footer)
- **Submit Issue button** — `Submit bug report as a GitHub issue`
- **Launch Copilot button** — `Launch a Copilot session to fix the bug or build the feature`

### Dashboard (expanded toolbar)
- **Send All button** — `Send message to all sessions in this group`

## Tests
Added `BottomBarTooltipTests.cs` with 14 regression tests that read the `.razor` files and verify all these elements have `title` attributes.

All 1300 existing tests continue to pass (1 pre-existing locale-related failure unrelated to this change).