### PR TITLE
Update NuGet packages and MauiDevFlow skill

### DIFF
--- a/.claude/skills/maui-ai-debugging/.skill-version
+++ b/.claude/skills/maui-ai-debugging/.skill-version
@@ -1,0 +1,5 @@
+{
+  "commit": "8a89c0b1c0c8711b59a3ed47000ab3cd1191f141",
+  "updatedAt": "2026-02-26T16:51:08.6726000Z",
+  "branch": "main"
+}

--- a/.claude/skills/maui-ai-debugging/references/android.md
+++ b/.claude/skills/maui-ai-debugging/references/android.md
@@ -10,6 +10,35 @@
 
 ## Emulator Management
 
+### Avoiding multi-project conflicts
+
+When multiple projects (or AI agents) may deploy to Android emulators simultaneously,
+each project should use its own dedicated AVD. Two apps deployed to the same emulator
+will coexist (unlike iOS), but `adb reverse`/`adb forward` port forwarding is per-device
+and can cause confusion when multiple emulators are running.
+
+**Before creating or starting an emulator, check what's already in use:**
+```bash
+maui-devflow list                             # shows agents with platform + port
+adb devices                                   # shows connected emulators
+```
+
+If an emulator is already running another project's agent, create a new AVD:
+```bash
+android avd create --name "ProjectName-Pixel8" \
+  --sdk "system-images;android-35;google_apis;arm64-v8a" --device pixel_8
+android avd start --name "ProjectName-Pixel8"
+```
+
+**When multiple emulators are running**, use `-s <serial>` to target a specific one:
+```bash
+adb -s emulator-5554 reverse tcp:19223 tcp:19223   # first emulator
+adb -s emulator-5556 reverse tcp:19223 tcp:19223   # second emulator
+```
+
+**Naming convention:** Use `<ProjectName>-<DeviceType>` (e.g. `TodoApp-Pixel8`) so it's
+clear which AVD belongs to which project.
+
 ### List and start AVDs
 ```bash
 android avd list                              # list available AVDs

--- a/.claude/skills/maui-ai-debugging/references/batch.md
+++ b/.claude/skills/maui-ai-debugging/references/batch.md
@@ -1,0 +1,50 @@
+# Batch Command Reference
+
+Execute multiple MAUI/cdp commands in a single CLI invocation via stdin. Outputs JSONL
+responses (one JSON object per line) to stdout — ideal for AI agents and scripting.
+
+## Usage
+
+```bash
+# Pipe multiple commands (semicolons or newlines as separators)
+echo "MAUI fill textUsername user; MAUI fill textPassword pwd123; MAUI tap buttonLogin" | maui-devflow batch
+
+# Multi-line input
+printf "MAUI status\nMAUI tree\nMAUI screenshot --output screen.png" | maui-devflow batch
+
+# With options
+echo "MAUI status; MAUI tree" | maui-devflow batch --delay 500 --continue-on-error --agent-port 10224
+
+# Human-readable output instead of JSONL
+echo "MAUI status; MAUI tree" | maui-devflow batch --human
+```
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--delay <ms>` | 250 | Delay between commands (lets UI settle) |
+| `--continue-on-error` | false | Continue after a command fails (default: stop) |
+| `--human` | false | Human-readable output instead of JSONL |
+
+## JSONL Response Format
+
+One JSON object per command, streamed as each completes:
+```json
+{"command":"MAUI fill textUsername user","exit_code":0,"output":"Filled: textUsername"}
+{"command":"MAUI tap buttonLogin","exit_code":1,"output":"Error: Element not found: buttonLogin"}
+```
+
+## Interactive Streaming
+
+The batch command processes stdin line-by-line, so a caller can read each JSONL response
+before sending the next command. This enables reactive workflows where the AI agent inspects
+results and decides the next action.
+
+## Input Rules
+
+- Lines starting with `#` are comments (skipped)
+- Empty lines are skipped
+- Semicolons separate multiple commands on one line
+- Quoted strings are preserved: `MAUI fill myEntry "hello world"`
+- Only `MAUI` and `cdp` commands are allowed (broker/list/etc. are rejected)

--- a/.claude/skills/maui-ai-debugging/references/ios-and-mac.md
+++ b/.claude/skills/maui-ai-debugging/references/ios-and-mac.md
@@ -9,6 +9,27 @@
 
 ## Simulator Management
 
+### Avoiding multi-project conflicts
+
+When multiple projects (or AI agents) may deploy to iOS simulators simultaneously, each
+project should use its own dedicated simulator. Two apps deployed to the same simulator
+will replace each other — only the last-deployed app survives.
+
+**Before creating or booting a simulator, check what's already in use:**
+```bash
+maui-devflow list                             # shows agents with platform + port
+xcrun simctl list devices booted              # shows all booted simulators
+```
+
+If a booted simulator is already running another project's agent, create a new one:
+```bash
+xcrun simctl create "ProjectName-iPhone17Pro" "iPhone 17 Pro" "iOS 26.2"
+# Use the returned UDID in your build command
+```
+
+**Naming convention:** Use `<ProjectName>-<DeviceType>` (e.g. `TodoApp-iPhone17Pro`) so
+it's clear which simulator belongs to which project.
+
 ### List simulators
 ```bash
 xcrun simctl list devices                     # all devices by runtime

--- a/.claude/skills/maui-ai-debugging/references/macos.md
+++ b/.claude/skills/maui-ai-debugging/references/macos.md
@@ -1,0 +1,205 @@
+# macOS (AppKit) Platform Guide
+
+Platform-specific setup and usage for .NET MAUI apps running on macOS via Platform.Maui.MacOS (AppKit).
+
+## Table of Contents
+- [Overview](#overview)
+- [Project Structure](#project-structure)
+- [NuGet Packages](#nuget-packages)
+- [Registration](#registration)
+- [Building and Running](#building-and-running)
+- [Blazor Hybrid](#blazor-hybrid)
+- [Platform Differences](#platform-differences)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+macOS (AppKit) apps use the community `Platform.Maui.MacOS` packages to run MAUI on native
+AppKit (not Mac Catalyst). The TFM is `net10.0-macos`. Like Linux/GTK, macOS apps typically
+use a **separate app head project** rather than adding `-macos` to the standard MAUI project's
+TargetFrameworks.
+
+Detect macOS projects:
+```bash
+grep -i 'Platform\.Maui\.MacOS\|net.*-macos' *.csproj Directory.Build.props 2>/dev/null
+```
+
+## Project Structure
+
+macOS apps use a separate app head project (similar to Linux/GTK):
+
+```
+src/
+├── MyApp/                    # Standard MAUI project (iOS, Android, Mac Catalyst, Windows)
+├── MyApp.MacOS/              # macOS AppKit app head
+│   ├── Program.cs            # Entry point: MacOSMauiApplication
+│   ├── MauiProgram.cs        # macOS-specific builder (UseMauiAppMacOS, AddMacOSEssentials)
+│   └── MyApp.MacOS.csproj    # References Platform.Maui.MacOS packages
+```
+
+Shared source files (pages, view models, services) are typically linked from the main project.
+
+## NuGet Packages
+
+The app project needs the Platform.Maui.MacOS packages plus the standard MauiDevFlow packages:
+
+```xml
+<ItemGroup>
+  <!-- macOS platform -->
+  <PackageReference Include="Platform.Maui.MacOS" Version="*" />
+  <PackageReference Include="Platform.Maui.MacOS.BlazorWebView" Version="*" />  <!-- Blazor only -->
+  <PackageReference Include="Platform.Maui.Essentials.MacOS" Version="*" />
+
+  <!-- MauiDevFlow (standard packages — they include net10.0-macos support) -->
+  <PackageReference Include="Redth.MauiDevFlow.Agent" Version="*" />
+  <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="*" />  <!-- Blazor only -->
+</ItemGroup>
+```
+
+The standard `Redth.MauiDevFlow.Agent` and `Redth.MauiDevFlow.Blazor` packages include
+`net10.0-macos` targets — no separate macOS-specific MauiDevFlow packages needed.
+
+## Registration
+
+### Program.cs (Entry Point)
+
+```csharp
+using AppKit;
+using Microsoft.Maui.Platform.MacOS;
+using ObjCRuntime;
+
+namespace MyApp.MacOS;
+
+[Register("Program")]
+public class Program : MacOSMauiApplication
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+    static void Main(string[] args)
+    {
+        NSApplication.Init();
+        NSApplication.Main(args);
+    }
+}
+```
+
+The `[Register]` attribute is required.
+
+### MauiProgram.cs
+
+```csharp
+using Microsoft.Maui.Platform.MacOS;
+using Microsoft.Maui.Platform.MacOS.Controls;
+
+#if DEBUG
+using MauiDevFlow.Agent;
+using MauiDevFlow.Blazor;
+#endif
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiAppMacOS<App>()    // NOT UseMauiApp — macOS-specific
+            .AddMacOSEssentials()       // REQUIRED — without this, no window appears
+            .AddMacOSBlazorWebView()    // Blazor only
+            .ConfigureFonts(fonts => { /* ... */ });
+
+#if DEBUG
+        builder.AddMauiDevFlowAgent();
+        builder.AddMauiBlazorDevFlowTools();  // Blazor only
+#endif
+
+        return builder.Build();
+    }
+}
+```
+
+**Critical:** `AddMacOSEssentials()` is required — without it the app runs but no window appears.
+
+## Building and Running
+
+macOS apps do NOT use `-t:Run`. Build first, then launch with `open`:
+
+```bash
+# Build
+dotnet build -f net10.0-macos path/to/MyApp.MacOS
+
+# Find and launch the .app bundle
+open path/to/MyApp.MacOS/bin/Debug/net10.0-macos/osx-arm64/AppName.app
+```
+
+**Code signing:** A clean `dotnet build` produces a valid ad-hoc signature. Do NOT manually
+re-sign the app — it breaks the signature (SIGKILL on launch). If the app fails to launch,
+clean rebuild: `rm -rf bin obj && dotnet build`.
+
+**Finding the .app bundle:**
+```bash
+find bin/Debug/net10.0-macos -name "*.app" -maxdepth 3
+```
+
+## Network Setup
+
+**No special setup needed.** macOS apps run directly on localhost — the CLI connects
+directly to `http://localhost:<port>`. No port forwarding or entitlements required.
+
+## Blazor Hybrid
+
+Use `MacOSBlazorWebView` instead of the standard `BlazorWebView`:
+
+```csharp
+using Microsoft.Maui.Platform.MacOS.Controls;
+
+// In page code-behind, replace BlazorWebView with MacOSBlazorWebView
+var blazorWebView = new MacOSBlazorWebView();
+blazorWebView.HostPage = "wwwroot/index.html";
+blazorWebView.RootComponents.Add(new RootComponent { ... });
+```
+
+Chobitsu.js is auto-injected via the Blazor JS module initializer — no manual `<script>` tag needed.
+
+## Platform Differences
+
+| Feature | Mac Catalyst | macOS (AppKit) |
+|---------|-------------|----------------|
+| TFM | `net10.0-maccatalyst` | `net10.0-macos` |
+| Base framework | UIKit via Catalyst | AppKit |
+| Packages | Standard MAUI | Platform.Maui.MacOS |
+| Project structure | Standard MAUI single-project | Separate app head project |
+| Build + Run | `dotnet build -t:Run` | `dotnet build` then `open App.app` |
+| Entry point | Standard MAUI | `MacOSMauiApplication` with `[Register]` |
+| Builder | `UseMauiApp<App>()` | `UseMauiAppMacOS<App>()` |
+| Essentials | Built-in | `AddMacOSEssentials()` (required) |
+| BlazorWebView | Standard `BlazorWebView` | `MacOSBlazorWebView` |
+| Entitlements | Required (`network.server`) | Not needed |
+| Native sidebar | N/A | `MacOSShell.SetUseNativeSidebar(shell, true)` |
+
+## Troubleshooting
+
+### App Launches But No Window Appears
+**Cause:** Missing `AddMacOSEssentials()` call in MauiProgram.cs.
+**Fix:** Add `.AddMacOSEssentials()` to the builder chain.
+
+### SIGKILL on Launch (Code Signature Invalid)
+**Cause:** Manually re-signing the app bundle or corrupted build artifacts.
+**Fix:** Clean rebuild: `rm -rf bin obj && dotnet build -f net10.0-macos`.
+Never use `codesign` manually — the build produces a valid ad-hoc signature.
+
+### Blazor Page Shows "Loading..." Indefinitely
+**Cause:** Using standard `BlazorWebView` instead of `MacOSBlazorWebView`.
+**Fix:** Replace `BlazorWebView` with `MacOSBlazorWebView` from `Microsoft.Maui.Platform.MacOS.Controls`.
+
+### No Shell Sidebar Content
+**Cause:** macOS Shell needs explicit native sidebar configuration.
+**Fix:** In AppShell code-behind:
+```csharp
+FlyoutBehavior = FlyoutBehavior.Locked;
+MacOSShell.SetUseNativeSidebar(this, true);
+```
+
+### Agent Not Connecting
+1. Ensure the app launched successfully (window appeared)
+2. Check `maui-devflow list` — agent should register within a few seconds
+3. If using an older build, clean and rebuild to pick up latest agent code

--- a/.claude/skills/maui-ai-debugging/references/setup.md
+++ b/.claude/skills/maui-ai-debugging/references/setup.md
@@ -37,7 +37,7 @@ grep -i 'GirCore\|Maui\.Gtk\|Gtk-4\.0' *.csproj Directory.Build.props 2>/dev/nul
 If GTK/GirCore references are found, use the **Linux/GTK packages** below.
 Otherwise, use the **standard MAUI packages**.
 
-### Standard MAUI Apps (iOS, Android, Mac Catalyst, Windows)
+### Standard MAUI Apps (iOS, Android, Mac Catalyst, Windows, macOS)
 
 Add to your MAUI app's `.csproj`:
 
@@ -49,10 +49,13 @@ Add to your MAUI app's `.csproj`:
 </ItemGroup>
 ```
 
-- `Redth.MauiDevFlow.Agent` — Required for all MAUI apps (iOS, Android, Mac Catalyst, Windows). Provides the in-app agent
+- `Redth.MauiDevFlow.Agent` — Required for all MAUI apps (iOS, Android, Mac Catalyst, Windows, macOS AppKit). Provides the in-app agent
   for visual tree inspection, screenshots, tapping, filling text, etc.
-- `Redth.MauiDevFlow.Blazor` — Required for Blazor Hybrid apps (iOS, Android, Mac Catalyst, Windows). Provides the CDP bridge
+- `Redth.MauiDevFlow.Blazor` — Required for Blazor Hybrid apps. Provides the CDP bridge
   for DOM inspection, JavaScript evaluation, and Blazor debugging.
+
+**macOS (AppKit) apps** also need the `Platform.Maui.MacOS` packages — see [references/macos.md](macos.md)
+for the full project setup including entry point, builder configuration, and BlazorWebView differences.
 
 ### Linux/GTK Apps
 
@@ -138,6 +141,19 @@ Both the MSBuild targets and the CLI read this file automatically:
 - **CLI**: `maui-devflow MAUI status` — connects to the configured port (when run from project dir)
 
 **Port priority:** Explicit `--agent-port` > Broker discovery > `.mauidevflow` > default 9223.
+
+**How port discovery works:** When you run any `MAUI` or `cdp` command, the CLI:
+1. Auto-starts the broker if not running
+2. Queries the broker for agents matching the current project (`.csproj` in cwd)
+3. If one agent matches → uses its port automatically
+4. If multiple match → prints a disambiguation table to stderr
+5. Falls back to `.mauidevflow` config file → default 9223
+
+**Multiple apps simultaneously:** The broker assigns unique ports from range 10223–10899.
+Use `maui-devflow list` to see all agents, then target a specific one:
+```bash
+maui-devflow MAUI status --agent-port 10224    # target specific agent
+```
 
 **Blazor options:**
 - `Enabled` — Enable/disable CDP support (default: true)
@@ -265,6 +281,7 @@ If status commands fail:
 - **Broker not running?** `maui-devflow broker status` — CLI auto-starts the broker, but check if it's healthy
 - **Agent not registered?** `maui-devflow list` — wait a few seconds for the agent to register
 - **Mac Catalyst:** Check entitlements (Step 5)
+- **macOS (AppKit):** Ensure `AddMacOSEssentials()` is called — see [references/macos.md](macos.md)
 - **Android:** Check port forwarding (Step 6) — need both `adb reverse tcp:19223` and `adb forward tcp:<port>`
 - **iOS Simulator:** Should work without extra config
 - **Linux/GTK:** Should work without extra config — runs directly on localhost
@@ -284,7 +301,8 @@ For an AI agent setting up MauiDevFlow in a new project:
 6. [ ] Mac Catalyst entitlements include `network.server` (Mac Catalyst only)
 7. [ ] `adb reverse tcp:19223` for broker + `adb forward tcp:<port>` for agent (Android only)
 8. [ ] Linux/GTK: `app.StartDevFlowAgent()` called after app activation
-9. [ ] Verify with `maui-devflow list` and `maui-devflow MAUI status`
+9. [ ] macOS (AppKit): `UseMauiAppMacOS()`, `AddMacOSEssentials()`, `MacOSBlazorWebView` — see [macos.md](macos.md)
+10. [ ] Verify with `maui-devflow list` and `maui-devflow MAUI status`
 
 ## Checking for Updates
 
@@ -304,8 +322,19 @@ dotnet tool update --global Redth.MauiDevFlow.CLI
 
 ### Update the skill
 ```bash
+# Check if the skill is up to date (compares local commit SHA against remote)
+maui-devflow skill-version
+
+# Download the latest skill files from GitHub
 maui-devflow update-skill
 ```
+
+The `update-skill` command writes a `.skill-version` file tracking the installed commit SHA.
+The `skill-version` command reads this file and compares against the latest remote commit.
+
+**AI agents should check at session start:** If `.claude/skills/maui-ai-debugging/.skill-version`
+exists, run `maui-devflow skill-version` to see if an update is available. If the remote SHA
+differs from the installed SHA, ask the user if they'd like to update before proceeding.
 
 ### Check NuGet packages in the project
 ```bash

--- a/.claude/skills/maui-ai-debugging/references/troubleshooting.md
+++ b/.claude/skills/maui-ai-debugging/references/troubleshooting.md
@@ -23,8 +23,10 @@ If `maui-devflow MAUI status` fails with connection refused:
 5. **Android?** Did you run `adb reverse tcp:19223 tcp:19223` (for broker) and
    `adb forward tcp:<port> tcp:<port>` (for agent)? Re-run after each deploy.
 6. **Mac Catalyst?** Check entitlements include `network.server` (see setup.md step 5).
-7. **Linux/GTK?** No special network setup needed — runs directly on localhost. Check if the app started successfully.
-8. **Broker issues?** `maui-devflow broker status` to check. `maui-devflow broker stop` then
+7. **macOS (AppKit)?** Ensure `AddMacOSEssentials()` is called and the app window appeared.
+   See [references/macos.md](macos.md) for troubleshooting.
+8. **Linux/GTK?** No special network setup needed — runs directly on localhost. Check if the app started successfully.
+9. **Broker issues?** `maui-devflow broker status` to check. `maui-devflow broker stop` then
    retry (CLI will auto-restart it).
 
 ## Build Failures
@@ -79,3 +81,13 @@ or dotfiles like `~/.myapp/` in the home root) programmatically. Instead use:
 
 If you can't avoid TCC paths, sign Debug builds with a stable Apple Development certificate
 so the code signature stays consistent across rebuilds.
+
+## macOS (AppKit) Issues
+
+For detailed macOS (AppKit) troubleshooting, see [references/macos.md](macos.md#troubleshooting).
+
+Common issues:
+- **No window appears** → Missing `AddMacOSEssentials()` in builder
+- **SIGKILL on launch** → Don't re-sign manually; clean rebuild instead
+- **Blazor stuck on "Loading..."** → Use `MacOSBlazorWebView`, not standard `BlazorWebView`
+- **No sidebar content** → Add `MacOSShell.SetUseNativeSidebar(shell, true)` + `FlyoutBehavior.Locked`

--- a/PolyPilot.Console/PolyPilot.csproj
+++ b/PolyPilot.Console/PolyPilot.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.25" />
+    <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.26" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />
   </ItemGroup>
 

--- a/PolyPilot.Tests/CliPathResolutionTests.cs
+++ b/PolyPilot.Tests/CliPathResolutionTests.cs
@@ -98,11 +98,12 @@ public class CliPathResolutionTests
         var client = new CopilotClient(options);
         Assert.NotNull(client);
 
-        // Confirm the inverse: setting CliUrl with a non-null CliPath throws.
+        // SDK 0.1.26+ no longer throws when CliUrl is set on a fresh options object.
         var options2 = new CopilotClientOptions();
         options2.CliUrl = "http://localhost:4321";
 
-        Assert.Throws<ArgumentException>(() => new CopilotClient(options2));
+        var client2 = new CopilotClient(options2);
+        Assert.NotNull(client2);
     }
 
     // ================================================================

--- a/PolyPilot.Tests/PersistentModeTests.cs
+++ b/PolyPilot.Tests/PersistentModeTests.cs
@@ -49,14 +49,14 @@ public class PersistentModeTests
     }
 
     [Fact]
-    public void CopilotClientOptions_CliUrl_WithoutClearingDefaults_Throws()
+    public void CopilotClientOptions_CliUrl_WithoutClearingDefaults_Accepted()
     {
-        // Proves that just setting CliUrl on a fresh options object throws
-        // because of auto-discovered CliPath or UseStdio.
+        // SDK 0.1.26+ no longer throws when CliUrl is set on a fresh options object.
         var options = new CopilotClientOptions();
         options.CliUrl = "http://localhost:4321";
 
-        Assert.Throws<ArgumentException>(() => new CopilotClient(options));
+        var client = new CopilotClient(options);
+        Assert.NotNull(client);
     }
 
     [Fact]
@@ -72,14 +72,16 @@ public class PersistentModeTests
     }
 
     [Fact]
-    public void CopilotClientOptions_CliUrl_WithUseStdio_Throws()
+    public void CopilotClientOptions_CliUrl_WithUseStdio_Accepted()
     {
+        // SDK 0.1.26+ no longer throws when CliUrl is set alongside UseStdio.
         var options = new CopilotClientOptions();
         options.CliPath = null;
         options.CliUrl = "http://localhost:4321";
         options.UseStdio = true;
 
-        Assert.Throws<ArgumentException>(() => new CopilotClient(options));
+        var client = new CopilotClient(options);
+        Assert.NotNull(client);
     }
 
     // --- ConnectionSettings.CliUrl property tests ---

--- a/PolyPilot.Tests/PolyPilot.Tests.csproj
+++ b/PolyPilot.Tests/PolyPilot.Tests.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="8.0.0" />
-    <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.25" />
+    <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.26" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/PolyPilot/PolyPilot.csproj
+++ b/PolyPilot/PolyPilot.csproj
@@ -68,18 +68,18 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.25" />
-        <PackageReference Include="Markdig" Version="0.45.0" />
+        <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.26" />
+        <PackageReference Include="Markdig" Version="1.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
-        <PackageReference Include="Microsoft.Maui.Essentials.AI" Version="10.0.50-ci.main.26117.2" />
+        <PackageReference Include="Microsoft.Maui.Essentials.AI" Version="10.0.50-ci.main.26126.2" />
         <PackageReference Include="sqlite-net-pcl" Version="*" />
         <PackageReference Include="SQLitePCLRaw.bundle_green" Version="*" />
         <PackageReference Include="QRCoder" Version="*" />
         <PackageReference Include="ZXing.Net.Maui.Controls" Version="*" />
-        <PackageReference Include="Redth.MauiDevFlow.Agent" Version="0.8.1" />
-        <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="0.8.1" />
+        <PackageReference Include="Redth.MauiDevFlow.Agent" Version="0.11.0" />
+        <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="0.11.0" />
     </ItemGroup>
 
     <!-- Prevent linker from trimming SDK event types needed for pattern matching -->

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "redth.mauidevflow.cli": {
-      "version": "0.8.0",
+      "version": "0.11.0",
       "commands": [
         "maui-devflow"
       ],


### PR DESCRIPTION
## Package Updates

| Package | Old | New |
|---|---|---|
| `GitHub.Copilot.SDK` | 0.1.25 | **0.1.26** |
| `Markdig` | 0.45.0 | **1.0.0** |
| `Redth.MauiDevFlow.Agent` | 0.8.1 | **0.11.0** |
| `Redth.MauiDevFlow.Blazor` | 0.8.1 | **0.11.0** |
| `Microsoft.NET.Test.Sdk` | 18.0.1 | **18.3.0** |
| `Microsoft.Maui.Essentials.AI` | ci.main.26117.2 | **ci.main.26126.2** |
| `redth.mauidevflow.cli` (tool) | 0.8.0 | **0.11.0** |

## Test Fixes

SDK 0.1.26 relaxed `CopilotClientOptions` validation — `CliUrl` no longer throws `ArgumentException` when set alongside `UseStdio` or without clearing defaults first. Updated 3 tests to reflect the new accepted behavior.

## Skill Updates

Ran `maui-devflow update-skill` to refresh the `maui-ai-debugging` skill (8 files updated, 2 new: `batch.md`, `macos.md`).

## Verification

- ✅ All 1415 tests pass
- ✅ Mac Catalyst build succeeds (0 errors)
- ✅ Console project build succeeds