### PR TITLE
Fix close session dialog not respecting theme

### DIFF
--- a/PolyPilot.Tests/CloseDialogThemeTests.cs
+++ b/PolyPilot.Tests/CloseDialogThemeTests.cs
@@ -69,6 +69,8 @@ public class CloseDialogThemeTests
         Assert.NotNull(block);
         Assert.Contains("var(--accent-error)", block);
         Assert.DoesNotContain("#ff6b6b", block);
+        Assert.Contains("var(--text-bright)", block);
+        Assert.DoesNotContain("color: #fff", block);
     }
 
     [Fact]

--- a/PolyPilot/wwwroot/app.css
+++ b/PolyPilot/wwwroot/app.css
@@ -672,7 +672,7 @@ h1:focus {
     border: none;
     border-radius: 6px;
     background: var(--accent-error);
-    color: #fff;
+    color: var(--text-bright);
     cursor: pointer;
     font-size: var(--type-footnote);
     font-weight: 600;


### PR DESCRIPTION
## Bug
The close session confirmation dialog used hardcoded dark-theme colors instead of CSS theme variables, making it look wrong in light themes.

## Fix
Replace hardcoded colors with theme variables in `app.css`:
- `background: #2a2a3e` → `var(--bg-secondary)`
- `border: rgba(124,92,252,...)` → `var(--border-accent)`
- `box-shadow`: removed hardcoded purple glow, uses `var(--border-accent)`
- `title color: #fff` → `var(--text-bright)`
- `close button: #ff6b6b` → `var(--accent-error)`

## Tests
Added `CloseDialogThemeTests.cs` (5 tests) that scan `app.css` to verify the dialog styles use theme variables and don't contain hardcoded colors.