### PR TITLE
Make multi-agent group name input more prominent and readable

### DIFF
--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -243,7 +243,7 @@ else
                     </div>
                     <input type="text" class="new-group-input" id="presetNameInput"
                            placeholder="Team name (optional — uses preset name)"
-                           style="margin: 4px 8px; font-size: 12px;" />
+                           style="margin: 4px 8px;" />
                     <div style="margin: 6px 8px; padding: 6px 8px; background: var(--bg-secondary); border-radius: 6px; border: 1px solid var(--control-border);">
                         <div style="font-size: 11px; font-weight: 600; color: var(--text-secondary); margin-bottom: 4px;">🌿 Worktree Isolation</div>
                         <select class="sort-select" style="width: 100%; font-size: 12px; padding: 4px 6px;" @onchange="OnStrategyChanged">

--- a/PolyPilot/Components/Layout/SessionSidebar.razor.css
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor.css
@@ -208,14 +208,24 @@
 
 .new-group-input {
     flex-basis: 100%;
-    font-size: var(--type-caption1);
+    font-size: var(--type-body);
     color: var(--text-primary);
-    background: var(--control-border);
-    border: 1px solid var(--border-accent);
-    border-radius: 4px;
-    padding: 0.15rem 0.4rem;
-    width: 100px;
+    background: var(--control-bg);
+    border: 1px solid transparent;
+    border-radius: 6px;
+    padding: 0.5rem 0.65rem;
+    width: 100%;
+    box-sizing: border-box;
     outline: none;
+    transition: border-color 0.15s;
+}
+
+.new-group-input:focus {
+    border-color: var(--accent-primary);
+}
+
+.new-group-input::placeholder {
+    color: var(--text-dim);
 }
 
 /* Group headers */

--- a/PolyPilot/Components/Pages/Dashboard.razor.css
+++ b/PolyPilot/Components/Pages/Dashboard.razor.css
@@ -342,14 +342,23 @@
 .dashboard-header .sort-select option { background: var(--bg-tertiary); color: var(--text-primary); }
 
 .dashboard-header .new-group-input {
-    font-size: var(--type-caption1);
+    font-size: var(--type-body);
     color: var(--text-primary);
-    background: var(--control-border);
-    border: 1px solid var(--border-accent);
+    background: var(--control-bg);
+    border: 1px solid transparent;
     border-radius: 6px;
-    padding: 0.2rem 0.5rem;
-    width: 120px;
+    padding: 0.5rem 0.65rem;
+    width: 200px;
     outline: none;
+    transition: border-color 0.15s;
+}
+
+.dashboard-header .new-group-input:focus {
+    border-color: var(--accent-primary);
+}
+
+.dashboard-header .new-group-input::placeholder {
+    color: var(--text-dim);
 }
 
 /* Group dividers in dashboard */


### PR DESCRIPTION
## Problem
When creating a new multi-agent group, the name input field was very small and hard to read compared to the session name input when creating a new session.

### Before
- Font size: `var(--type-caption1)` (tiny)
- Padding: `0.15rem 0.4rem` / `0.2rem 0.5rem`
- Width: `100px` / `120px` (fixed, narrow)
- Background: `var(--control-border)` (dark, blends in)

### After
- Font size: `var(--type-body)` (matches session name input)
- Padding: `0.5rem 0.65rem` (matches session name input)
- Width: `100%` / `200px` (more room to type)
- Background: `var(--control-bg)` (standard input look)
- Added focus state with accent border color
- Added placeholder color styling
- Removed inline `font-size: 12px` override on preset name input

## Files Changed
- `SessionSidebar.razor.css` — Updated `.new-group-input` class
- `Dashboard.razor.css` — Updated `.dashboard-header .new-group-input` class
- `SessionSidebar.razor` — Removed inline font-size override on preset name input

## Testing
- All 1545 tests pass (1 pre-existing locale-dependent failure unrelated to this change)
- Mac Catalyst build succeeds