### PR TITLE
Fix contextual menus not closing on click outside main content area

### DIFF
--- a/PolyPilot.Tests/ClickOutsideMenuTests.cs
+++ b/PolyPilot.Tests/ClickOutsideMenuTests.cs
@@ -1,0 +1,111 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace PolyPilot.Tests;
+
+/// <summary>
+/// Verifies that contextual menus (session ⋯, group ⋯, card ⋯) close when clicking
+/// outside, even when the menu is inside a stacking context (e.g. the sidebar with
+/// position:sticky in WebKit). The fix uses a global mousedown listener in index.html
+/// that programmatically clicks the overlay when the real click lands outside the
+/// menu container.
+/// </summary>
+public class ClickOutsideMenuTests
+{
+    private static string GetRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "PolyPilot.slnx")))
+            dir = Directory.GetParent(dir)?.FullName;
+        return dir ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+
+    // -------- Global JS click-outside handler --------
+
+    [Fact]
+    public void IndexHtml_HasGlobalClickOutsideHandler()
+    {
+        var html = File.ReadAllText(Path.Combine(GetRepoRoot(), "PolyPilot", "wwwroot", "index.html"));
+        // Must listen for mousedown on document
+        Assert.Contains("document.addEventListener('mousedown'", html);
+        // Must query for overlay elements
+        Assert.Contains(".menu-overlay", html);
+        Assert.Contains(".group-menu-overlay", html);
+    }
+
+    [Fact]
+    public void IndexHtml_ClickOutsideHandler_ChecksContainerClasses()
+    {
+        var html = File.ReadAllText(Path.Combine(GetRepoRoot(), "PolyPilot", "wwwroot", "index.html"));
+        // Handler must check the known container wrappers
+        Assert.Contains(".session-actions", html);
+        Assert.Contains(".card-more-wrapper", html);
+        Assert.Contains(".group-menu-wrapper", html);
+    }
+
+    // -------- Overlay markup in components --------
+
+    [Fact]
+    public void SessionListItem_HasMenuOverlay()
+    {
+        var razor = File.ReadAllText(Path.Combine(GetRepoRoot(),
+            "PolyPilot", "Components", "Layout", "SessionListItem.razor"));
+        Assert.Contains("menu-overlay", razor);
+        Assert.Contains("OnCloseMenu.InvokeAsync()", razor);
+    }
+
+    [Fact]
+    public void SessionCard_HasMenuOverlay()
+    {
+        var razor = File.ReadAllText(Path.Combine(GetRepoRoot(),
+            "PolyPilot", "Components", "SessionCard.razor"));
+        Assert.Contains("menu-overlay", razor);
+        Assert.Contains("OnCloseMenu.InvokeAsync()", razor);
+    }
+
+    [Fact]
+    public void SessionSidebar_HasGroupMenuOverlay()
+    {
+        var razor = File.ReadAllText(Path.Combine(GetRepoRoot(),
+            "PolyPilot", "Components", "Layout", "SessionSidebar.razor"));
+        Assert.Contains("group-menu-overlay", razor);
+        Assert.Contains("openGroupMenuId = null", razor);
+    }
+
+    // -------- Overlay CSS is position:fixed --------
+
+    [Fact]
+    public void SessionListItem_OverlayCss_IsPositionFixed()
+    {
+        var css = File.ReadAllText(Path.Combine(GetRepoRoot(),
+            "PolyPilot", "Components", "Layout", "SessionListItem.razor.css"));
+        AssertOverlayCssCoversViewport(css, ".menu-overlay");
+    }
+
+    [Fact]
+    public void SessionCard_OverlayCss_IsPositionFixed()
+    {
+        var css = File.ReadAllText(Path.Combine(GetRepoRoot(),
+            "PolyPilot", "Components", "SessionCard.razor.css"));
+        AssertOverlayCssCoversViewport(css, ".menu-overlay");
+    }
+
+    [Fact]
+    public void SessionSidebar_GroupOverlayCss_IsPositionFixed()
+    {
+        var css = File.ReadAllText(Path.Combine(GetRepoRoot(),
+            "PolyPilot", "Components", "Layout", "SessionSidebar.razor.css"));
+        AssertOverlayCssCoversViewport(css, ".group-menu-overlay");
+    }
+
+    private static void AssertOverlayCssCoversViewport(string css, string selector)
+    {
+        // Find the rule block for the selector
+        var escapedSelector = Regex.Escape(selector);
+        var match = Regex.Match(css, escapedSelector + @"\s*\{([^}]+)\}");
+        Assert.True(match.Success, $"Expected CSS rule for {selector}");
+        var rule = match.Groups[1].Value;
+        Assert.Contains("position: fixed", rule);
+        Assert.Contains("z-index:", rule);
+    }
+}

--- a/PolyPilot.Tests/Scenarios/mode-switch-scenarios.json
+++ b/PolyPilot.Tests/Scenarios/mode-switch-scenarios.json
@@ -974,6 +974,102 @@
                     "note": "Shell output contains the echoed text, confirming the platform shell executed successfully"
                 }
             ]
+        },
+        {
+            "id": "session-menu-closes-on-click-outside",
+            "name": "Session contextual menu (⋯) closes when clicking outside, including main content area",
+            "steps": [
+                {
+                    "action": "evaluate",
+                    "script": "document.querySelectorAll('.more-btn').length > 0",
+                    "expect": {
+                        "equals": true
+                    },
+                    "note": "At least one session exists with a more-btn"
+                },
+                {
+                    "action": "evaluate",
+                    "script": "document.querySelectorAll('.more-btn')[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true})); true",
+                    "note": "Open the session menu"
+                },
+                {
+                    "action": "wait",
+                    "duration": 500
+                },
+                {
+                    "action": "evaluate",
+                    "script": "document.querySelectorAll('.session-menu').length",
+                    "expect": {
+                        "equals": 1
+                    },
+                    "note": "Session menu is open"
+                },
+                {
+                    "action": "evaluate",
+                    "script": "document.querySelector('main').dispatchEvent(new MouseEvent('mousedown', {bubbles: true, cancelable: true})); true",
+                    "note": "Click in the main content area (outside sidebar)"
+                },
+                {
+                    "action": "wait",
+                    "duration": 500
+                },
+                {
+                    "action": "evaluate",
+                    "script": "document.querySelectorAll('.session-menu').length",
+                    "expect": {
+                        "equals": 0
+                    },
+                    "note": "Session menu closed after clicking outside in main content area"
+                }
+            ]
+        },
+        {
+            "id": "group-menu-closes-on-click-outside",
+            "name": "Group contextual menu closes when clicking outside, including main content area",
+            "steps": [
+                {
+                    "action": "evaluate",
+                    "script": "document.querySelectorAll('.group-more-btn').length > 0",
+                    "expect": {
+                        "equals": true
+                    },
+                    "note": "At least one group exists with a more-btn"
+                },
+                {
+                    "action": "evaluate",
+                    "script": "document.querySelectorAll('.group-more-btn')[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true})); true",
+                    "note": "Open the group menu"
+                },
+                {
+                    "action": "wait",
+                    "duration": 500
+                },
+                {
+                    "action": "evaluate",
+                    "script": "document.querySelectorAll('.group-menu').length",
+                    "expect": {
+                        "equals": 1
+                    },
+                    "note": "Group menu is open"
+                },
+                {
+                    "action": "evaluate",
+                    "script": "document.querySelector('main').dispatchEvent(new MouseEvent('mousedown', {bubbles: true, cancelable: true})); true",
+                    "note": "Click in the main content area"
+                },
+                {
+                    "action": "wait",
+                    "duration": 500
+                },
+                {
+                    "action": "evaluate",
+                    "script": "document.querySelectorAll('.group-menu').length",
+                    "expect": {
+                        "equals": 0
+                    },
+                    "note": "Group menu closed after clicking outside in main content area"
+                }
+            ]
         }
     ]
 }

--- a/PolyPilot/wwwroot/index.html
+++ b/PolyPilot/wwwroot/index.html
@@ -1187,6 +1187,25 @@
         };
     </script>
 
+    <script>
+        // Click-outside handler for contextual menus.
+        // WebKit treats position:sticky as creating a stacking context, so
+        // position:fixed overlays inside the sidebar don't receive clicks
+        // that land on the main content area. This global mousedown listener
+        // detects clicks outside any open menu and programmatically clicks
+        // the overlay to trigger Blazor's close handler.
+        document.addEventListener('mousedown', function (e) {
+            var overlays = document.querySelectorAll('.menu-overlay, .group-menu-overlay');
+            if (!overlays.length) return;
+            overlays.forEach(function (overlay) {
+                var container = overlay.closest('.session-actions, .card-more-wrapper, .group-menu-wrapper');
+                if (container && !container.contains(e.target)) {
+                    overlay.click();
+                }
+            });
+        });
+    </script>
+
 </body>
 
 </html>


### PR DESCRIPTION
## Problem
Clicking outside the "⋯" contextual menu next to session names doesn't close the menu when the click lands in the main content area (to the right of the sidebar).

## Root Cause
WebKit (used by Mac Catalyst) treats `position: sticky` on the sidebar as creating a new stacking context. The `position: fixed` `.menu-overlay` div inside each menu is confined within this stacking context — it visually covers the viewport but only receives click events within the sidebar area. Clicks in the main content area pass through without hitting the overlay.

**Confirmed via MauiDevFlow:** `elementFromPoint()` at main content coordinates returns elements behind the overlay, not the overlay itself. Screenshot with colored overlay shows coverage only within the sidebar.

## Fix
Added a global `mousedown` event listener on `document` (in `index.html`) that:
1. Finds all visible menu overlays (`.menu-overlay`, `.group-menu-overlay`)
2. Checks if the click target is outside the menu's container wrapper
3. Programmatically clicks the overlay to trigger Blazor's existing close handler

This supplements the existing overlay approach (which still works for clicks within the sidebar) and handles the cross-stacking-context case.

**Affected menus:** Session menus (⋯), group menus, and card menus.

## Testing
- 8 new regression tests in `ClickOutsideMenuTests.cs` (all pass)
- 2 new UI scenarios in `mode-switch-scenarios.json`  
- All 1553 existing tests pass (1 pre-existing locale-dependent failure unrelated)
- Mac Catalyst build succeeds