### PR TITLE
fix: use InvariantCulture in locale-sensitive test assertions

### DIFF
--- a/PolyPilot.Tests/SessionOrganizationTests.cs
+++ b/PolyPilot.Tests/SessionOrganizationTests.cs
@@ -1875,7 +1875,7 @@ public class MultiAgentScenarioTests
 
         // Sidebar would show: 🔄 1/5 📊 0.4 (gpt-4.1)
         var lastEval = state.EvaluationHistory.Last();
-        Assert.Equal("0.4", lastEval.Score.ToString("F1"));
+        Assert.Equal("0.4", lastEval.Score.ToString("F1", System.Globalization.CultureInfo.InvariantCulture));
         Assert.Equal("gpt-4.1", lastEval.EvaluatorModel);
 
         // Step 6: Iteration 2 — significant improvement


### PR DESCRIPTION
## Problem
`Scenario_FullReflectCycleWithScoring` fails on systems with comma decimal separators (e.g., fr-FR, de-DE) because `ToString("F1")` uses the current culture, producing "0,4" instead of "0.4".

## Fix
Use `CultureInfo.InvariantCulture` in the `ToString` call in `SessionOrganizationTests.cs:1878`.

## Testing
All 1650 tests pass locally including the previously-failing test.