### PR TITLE
Fix unstyled 'Loading...' text flash at app launch

### DIFF
--- a/PolyPilot.Tests/LoadingScreenTests.cs
+++ b/PolyPilot.Tests/LoadingScreenTests.cs
@@ -1,0 +1,53 @@
+using Xunit;
+
+namespace PolyPilot.Tests;
+
+/// <summary>
+/// Validates that the pre-Blazor loading screen in index.html uses a styled
+/// loading indicator instead of unstyled plain text, and that app.css contains
+/// matching styles so the loading screen blends with the app theme.
+/// </summary>
+public class LoadingScreenTests
+{
+    private static string? _repoRoot;
+    private static string GetRepoRoot()
+    {
+        if (_repoRoot != null) return _repoRoot;
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "PolyPilot.slnx")))
+            dir = Directory.GetParent(dir)?.FullName;
+        return _repoRoot = dir ?? throw new InvalidOperationException("Could not find repo root");
+    }
+
+    [Fact]
+    public void IndexHtml_AppDiv_DoesNotContainPlainLoadingText()
+    {
+        var html = File.ReadAllText(Path.Combine(GetRepoRoot(), "PolyPilot", "wwwroot", "index.html"));
+
+        // The #app div must NOT contain bare unstyled text like "Loading..."
+        Assert.DoesNotContain(">Loading...</", html);
+        Assert.DoesNotContain(">Launching</", html);
+        Assert.DoesNotContain(">Launching…</", html);
+    }
+
+    [Fact]
+    public void IndexHtml_AppDiv_ContainsStyledLoadingIndicator()
+    {
+        var html = File.ReadAllText(Path.Combine(GetRepoRoot(), "PolyPilot", "wwwroot", "index.html"));
+
+        // Must have a styled loading container inside the #app div
+        Assert.Contains("app-loading", html);
+        Assert.Contains("app-loading-logo", html);
+    }
+
+    [Fact]
+    public void AppCss_ContainsLoadingScreenStyles()
+    {
+        var css = File.ReadAllText(Path.Combine(GetRepoRoot(), "PolyPilot", "wwwroot", "app.css"));
+
+        // CSS must style the loading screen with centering and dark background
+        Assert.Contains("#app > .app-loading", css);
+        Assert.Contains("height: 100vh", css);
+        Assert.Contains("app-loading-logo", css);
+    }
+}

--- a/PolyPilot/wwwroot/app.css
+++ b/PolyPilot/wwwroot/app.css
@@ -363,6 +363,27 @@ h1:focus {
     color: #e50000;
 }
 
+/* Pre-Blazor loading state — shown before the framework initializes */
+#app > .app-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    background: #0f0f23;
+}
+
+.app-loading-logo {
+    width: 80px;
+    height: auto;
+    opacity: 0.5;
+    animation: pulse-fade 2s ease-in-out infinite;
+}
+
+@keyframes pulse-fade {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 0.7; }
+}
+
 #blazor-error-ui {
     color-scheme: light only;
     background: lightyellow;

--- a/PolyPilot/wwwroot/index.html
+++ b/PolyPilot/wwwroot/index.html
@@ -13,7 +13,7 @@
 
 <body>
 
-    <div id="app">Loading...</div>
+    <div id="app"><div class="app-loading"><img src="PolyPilot_logo_lg.png" alt="" class="app-loading-logo" /></div></div>
 
     <div id="blazor-error-ui" data-nosnippet>
         An unhandled error has occurred.


### PR DESCRIPTION
## Problem
When PolyPilot launches, the plain text "Loading..." appears unstyled at the top-left corner of the window before Blazor initializes. Even though it's brief (~0.5s), it's visually jarring against the dark theme.

## Root Cause
`index.html` contained `<div id="app">Loading...</div>` with no CSS styling. The `#app` div had no styles in `app.css`, so the text rendered as default browser text at position (0,0).

## Fix
- **`index.html`**: Replaced plain text with a styled loading container showing the PolyPilot logo with a pulse-fade animation, centered vertically and horizontally
- **`app.css`**: Added `#app > .app-loading` styles — dark background (`#0f0f23`) matching the default theme, full viewport height, flexbox centering, and a subtle pulse animation

## Tests
Added `LoadingScreenTests.cs` with 3 regression tests:
- `IndexHtml_AppDiv_DoesNotContainPlainLoadingText` — ensures no unstyled text
- `IndexHtml_AppDiv_ContainsStyledLoadingIndicator` — verifies styled markup
- `AppCss_ContainsLoadingScreenStyles` — verifies CSS exists

All 1664 tests pass (1661 existing + 3 new).