### PR TITLE
Add speech-to-text input and demo mode for mobile

### DIFF
--- a/PolyPilot/Components/ExpandedSessionView.razor
+++ b/PolyPilot/Components/ExpandedSessionView.razor
@@ -1,8 +1,11 @@
 @using PolyPilot.Services
 @using PolyPilot.Models
 @using static PolyPilot.Components.Pages.Dashboard
+@using CommunityToolkit.Maui.Media
+@using System.Globalization
 @inject CopilotService CopilotService
 @inject IJSRuntime JS
+@inject ISpeechToText SpeechToText
 
 @{
     var isCompleted = IsCompleted;
@@ -156,6 +159,23 @@
     }
 
     <div class="input-area">
+        @if (_isListening)
+        {
+            <div class="stt-overlay" @onclick="StopListening">
+                <div class="stt-overlay-content" @onclick:stopPropagation="true">
+                    <button class="stt-mic-circle" @onclick="StopListening" title="Click to stop">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2" fill="none" stroke="currentColor" stroke-width="2"/><line x1="12" y1="19" x2="12" y2="23" stroke="currentColor" stroke-width="2"/><line x1="8" y1="23" x2="16" y2="23" stroke="currentColor" stroke-width="2"/></svg>
+                    </button>
+                    <p class="stt-transcript">@(string.IsNullOrEmpty(_partialText) ? "Listening…" : _partialText)</p>
+                    @if (!string.IsNullOrEmpty(_partialText))
+                    {
+                        <button class="stt-send-btn" @onclick="StopAndSend" title="Send now">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M6 4l14 8-14 8V4z"/></svg>
+                        </button>
+                    }
+                </div>
+            </div>
+        }
         @if (!string.IsNullOrEmpty(Intent))
         {
             <div class="intent-pill">💭 @Intent</div>
@@ -204,6 +224,11 @@
                       rows="1"></textarea>
             <button class="attach-btn" @onclick="() => OnAttach.InvokeAsync(Session.Name)" title="Attach image">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.49"/></svg>
+            </button>
+            <button class="mic-btn @(_isListening ? "listening" : "")"
+                    @onclick="ToggleListening"
+                    title="@(_isListening ? "Click to stop recording" : "Click to start recording")">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
             </button>
             @if (Session.IsProcessing)
             {
@@ -323,6 +348,135 @@
     private bool _showFiestaPicker;
     private string _fiestaName = "";
     private readonly HashSet<string> _selectedWorkerIds = new(StringComparer.Ordinal);
+    private bool _isListening;
+    private string _partialText = "";
+    private CancellationTokenSource? _listenCts;
+
+    private async Task ToggleListening()
+    {
+        if (_isListening)
+            await StopListening();
+        else
+            await StartListening();
+    }
+
+    private async Task StopAndSend()
+    {
+        var text = _partialText;
+        try { await SpeechToText.StopListenAsync(CancellationToken.None); } catch { }
+        CleanupListening();
+        StateHasChanged();
+
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            var inputId = $"input-{Session.Name.Replace(" ", "-")}";
+            await JS.InvokeVoidAsync("appendSpeechText", inputId, text);
+            await OnSend.InvokeAsync(Session.Name);
+        }
+    }
+
+    private async Task StartListening()
+    {
+        if (_isListening) return;
+        try
+        {
+            var granted = await SpeechToText.RequestPermissions(CancellationToken.None);
+            if (!granted) return;
+
+            _isListening = true;
+            _partialText = "";
+            _listenCts = new CancellationTokenSource();
+
+            SpeechToText.RecognitionResultUpdated += OnRecognitionUpdated;
+            SpeechToText.RecognitionResultCompleted += OnRecognitionCompleted;
+
+            // Use a well-known locale as fallback if current culture isn't supported
+            CultureInfo culture;
+            try { culture = CultureInfo.CurrentCulture; }
+            catch { culture = new CultureInfo("en-US"); }
+
+            await SpeechToText.StartListenAsync(new SpeechToTextOptions
+            {
+                Culture = culture,
+                ShouldReportPartialResults = true
+            }, _listenCts.Token);
+
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[STT] StartListening error: {ex}");
+            CleanupListening();
+            StateHasChanged();
+        }
+    }
+
+    private async Task StopListening()
+    {
+        if (!_isListening) return;
+        try
+        {
+            await SpeechToText.StopListenAsync(CancellationToken.None);
+        }
+        catch
+        {
+            CleanupListening();
+            StateHasChanged();
+        }
+    }
+
+    private void CleanupListening()
+    {
+        SpeechToText.RecognitionResultUpdated -= OnRecognitionUpdated;
+        SpeechToText.RecognitionResultCompleted -= OnRecognitionCompleted;
+        _listenCts?.Dispose();
+        _listenCts = null;
+        _isListening = false;
+    }
+
+    private void OnRecognitionUpdated(object? sender, SpeechToTextRecognitionResultUpdatedEventArgs e)
+    {
+        try
+        {
+            var word = e.RecognitionResult;
+            if (!string.IsNullOrWhiteSpace(word))
+                _partialText = string.IsNullOrEmpty(_partialText) ? word : _partialText + " " + word;
+            InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[STT] OnRecognitionUpdated error: {ex}");
+        }
+    }
+
+    private void OnRecognitionCompleted(object? sender, SpeechToTextRecognitionResultCompletedEventArgs e)
+    {
+        try
+        {
+            var lastPartial = _partialText;
+            CleanupListening();
+
+            var finalText = e.RecognitionResult?.Text;
+            if (string.IsNullOrWhiteSpace(finalText))
+                finalText = lastPartial;
+
+            InvokeAsync(async () =>
+            {
+                if (!string.IsNullOrWhiteSpace(finalText))
+                {
+                    var inputId = $"input-{Session.Name.Replace(" ", "-")}";
+                    await JS.InvokeVoidAsync("appendSpeechText", inputId, finalText);
+                }
+                StateHasChanged();
+            });
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[STT] OnRecognitionCompleted error: {ex}");
+            CleanupListening();
+            InvokeAsync(StateHasChanged);
+        }
+    }
 
     private List<ChatMessage> GetWindowedMessages()
     {

--- a/PolyPilot/Components/ExpandedSessionView.razor.css
+++ b/PolyPilot/Components/ExpandedSessionView.razor.css
@@ -518,6 +518,101 @@
 }
 .attach-btn:hover { background: rgba(59,130,246,0.3); color: white; }
 
+/* Mic button */
+.mic-btn {
+    border: none;
+    border-radius: 50%;
+    background: var(--control-bg);
+    color: var(--text-on-surface);
+    cursor: pointer;
+    transition: all 0.15s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    height: 36px;
+    aspect-ratio: 1;
+    padding: 0;
+}
+.mic-btn:hover { background: rgba(59,130,246,0.3); color: white; }
+.mic-btn.listening { background: rgba(239,68,68,0.25); color: #ef4444; }
+
+/* Speech-to-text overlay (compact inline popover) */
+.stt-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding-bottom: 80px;
+    animation: stt-fade-in 0.15s ease;
+}
+@keyframes stt-fade-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+
+.stt-overlay-content {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem 1.25rem;
+    background: var(--bg-tertiary, #1e1e2e);
+    border: 1px solid var(--border-default, #333);
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.45);
+    max-width: 420px;
+}
+
+.stt-mic-circle {
+    all: unset;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: #ef4444;
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+    animation: stt-pulse 1.5s ease-in-out infinite;
+    transition: transform 0.15s ease;
+}
+.stt-mic-circle:hover { transform: scale(1.1); }
+@keyframes stt-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(239,68,68,0.45); }
+    50% { box-shadow: 0 0 0 10px rgba(239,68,68,0); }
+}
+
+.stt-transcript {
+    font-size: 0.9rem;
+    color: var(--text-primary, #e0e0e0);
+    min-width: 80px;
+    max-width: 320px;
+    word-break: break-word;
+    line-height: 1.4;
+    margin: 0;
+}
+
+.stt-hint {
+    display: none;
+}
+
+.stt-send-btn {
+    all: unset;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--accent-primary, #3b82f6);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: all 0.15s ease;
+}
+.stt-send-btn:hover { background: #2563eb; transform: scale(1.08); }
+
 /* Status bar (expanded) */
 .input-status-bar {
     display: flex;

--- a/PolyPilot/Components/Pages/Settings.razor
+++ b/PolyPilot/Components/Pages/Settings.razor
@@ -53,7 +53,7 @@
         </div>
     </div>
 
-    @if (!PlatformHelper.IsMobile || CopilotService.IsInitialized)
+    @if (!PlatformHelper.IsMobile || CopilotService.IsInitialized || PlatformHelper.AvailableModes.Length > 1)
     {
     <div class="settings-group @(GroupVisible("connection") ? "" : "search-hidden")">
         <h2 class="group-title">Connection</h2>
@@ -809,6 +809,7 @@
         ConnectionMode.Embedded => new("<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect x=\"4\" y=\"4\" width=\"16\" height=\"16\" rx=\"2\" ry=\"2\"/><rect x=\"9\" y=\"9\" width=\"6\" height=\"6\"/><line x1=\"9\" y1=\"1\" x2=\"9\" y2=\"4\"/><line x1=\"15\" y1=\"1\" x2=\"15\" y2=\"4\"/><line x1=\"9\" y1=\"20\" x2=\"9\" y2=\"23\"/><line x1=\"15\" y1=\"20\" x2=\"15\" y2=\"23\"/><line x1=\"20\" y1=\"9\" x2=\"23\" y2=\"9\"/><line x1=\"20\" y1=\"14\" x2=\"23\" y2=\"14\"/><line x1=\"1\" y1=\"9\" x2=\"4\" y2=\"9\"/><line x1=\"1\" y1=\"14\" x2=\"4\" y2=\"14\"/></svg>"),
         ConnectionMode.Persistent => new("<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect x=\"2\" y=\"2\" width=\"20\" height=\"8\" rx=\"2\" ry=\"2\"/><rect x=\"2\" y=\"14\" width=\"20\" height=\"8\" rx=\"2\" ry=\"2\"/><line x1=\"6\" y1=\"6\" x2=\"6.01\" y2=\"6\"/><line x1=\"6\" y1=\"18\" x2=\"6.01\" y2=\"18\"/></svg>"),
         ConnectionMode.Remote => new("<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\"/><line x1=\"2\" y1=\"12\" x2=\"22\" y2=\"12\"/><path d=\"M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z\"/></svg>"),
+        ConnectionMode.Demo => new("<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polygon points=\"5 3 19 12 5 21 5 3\"/></svg>"),
         _ => new("<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\"/><path d=\"M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3\"/><line x1=\"12\" y1=\"17\" x2=\"12.01\" y2=\"17\"/></svg>")
     };
 
@@ -817,6 +818,7 @@
         ConnectionMode.Embedded => "Copilot process dies when app closes.",
         ConnectionMode.Persistent => "Default. Copilot server survives app restarts. Sessions persist.",
         ConnectionMode.Remote => "Connect to a remote server via DevTunnel URL.",
+        ConnectionMode.Demo => "Mock responses for testing the UI without a connection.",
         _ => ""
     };
 

--- a/PolyPilot/MauiProgram.cs
+++ b/PolyPilot/MauiProgram.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.Logging;
 using ZXing.Net.Maui.Controls;
 using MauiDevFlow.Agent;
 using MauiDevFlow.Blazor;
+using CommunityToolkit.Maui;
+using CommunityToolkit.Maui.Media;
 #if MACCATALYST
 using Microsoft.Maui.LifecycleEvents;
 using UIKit;
@@ -51,6 +53,7 @@ public static class MauiProgram
 		var builder = MauiApp.CreateBuilder();
 		builder
 			.UseMauiApp<App>()
+			.UseMauiCommunityToolkit()
 			.UseBarcodeReader()
 			.ConfigureFonts(fonts =>
 			{
@@ -105,6 +108,7 @@ public static class MauiProgram
 	builder.Services.AddSingleton<TutorialService>();
 	builder.Services.AddSingleton<UsageStatsService>();
 	builder.Services.AddSingleton<INotificationManagerService, NotificationManagerService>();
+	builder.Services.AddSingleton<ISpeechToText>(SpeechToText.Default);
 
 #if DEBUG
 		builder.Services.AddBlazorWebViewDeveloperTools();

--- a/PolyPilot/Models/PlatformHelper.cs
+++ b/PolyPilot/Models/PlatformHelper.cs
@@ -18,7 +18,11 @@ public static class PlatformHelper
 
     public static ConnectionMode[] AvailableModes => IsDesktop
         ? [ConnectionMode.Embedded, ConnectionMode.Persistent, ConnectionMode.Remote]
+#if DEBUG
+        : [ConnectionMode.Remote, ConnectionMode.Demo];
+#else
         : [ConnectionMode.Remote];
+#endif
 
     public static ConnectionMode DefaultMode => IsDesktop
         ? ConnectionMode.Persistent

--- a/PolyPilot/Platforms/Android/AndroidManifest.xml
+++ b/PolyPilot/Platforms/Android/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
 </manifest>

--- a/PolyPilot/Platforms/MacCatalyst/Entitlements.plist
+++ b/PolyPilot/Platforms/MacCatalyst/Entitlements.plist
@@ -8,5 +8,8 @@
         <!-- Network access -->
         <key>com.apple.security.network.client</key>
         <true/>
+        <!-- Microphone access for speech-to-text -->
+        <key>com.apple.security.device.audio-input</key>
+        <true/>
     </dict>
 </plist>

--- a/PolyPilot/Platforms/MacCatalyst/Info.plist
+++ b/PolyPilot/Platforms/MacCatalyst/Info.plist
@@ -38,5 +38,9 @@
     <string>PolyPilot</string>
     <key>CFBundleName</key>
     <string>PolyPilot</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>PolyPilot uses speech recognition to convert your voice into text messages.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>PolyPilot needs microphone access for speech-to-text input.</string>
 </dict>
 </plist>

--- a/PolyPilot/Platforms/Windows/Package.appxmanifest
+++ b/PolyPilot/Platforms/Windows/Package.appxmanifest
@@ -41,6 +41,7 @@
 
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
+    <DeviceCapability Name="microphone" />
   </Capabilities>
 
 </Package>

--- a/PolyPilot/Platforms/iOS/Info.plist
+++ b/PolyPilot/Platforms/iOS/Info.plist
@@ -32,6 +32,10 @@
     <string>Assets.xcassets/appicon.appiconset</string>
     <key>NSCameraUsageDescription</key>
     <string>PolyPilot uses the camera to scan QR codes for connecting to remote servers.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>PolyPilot uses speech recognition to convert your voice into text messages.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>PolyPilot needs microphone access for speech-to-text input.</string>
     <key>UIViewControllerBasedStatusBarAppearance</key>
     <true/>
 </dict>

--- a/PolyPilot/PolyPilot.csproj
+++ b/PolyPilot/PolyPilot.csproj
@@ -68,6 +68,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="CommunityToolkit.Maui" Version="14.0.1" />
         <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.26" />
         <PackageReference Include="Markdig" Version="1.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
@@ -85,6 +86,8 @@
     <!-- Prevent linker from trimming SDK event types needed for pattern matching -->
     <ItemGroup>
         <TrimmerRootAssembly Include="GitHub.Copilot.SDK" RootMode="All" />
+        <TrimmerRootAssembly Include="CommunityToolkit.Maui" />
+        <TrimmerRootAssembly Include="CommunityToolkit.Maui.Core" />
     </ItemGroup>
 
     <!-- The SDK registers the copilot CLI as ContentWithTargetPath but doesn't set
@@ -98,11 +101,21 @@
         <ItemGroup>
             <ContentWithTargetPath Remove="$(_CopilotCacheDir)/$(_CopilotBinary)" />
             <ContentWithTargetPath Remove="$(_CopilotCacheDir)\$(_CopilotBinary)" />
-            <ContentWithTargetPath Include="$(_CopilotCacheDir)/$(_CopilotBinary)"
-                                   TargetPath="copilot"
-                                   CopyToOutputDirectory="PreserveNewest"
-                                   PublishFolderType="Assembly" />
+            <ContentWithTargetPath Include="$(_CopilotCacheDir)/$(_CopilotBinary)" TargetPath="copilot" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Assembly" />
         </ItemGroup>
+    </Target>
+
+    <!-- Inject privacy keys into Mac Catalyst Info.plist (MAUI build strips NS*UsageDescription keys) -->
+    <Target Name="InjectMacCatalystPrivacyKeys" AfterTargets="Build" Condition="$(TargetFramework.Contains('maccatalyst'))">
+        <Exec Command="/usr/libexec/PlistBuddy -c &quot;Set :NSMicrophoneUsageDescription 'PolyPilot needs microphone access for speech-to-text input.'&quot; &quot;$(OutputPath)$(AssemblyName).app/Contents/Info.plist&quot; 2>/dev/null || /usr/libexec/PlistBuddy -c &quot;Add :NSMicrophoneUsageDescription string 'PolyPilot needs microphone access for speech-to-text input.'&quot; &quot;$(OutputPath)$(AssemblyName).app/Contents/Info.plist&quot;" />
+        <Exec Command="/usr/libexec/PlistBuddy -c &quot;Set :NSSpeechRecognitionUsageDescription 'PolyPilot uses speech recognition to convert your voice into text messages.'&quot; &quot;$(OutputPath)$(AssemblyName).app/Contents/Info.plist&quot; 2>/dev/null || /usr/libexec/PlistBuddy -c &quot;Add :NSSpeechRecognitionUsageDescription string 'PolyPilot uses speech recognition to convert your voice into text messages.'&quot; &quot;$(OutputPath)$(AssemblyName).app/Contents/Info.plist&quot;" />
+    </Target>
+
+    <!-- Inject privacy keys into iOS Info.plist (MAUI build strips NS*UsageDescription keys here too) -->
+    <Target Name="InjectIOSPrivacyKeys" AfterTargets="Build" Condition="$(TargetFramework.Contains('ios'))">
+        <Exec Command="/usr/libexec/PlistBuddy -c &quot;Set :NSMicrophoneUsageDescription 'PolyPilot needs microphone access for speech-to-text input.'&quot; &quot;$(OutputPath)$(AssemblyName).app/Info.plist&quot; 2>/dev/null || /usr/libexec/PlistBuddy -c &quot;Add :NSMicrophoneUsageDescription string 'PolyPilot needs microphone access for speech-to-text input.'&quot; &quot;$(OutputPath)$(AssemblyName).app/Info.plist&quot;" />
+        <Exec Command="/usr/libexec/PlistBuddy -c &quot;Set :NSSpeechRecognitionUsageDescription 'PolyPilot uses speech recognition to convert your voice into text messages.'&quot; &quot;$(OutputPath)$(AssemblyName).app/Info.plist&quot; 2>/dev/null || /usr/libexec/PlistBuddy -c &quot;Add :NSSpeechRecognitionUsageDescription string 'PolyPilot uses speech recognition to convert your voice into text messages.'&quot; &quot;$(OutputPath)$(AssemblyName).app/Info.plist&quot;" />
+        <Exec Command="codesign --force --sign &quot;Apple Development: Jakub Florkowski (8MT3Q77PP8)&quot; --entitlements &quot;$(MSBuildProjectDirectory)/obj/Debug/$(TargetFramework)/ios-arm64/Entitlements.xcent&quot; &quot;$(OutputPath)$(AssemblyName).app&quot;" />
     </Target>
 
 </Project>

--- a/PolyPilot/wwwroot/index.html
+++ b/PolyPilot/wwwroot/index.html
@@ -357,6 +357,16 @@
             }
         };
 
+        // Speech-to-text: append final recognized text to textarea
+        window.appendSpeechText = function(elementId, text) {
+            var el = document.getElementById(elementId);
+            if (!el) return;
+            var existing = el.value || '';
+            el.value = existing ? existing + ' ' + text : text;
+            el.style.height = 'auto';
+            el.style.height = Math.min(el.scrollHeight, 150) + 'px';
+        };
+
         window.escapeHtml = function(str) {
             var div = document.createElement('div');
             div.appendChild(document.createTextNode(str));


### PR DESCRIPTION
## Summary

Adds voice input support via a mic button in the chat input row, and exposes Demo mode on mobile (debug builds only) for testing without a remote connection.

### Speech-to-Text
- **Mic button** between attach and send buttons using CommunityToolkit.Maui `ISpeechToText`
- **Compact floating popover** with pulsing red mic indicator, live transcript, and send button
- Click to start/stop recording; send button submits recognized text immediately
- Accumulates partial results (Apple platforms deliver word-by-word deltas)
- Platform permissions: `RECORD_AUDIO` (Android), `NSMicrophoneUsageDescription` + `NSSpeechRecognitionUsageDescription` (iOS/MacCatalyst), microphone capability (Windows), `com.apple.security.device.audio-input` entitlement (MacCatalyst)

### Build Fixes
- **Post-build MSBuild targets** inject privacy plist keys for iOS and Mac Catalyst (MAUI build strips `NS*UsageDescription` keys from compiled plists)
- iOS target re-signs the app bundle after plist modification
- `TrimmerRootAssembly` for `CommunityToolkit.Maui` + `CommunityToolkit.Maui.Core` to prevent IL linker from stripping speech implementation types

### Demo Mode
- Expose `ConnectionMode.Demo` on mobile in `#if DEBUG` builds
- Adds play icon and description in Settings page
- Connection section visible on mobile even before initialization (so users can switch to Demo)

### Files Changed
- `ExpandedSessionView.razor` / `.razor.css` — mic button, popover UI, STT logic
- `Settings.razor` — Demo mode icon, description, visibility guard
- `MauiProgram.cs` — CommunityToolkit.Maui + ISpeechToText registration
- `PlatformHelper.cs` — Demo in mobile AvailableModes (DEBUG only)
- `PolyPilot.csproj` — package, trimmer roots, plist injection targets
- Platform plists/manifests — permissions
- `index.html` — `appendSpeechText` JS helper