### PR TITLE
fix: move info/shortcuts popover from Settings to sidebar for global access

### DIFF
--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -55,6 +55,27 @@ else
                     <a href="/" class="header-icon-btn @(currentPage == "/" || currentPage == "/dashboard" ? "active" : "")" title="Dashboard" @onclick="DashboardClicked" @onclick:preventDefault="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg></a>
                     <a href="/settings" class="header-icon-btn @(currentPage == "/settings" ? "active" : "")" title="Settings" @onclick='() => { CopilotService.SaveUiState("/settings"); currentPage = "/settings"; }'><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></a>
                     <a href="/tutorial" class="header-icon-btn @(currentPage == "/tutorial" ? "active" : "")" title="Tutorial" @onclick='() => { CopilotService.SaveUiState("/tutorial"); currentPage = "/tutorial"; }'><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></a>
+                    <div class="info-popover">
+                        <span class="info-trigger" title="Connection & shortcuts">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+                        </span>
+                        <div class="info-panel">
+                            <div class="info-row"><span class="info-label">Mode</span><span class="info-value">@CopilotService.CurrentMode</span></div>
+                            <div class="info-row"><span class="info-label">Status</span><span class="info-value">@(CopilotService.IsInitialized ? "Connected" : "Disconnected")</span></div>
+                            <div class="info-row"><span class="info-label">Build</span><span class="info-value" title="@BuildInfo.BuildTimestamp">@BuildInfo.ShortBuildId</span></div>
+                            @if (PlatformHelper.IsDesktop)
+                            {
+                                <div class="info-divider"></div>
+                                <div class="info-row"><span class="info-label">⌘1-9</span><span class="info-value">Switch session</span></div>
+                                <div class="info-row"><span class="info-label">⌘E</span><span class="info-value">Expand/collapse</span></div>
+                                <div class="info-row"><span class="info-label">Esc</span><span class="info-value">Collapse to grid</span></div>
+                                <div class="info-row"><span class="info-label">Tab</span><span class="info-value">Next session</span></div>
+                                <div class="info-row"><span class="info-label">⌘+/−/0</span><span class="info-value">Font size</span></div>
+                                <div class="info-row"><span class="info-label">Ctrl+C</span><span class="info-value">Interrupt</span></div>
+                                <div class="info-row"><span class="info-label">↑/↓</span><span class="info-value">History</span></div>
+                            }
+                        </div>
+                    </div>
                 </div>
             </div>
             <p class="status @(CopilotService.IsInitialized ? "connected" : "disconnected")" style="font-size:0.8rem">

--- a/PolyPilot/Components/Layout/SessionSidebar.razor.css
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor.css
@@ -1101,6 +1101,60 @@
     color: var(--accent-primary);
 }
 
+.info-popover { position: relative; display: flex; align-items: center; }
+.info-trigger {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    padding: 0.3rem;
+    border-radius: 6px;
+    color: var(--text-dim);
+    transition: background 0.15s, color 0.15s;
+}
+.info-trigger:hover { background: var(--hover-bg); color: var(--text-primary); }
+.info-panel {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--control-border);
+    border-radius: 8px;
+    padding: 0.5rem 0;
+    min-width: 180px;
+    max-width: calc(100vw - 2rem);
+    max-height: 70vh;
+    overflow-y: auto;
+    z-index: 200;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-4px);
+    transition: opacity 0.15s 0.05s, transform 0.15s 0.05s;
+}
+.info-panel::before {
+    content: '';
+    position: absolute;
+    top: -12px;
+    left: 0;
+    right: 0;
+    height: 12px;
+}
+.info-popover:hover .info-panel {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+}
+.info-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.72rem;
+}
+.info-label { color: var(--text-muted); white-space: nowrap; }
+.info-value { color: var(--text-primary); }
+.info-divider { height: 1px; background: var(--control-border); margin: 0.25rem 0.75rem; }
+
 .rename-input {
     width: 100%;
     padding: 0.2rem 0.4rem;

--- a/PolyPilot/Components/Pages/Settings.razor
+++ b/PolyPilot/Components/Pages/Settings.razor
@@ -28,27 +28,6 @@
                         <button class="search-clear" @onclick="ClearSearch">×</button>
                     }
                 </div>
-                <div class="info-popover">
-                    <span class="info-trigger" title="Connection & shortcuts">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-                    </span>
-                    <div class="info-panel">
-                        <div class="info-row"><span class="info-label">Mode</span><span class="info-value">@CopilotService.CurrentMode</span></div>
-                        <div class="info-row"><span class="info-label">Status</span><span class="info-value">@(CopilotService.IsInitialized ? "Connected" : "Disconnected")</span></div>
-                        <div class="info-row"><span class="info-label">Build</span><span class="info-value" title="@BuildInfo.BuildTimestamp">@BuildInfo.ShortBuildId</span></div>
-                        @if (PlatformHelper.IsDesktop)
-                        {
-                            <div class="info-divider"></div>
-                            <div class="info-row"><span class="info-label">⌘1-9</span><span class="info-value">Switch session</span></div>
-                            <div class="info-row"><span class="info-label">⌘E</span><span class="info-value">Expand/collapse</span></div>
-                            <div class="info-row"><span class="info-label">Esc</span><span class="info-value">Collapse to grid</span></div>
-                            <div class="info-row"><span class="info-label">Tab</span><span class="info-value">Next session</span></div>
-                            <div class="info-row"><span class="info-label">⌘+/−/0</span><span class="info-value">Font size</span></div>
-                            <div class="info-row"><span class="info-label">Ctrl+C</span><span class="info-value">Interrupt</span></div>
-                            <div class="info-row"><span class="info-label">↑/↓</span><span class="info-value">History</span></div>
-                        }
-                    </div>
-                </div>
             </div>
         </div>
     </div>

--- a/PolyPilot/Components/Pages/Settings.razor.css
+++ b/PolyPilot/Components/Pages/Settings.razor.css
@@ -72,59 +72,7 @@
 }
 
 /* Info popover (connection status) */
-.info-popover { position: relative; }
-.info-trigger {
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    padding: 0.25rem;
-    border-radius: 6px;
-    color: var(--text-dim);
-    transition: background 0.15s, color 0.15s;
-}
-.info-trigger:hover { background: var(--hover-bg); color: var(--text-primary); }
-.info-panel {
-    position: absolute;
-    top: calc(100% + 4px);
-    right: 0;
-    background: var(--bg-tertiary);
-    border: 1px solid var(--control-border);
-    border-radius: 8px;
-    padding: 0.5rem 0;
-    min-width: 180px;
-    max-width: calc(100vw - 2rem);
-    max-height: 70vh;
-    overflow-y: auto;
-    z-index: 200;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.25);
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(-4px);
-    transition: opacity 0.15s 0.05s, transform 0.15s 0.05s;
-}
-.info-panel::before {
-    content: '';
-    position: absolute;
-    top: -12px;
-    left: 0;
-    right: 0;
-    height: 12px;
-}
-.info-popover:hover .info-panel {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0);
-}
-.info-row {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
-    padding: 0.3rem 0.75rem;
-    font-size: 0.72rem;
-}
-.info-label { color: var(--text-muted); white-space: nowrap; }
-.info-value { color: var(--text-primary); }
-.info-divider { height: 1px; background: var(--control-border); margin: 0.25rem 0.75rem; }
+/* info-popover styles removed — now in SessionSidebar.razor.css */
 
 .badge-dot {
     width: 8px;


### PR DESCRIPTION
## Problem
The circled-i info menu (showing connection status, build info, and keyboard shortcuts) was only visible on the Settings page.

## Fix
Moved the info popover from `Settings.razor` to `SessionSidebar.razor`'s header actions row (next to Dashboard, Settings, and Tutorial icons), making it accessible from every page.

### Changes
- **SessionSidebar.razor**: Added info popover markup after the Tutorial icon
- **SessionSidebar.razor.css**: Added info popover styles (adapted positioning for sidebar context)
- **Settings.razor**: Removed info popover markup
- **Settings.razor.css**: Removed info popover styles