### PR TITLE
fix: build error and failing test

### DIFF
--- a/PolyPilot.Tests/PlatformHelperTests.cs
+++ b/PolyPilot.Tests/PlatformHelperTests.cs
@@ -21,13 +21,19 @@ public class PlatformHelperTests
     }
 
     [Fact]
-    public void AvailableModes_OnNonDesktop_IsRemoteOnly()
+    public void AvailableModes_OnNonDesktop_IncludesRemote()
     {
-        // When IsDesktop is false (test host), only Remote mode is available
+        // When IsDesktop is false (test host), Remote is always available;
+        // DEBUG builds also include Demo mode.
         if (!PlatformHelper.IsDesktop)
         {
+            Assert.Contains(ConnectionMode.Remote, PlatformHelper.AvailableModes);
+#if DEBUG
+            Assert.Equal(2, PlatformHelper.AvailableModes.Length);
+            Assert.Contains(ConnectionMode.Demo, PlatformHelper.AvailableModes);
+#else
             Assert.Single(PlatformHelper.AvailableModes);
-            Assert.Equal(ConnectionMode.Remote, PlatformHelper.AvailableModes[0]);
+#endif
         }
     }
 

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -1522,7 +1522,7 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
         if (!_sessions.ContainsKey(name))
         {
             try { await copilotSession.DisposeAsync(); } catch { }
-            return;
+            return info;
         }
 
         Debug($"Session '{name}' created with ID: {copilotSession.SessionId}");


### PR DESCRIPTION
## Summary

Fixes two issues preventing the test suite from passing:

### 1. Build error in CopilotService.cs (CS0126)
`CreateSessionAsync` returns `Task<AgentSessionInfo>` but had a bare `return;` on the early-exit path (when a session is closed during SDK creation). Changed to `return info;`.

### 2. Failing test: `AvailableModes_OnNonDesktop_IsRemoteOnly`
`PlatformHelper.AvailableModes` was updated to include `Demo` mode on non-desktop in DEBUG builds, but the test still asserted `Assert.Single()`. Updated the test to expect `[Remote, Demo]` in DEBUG and `[Remote]` in Release.

### Verification
All 1700 tests pass after these changes (run twice to confirm no flakiness).