### PR TITLE
Add /prompt edit and /prompt show subcommands

### DIFF
--- a/PolyPilot.Tests/PromptCommandTests.cs
+++ b/PolyPilot.Tests/PromptCommandTests.cs
@@ -253,7 +253,8 @@ public class PromptCommandTests : IDisposable
     public void Dashboard_EditUsesGreedyNameMatch()
     {
         var content = ReadDashboard();
-        // Verifies greedy longest-prefix matching is used for multi-word prompt names
+        // Verifies greedy longest-prefix matching is used (single DiscoverPrompts call, loop from longest to shortest)
+        Assert.Contains("DiscoverPrompts(session.WorkingDirectory)", content);
         Assert.Contains("editWords.Length; i >= 1; i--", content);
     }
 

--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -1928,15 +1928,18 @@
                     session.History.Add(ChatMessage.ErrorMessage("Usage: `/prompt edit <name> <new content>`\nOr: `/prompt edit <name>` (shows current content)"));
                     break;
                 }
-                // Greedy name match: try longest prefix first so multi-word names take priority over shorter ones
+                // Greedy name match: discover prompts once, then try longest prefix first so
+                // multi-word names take priority over shorter ones (single filesystem scan).
                 SavedPrompt? existingPrompt = null;
                 string? editContent = null;
                 {
+                    var allPrompts = PromptLibraryService.DiscoverPrompts(session.WorkingDirectory);
                     var editWords = target.Split(' ', StringSplitOptions.RemoveEmptyEntries);
                     for (var i = editWords.Length; i >= 1; i--)
                     {
                         var candidateName = string.Join(' ', editWords[..i]);
-                        var candidate = PromptLibraryService.GetPrompt(candidateName, session.WorkingDirectory);
+                        var candidate = allPrompts.FirstOrDefault(p =>
+                            string.Equals(p.Name, candidateName, StringComparison.OrdinalIgnoreCase));
                         if (candidate != null)
                         {
                             existingPrompt = candidate;


### PR DESCRIPTION
## Problem
Users couldn't figure out how to edit saved prompts or view their content. The `/prompt` command only supported `use`, `save`, and `delete` — there was no `edit` or `show` subcommand, and it wasn't clear that `save` overwrites existing prompts.

## Changes
- **`/prompt edit <name>`** — Shows the current prompt content with instructions to update it. Rejects project prompts (read-only).
- **`/prompt edit <name> <new content>`** — Updates an existing user prompt in-place.
- **`/prompt show <name>`** (alias: `/prompt view`) — Displays prompt content and metadata without sending it to the model.
- Updated `/help` text and prompt listing footer to mention all subcommands: `use|save|edit|show|delete`.

## Tests
17 new tests in `PromptCommandTests.cs` covering:
- Edit with content overwrites existing prompt
- Edit non-existent prompt returns null
- Edit rejects project prompts (source validation)
- Show retrieves content correctly
- Case-insensitive lookup
- Dashboard.razor contains new subcommands and help text

All existing tests continue to pass (13 pre-existing PopupThemeTests failures unrelated).