### PR TITLE
fix: isolate PromptLibraryService from real filesystem in tests

### DIFF
--- a/PolyPilot.Tests/PromptCommandTests.cs
+++ b/PolyPilot.Tests/PromptCommandTests.cs
@@ -7,6 +7,7 @@ namespace PolyPilot.Tests;
 /// Tests for /prompt edit and /prompt show subcommands.
 /// Verifies the service-level behavior that backs these commands.
 /// </summary>
+[Collection("PromptLibrary")]
 public class PromptCommandTests : IDisposable
 {
     private readonly string _testDir;

--- a/PolyPilot.Tests/PromptLibraryCollection.cs
+++ b/PolyPilot.Tests/PromptLibraryCollection.cs
@@ -1,0 +1,14 @@
+using Xunit;
+
+namespace PolyPilot.Tests;
+
+/// <summary>
+/// xUnit collection that serializes test classes that mutate
+/// PromptLibraryService._userPromptsDir (via SetUserPromptsDirForTesting).
+/// Without this, PromptCommandTests and PromptLibraryTests race on the
+/// shared static field, causing flaky failures.
+/// </summary>
+[CollectionDefinition("PromptLibrary")]
+public class PromptLibraryCollection : ICollectionFixture<PromptLibraryCollectionFixture> { }
+
+public class PromptLibraryCollectionFixture { }

--- a/PolyPilot.Tests/PromptLibraryTests.cs
+++ b/PolyPilot.Tests/PromptLibraryTests.cs
@@ -3,6 +3,7 @@ using PolyPilot.Services;
 
 namespace PolyPilot.Tests;
 
+[Collection("PromptLibrary")]
 public class PromptLibraryTests : IDisposable
 {
     private readonly string _testDir;

--- a/PolyPilot.Tests/TestSetup.cs
+++ b/PolyPilot.Tests/TestSetup.cs
@@ -26,5 +26,6 @@ internal static class TestSetup
         Directory.CreateDirectory(TestBaseDir);
         CopilotService.SetBaseDirForTesting(TestBaseDir);
         RepoManager.SetBaseDirForTesting(TestBaseDir);
+        PromptLibraryService.SetUserPromptsDirForTesting(Path.Combine(TestBaseDir, "prompts"));
     }
 }


### PR DESCRIPTION
Follow-up to #272.

Fixes a test isolation gap where `PromptLibraryService` could read/write the real `~/.polypilot/prompts/` directory during tests, and a parallel race between `PromptCommandTests` and `PromptLibraryTests` causing flaky failures.

**Changes:**
- Add `PromptLibraryService.SetUserPromptsDirForTesting()` to `TestSetup` module initializer so tests always start with an isolated temp dir (matches the pattern for `CopilotService` and `RepoManager`)
- Add `[Collection("PromptLibrary")]` to both `PromptCommandTests` and `PromptLibraryTests` to prevent parallel mutation of the process-global `_userPromptsDir` static field
- Add `PromptLibraryCollection.cs` with the `[CollectionDefinition]`

Without this fix, tests that access `PromptLibraryService.UserPromptsDir` before an explicit `SetUserPromptsDirForTesting` call resolve to the real filesystem path.