### PR TITLE
fix: statistics icon near-white in dark mode due to missing button reset

### DIFF
--- a/PolyPilot.Tests/StatisticsIconTests.cs
+++ b/PolyPilot.Tests/StatisticsIconTests.cs
@@ -1,0 +1,101 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace PolyPilot.Tests;
+
+/// <summary>
+/// Regression tests for the statistics icon dark-mode visibility bug.
+/// The Statistics button in the sidebar header used a &lt;button&gt; element
+/// without browser reset styles (background: none; border: none), causing
+/// it to render with default browser button styling that appeared near-white
+/// in dark mode, unlike the other header icons which are &lt;a&gt; elements.
+/// </summary>
+public class StatisticsIconTests
+{
+    private static string GetRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "PolyPilot.slnx")))
+            dir = Directory.GetParent(dir)?.FullName;
+        return dir ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+
+    private static string SidebarCssPath =>
+        Path.Combine(GetRepoRoot(), "PolyPilot", "Components", "Layout", "SessionSidebar.razor.css");
+
+    private static string SidebarRazorPath =>
+        Path.Combine(GetRepoRoot(), "PolyPilot", "Components", "Layout", "SessionSidebar.razor");
+
+    private static string? ExtractCssBlock(string css, string selector)
+    {
+        var escaped = Regex.Escape(selector);
+        var pattern = new Regex(escaped + @"\s*\{([^}]*)\}", RegexOptions.Singleline);
+        var match = pattern.Match(css);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    [Fact]
+    public void HeaderIconBtn_HasBackgroundNone()
+    {
+        var css = File.ReadAllText(SidebarCssPath);
+        var block = ExtractCssBlock(css, ".header-icon-btn");
+        Assert.NotNull(block);
+        Assert.Contains("background: none", block);
+    }
+
+    [Fact]
+    public void HeaderIconBtn_HasBorderNone()
+    {
+        var css = File.ReadAllText(SidebarCssPath);
+        var block = ExtractCssBlock(css, ".header-icon-btn");
+        Assert.NotNull(block);
+        Assert.Contains("border: none", block);
+    }
+
+    [Fact]
+    public void HeaderIconBtn_HasCursorPointer()
+    {
+        var css = File.ReadAllText(SidebarCssPath);
+        var block = ExtractCssBlock(css, ".header-icon-btn");
+        Assert.NotNull(block);
+        Assert.Contains("cursor: pointer", block);
+    }
+
+    [Fact]
+    public void HeaderIconBtn_UsesTextDimColor()
+    {
+        var css = File.ReadAllText(SidebarCssPath);
+        var block = ExtractCssBlock(css, ".header-icon-btn");
+        Assert.NotNull(block);
+        Assert.Contains("var(--text-dim)", block);
+    }
+
+    [Fact]
+    public void StatisticsButton_IsButtonElement()
+    {
+        // The statistics icon is a <button> (not an <a>) since it opens a popup.
+        // This test ensures the button exists so the CSS reset tests stay relevant.
+        var content = File.ReadAllText(SidebarRazorPath);
+        Assert.Contains("title=\"Statistics\"", content);
+        Assert.Matches(@"<button\s[^>]*title=""Statistics""", content);
+    }
+
+    [Fact]
+    public void StatisticsButton_UsesStrokeCurrentColor()
+    {
+        // The SVG icon must use stroke="currentColor" so it inherits the CSS color
+        var content = File.ReadAllText(SidebarRazorPath);
+        var buttonMatch = Regex.Match(content, @"title=""Statistics""[^>]*>(<svg[^<]*(?:<[^/]*/>)*</svg>)");
+        Assert.True(buttonMatch.Success, "Statistics button SVG not found");
+        Assert.Contains("stroke=\"currentColor\"", buttonMatch.Groups[1].Value);
+    }
+
+    [Fact]
+    public void HeaderIconBtn_HoverUsesTextPrimary()
+    {
+        var css = File.ReadAllText(SidebarCssPath);
+        var block = ExtractCssBlock(css, ".header-icon-btn:hover");
+        Assert.NotNull(block);
+        Assert.Contains("var(--text-primary)", block);
+    }
+}

--- a/PolyPilot/Components/Layout/SessionSidebar.razor.css
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor.css
@@ -1090,6 +1090,9 @@
     padding: 0.3rem;
     border-radius: 6px;
     color: var(--text-dim);
+    background: none;
+    border: none;
+    cursor: pointer;
     text-decoration: none;
     transition: all 0.15s;
 }


### PR DESCRIPTION
## Bug
The statistics icon in the sidebar header appeared near-white in dark mode, not matching the other header icons (Dashboard, Settings, Tutorial). It turned dark on hover — the opposite of expected behavior.

## Root Cause
The Statistics button is a `<button>` element while the other header icons are `<a>` elements. The `.header-icon-btn` CSS class was missing browser reset styles for buttons (`background: none; border: none; cursor: pointer;`), so the Statistics button rendered with default browser/WebKit button styling.

## Fix
Added `background: none; border: none; cursor: pointer;` to the `.header-icon-btn` CSS rule in `SessionSidebar.razor.css`. This ensures consistent styling regardless of whether the element is an `<a>` or `<button>`.

## Tests
Added 7 regression tests in `StatisticsIconTests.cs`:
- CSS reset properties (`background: none`, `border: none`, `cursor: pointer`)
- Color uses `var(--text-dim)` theme variable
- Statistics button exists as `<button>` element
- SVG uses `stroke="currentColor"` for theme inheritance
- Hover state uses `var(--text-primary)`

All 1951 existing passing tests still pass. 13 pre-existing failures in `PopupThemeTests` are unrelated.