### PR TITLE
fix: correct originalPrompt parameter in reflect loop exit drain

### DIFF
--- a/PolyPilot/Services/CopilotService.Organization.cs
+++ b/PolyPilot/Services/CopilotService.Organization.cs
@@ -1866,7 +1866,7 @@ public partial class CopilotService
                 {
                     Debug($"[DISPATCH] Draining queued prompt for '{orchestratorName}' (len={queuedPrompt.Length})");
                     var queuedResponse = await SendPromptAndWaitAsync(orchestratorName,
-                        $"[User sent a new message while you were working]\n\n{queuedPrompt}", ct, originalPrompt: prompt);
+                        $"[User sent a new message while you were working]\n\n{queuedPrompt}", ct, originalPrompt: queuedPrompt);
                     var parsed = ParseTaskAssignments(queuedResponse, workerNames);
                     if (parsed.Count > 0)
                     {
@@ -2172,7 +2172,7 @@ public partial class CopilotService
                     {
                         Debug($"[DISPATCH] Sending leftover queued prompt on loop exit (len={leftover.Length})");
                         await SendPromptAndWaitAsync(orchestratorName,
-                            $"[User sent a message — the reflection loop has completed]\n\n{leftover}", ct, originalPrompt: prompt);
+                            $"[User sent a message — the reflection loop has completed]\n\n{leftover}", ct, originalPrompt: leftover);
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
Follow-up to #275. The exit drain in `SendViaOrchestratorReflectAsync` passes `originalPrompt: prompt` (the outer loop prompt) instead of `originalPrompt: leftover` (the actual message being sent). This causes the response to be misattributed in chat history — the user sees their queued message associated with the wrong original input.

One-line fix identified in Round 6 review (R6-N1).