### PR TITLE
Add diagnostic tags to reconnect retry logging

### DIFF
--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -2107,12 +2107,13 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
                     // Start fresh watchdog for the new connection
                     StartProcessingWatchdog(state, sessionName);
                     
-                    Debug($"Session '{sessionName}' reconnected, retrying prompt...");
+                    Debug($"[RECONNECT] '{sessionName}' retrying prompt (len={prompt.Length})...");
                     var retryOptions = new MessageOptions
                     {
                         Prompt = prompt
                     };
                     await state.Session.SendAsync(retryOptions, cancellationToken);
+                    Debug($"[RECONNECT] '{sessionName}' SendAsync completed after reconnect — awaiting events");
                 }
                 catch (Exception retryEx)
                 {


### PR DESCRIPTION
The reconnect retry path in `SendPromptAsync` logged `retrying prompt...` without a `[RECONNECT]` tag, so the message was invisible in `event-diagnostics.log` (only tagged messages are persisted to the file). This made it impossible to confirm whether a retry actually fired when diagnosing silent prompt drops after session reconnection.

**Problem observed:** Two sessions (CI-Investigate, CopilotImprovements) went through SEND → RECONNECT → no SDK events → watchdog timeout. The log showed the reconnect but not whether the prompt retry was actually sent. MergeNET11 went through the same flow and succeeded, confirming it's an intermittent SDK/server issue — but without these logs we couldn't distinguish 'sent but server dropped it' from 'never sent'.

**Changes:**
- Add `[RECONNECT]` tag to the retry intent log so it appears in the diagnostics file
- Add a post-`SendAsync` log confirming the retry was accepted by the SDK, distinguishing 'sent but no response' from 'never sent'

After this change, the reconnect sequence in `event-diagnostics.log` will show:
```
[RECONNECT] 'name' replacing state ...
[RECONNECT] 'name' reset processing state: gen=N
[RECONNECT] 'name' retrying prompt (len=123)...
[RECONNECT] 'name' SendAsync completed after reconnect — awaiting events
```