### PR TITLE
fix: preserve DevTunnel error message when HostAsync fails

### DIFF
--- a/PolyPilot.Tests/DevTunnelServiceTests.cs
+++ b/PolyPilot.Tests/DevTunnelServiceTests.cs
@@ -381,18 +381,15 @@ public class DevTunnelServiceTests
         var copilot = CreateTestCopilotService();
         var service = new DevTunnelService(bridge, copilot, new RepoManager());
 
-        // HostAsync will fail because devtunnel CLI is unlikely to be installed
-        // in CI / test environments, OR the bridge port is unavailable.
+        // HostAsync will fail because devtunnel CLI is not installed in CI/test environments.
         var result = await service.HostAsync(4321);
 
-        // The key assertion: if it failed, state must be Error (not NotStarted)
+        // The failure must be deterministic: state must be Error (not NotStarted)
         // and ErrorMessage must be non-null so the UI can display feedback.
-        if (!result)
-        {
-            Assert.Equal(TunnelState.Error, service.State);
-            Assert.NotNull(service.ErrorMessage);
-            Assert.NotEmpty(service.ErrorMessage);
-        }
+        Assert.False(result, "HostAsync should fail when devtunnel CLI is not installed");
+        Assert.Equal(TunnelState.Error, service.State);
+        Assert.NotNull(service.ErrorMessage);
+        Assert.NotEmpty(service.ErrorMessage);
 
         // Cleanup
         service.Stop();

--- a/PolyPilot/Services/DevTunnelService.cs
+++ b/PolyPilot/Services/DevTunnelService.cs
@@ -237,9 +237,8 @@ public partial class DevTunnelService : IDisposable
                 var lastError = _errorMessage;
                 Stop();
                 // Stop() clears _errorMessage via SetState(NotStarted).
-                // Restore the error so the user sees what went wrong.
-                if (!string.IsNullOrEmpty(lastError))
-                    SetError(lastError);
+                // Restore the error (or a generic fallback) so the user sees what went wrong.
+                SetError(lastError ?? "DevTunnel failed to start");
                 return false;
             }
 


### PR DESCRIPTION
## Problem
When clicking "Start Dev Tunnels", the button briefly flashes a spinner then returns to its initial state with **no error message** — no QR code appears and no explanation is shown.

## Root Cause
In `DevTunnelService.HostAsync()`, when `TryHostTunnelAsync()` fails (both initial and retry attempts), `Stop()` is called for cleanup at line 237. `Stop()` transitions through `Stopping → NotStarted`, and `SetState(NotStarted)` clears `_errorMessage` (since only the `Error` state preserves it). The error that was set by `SetError()` during the failed attempt is wiped before the UI can display it.

The UI then shows the start button again (state = `NotStarted`) instead of the error panel (state = `Error`).

## Fix
1. **Preserve error across `Stop()`**: Save `_errorMessage` before `Stop()`, then re-set it via `SetError()` after cleanup so the user sees what went wrong.
2. **Catch block cleanup**: Call `Stop()` before `SetError()` in the catch block so the WsBridge started earlier in the method is properly cleaned up on unexpected exceptions.

## Tests Added
- `Stop_ClearsErrorMessage_ByDesign` — confirms Stop() clears error (documents the root cause behavior)
- `HostAsync_WhenTunnelFails_PreservesErrorMessage` — end-to-end: verifies failed HostAsync ends in Error state with a message
- `ErrorPreservation_SaveAndRestore_AcrossStop` — tests the save/restore pattern used in the fix
- `SetError_SetsStateToError_AndPreservesMessage` — verifies SetError behavior
- `SetError_FiresOnStateChanged` — verifies event fires

All 85 DevTunnel tests pass. All 1970 passing tests remain green (13 pre-existing PopupThemeTests failures unrelated).