### PR TITLE
feat: Add VS Code Insiders support with configurable editor preference

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,7 +118,7 @@ When switching between Embedded and Persistent modes (via Settings → Save & Re
 - Processing status indicator shows elapsed time and tool round count, synced via bridge.
 
 **Editor preference:**
-- `VsCodeVariant` setting (`Stable`/`Insiders`) in `ConnectionSettings` controls which VS Code binary (`code`/`code-insiders`) is launched from session context menus.
+- `Editor` setting (`VsCodeVariant.Stable`/`Insiders`) in `ConnectionSettings` controls which VS Code binary (`code`/`code-insiders`) is launched from session context menus.
 - Configurable in Settings → UI → Editor (desktop only). Persists in `settings.json`.
 
 ## Critical Conventions

--- a/PolyPilot.Tests/ConnectionSettingsTests.cs
+++ b/PolyPilot.Tests/ConnectionSettingsTests.cs
@@ -392,10 +392,10 @@ public class ConnectionSettingsTests
     }
 
     [Fact]
-    public void VsCodeVariant_DefaultIsStable()
+    public void Editor_DefaultIsStable()
     {
         var settings = new ConnectionSettings();
-        Assert.Equal(VsCodeVariant.Stable, settings.VsCodeVariant);
+        Assert.Equal(VsCodeVariant.Stable, settings.Editor);
     }
 
     [Fact]
@@ -406,36 +406,36 @@ public class ConnectionSettingsTests
     }
 
     [Fact]
-    public void VsCodeVariant_RoundTrip()
+    public void Editor_RoundTrip()
     {
-        var original = new ConnectionSettings { VsCodeVariant = VsCodeVariant.Insiders };
+        var original = new ConnectionSettings { Editor = VsCodeVariant.Insiders };
         var json = JsonSerializer.Serialize(original);
         var loaded = JsonSerializer.Deserialize<ConnectionSettings>(json);
 
         Assert.NotNull(loaded);
-        Assert.Equal(VsCodeVariant.Insiders, loaded!.VsCodeVariant);
+        Assert.Equal(VsCodeVariant.Insiders, loaded!.Editor);
     }
 
     [Fact]
-    public void VsCodeVariant_BackwardCompatibility_MissingField()
+    public void Editor_BackwardCompatibility_MissingField()
     {
         var json = """{"Mode":0,"Host":"localhost","Port":4321}""";
         var loaded = JsonSerializer.Deserialize<ConnectionSettings>(json);
 
         Assert.NotNull(loaded);
-        Assert.Equal(VsCodeVariant.Stable, loaded!.VsCodeVariant);
+        Assert.Equal(VsCodeVariant.Stable, loaded!.Editor);
     }
 
     [Fact]
-    public void VsCodeVariant_InvalidValue_NormalizesToStable()
+    public void Editor_InvalidValue_NormalizesToStable()
     {
-        var json = """{"Mode":1,"Host":"localhost","Port":4321,"VsCodeVariant":99}""";
+        var json = """{"Mode":1,"Host":"localhost","Port":4321,"Editor":99}""";
         var settings = JsonSerializer.Deserialize<ConnectionSettings>(json)!;
 
         // Call the real validation that Load() uses
         ConnectionSettings.NormalizeEnumFields(settings);
 
-        Assert.Equal(VsCodeVariant.Stable, settings.VsCodeVariant);
+        Assert.Equal(VsCodeVariant.Stable, settings.Editor);
     }
 
     [Fact]
@@ -444,13 +444,27 @@ public class ConnectionSettingsTests
         var settings = new ConnectionSettings
         {
             CliSource = CliSourceMode.System,
-            VsCodeVariant = VsCodeVariant.Insiders
+            Editor = VsCodeVariant.Insiders
         };
 
         ConnectionSettings.NormalizeEnumFields(settings);
 
         Assert.Equal(CliSourceMode.System, settings.CliSource);
-        Assert.Equal(VsCodeVariant.Insiders, settings.VsCodeVariant);
+        Assert.Equal(VsCodeVariant.Insiders, settings.Editor);
+    }
+
+    [Fact]
+    public void VsCodeVariant_Command_ReturnsCorrectBinary()
+    {
+        Assert.Equal("code", VsCodeVariant.Stable.Command());
+        Assert.Equal("code-insiders", VsCodeVariant.Insiders.Command());
+    }
+
+    [Fact]
+    public void VsCodeVariant_DisplayName_ReturnsCorrectLabel()
+    {
+        Assert.Equal("VS Code", VsCodeVariant.Stable.DisplayName());
+        Assert.Equal("VS Code Insiders", VsCodeVariant.Insiders.DisplayName());
     }
 
     private void Dispose()

--- a/PolyPilot.Tests/SettingsRegistryTests.cs
+++ b/PolyPilot.Tests/SettingsRegistryTests.cs
@@ -263,7 +263,7 @@ public class SettingsRegistryTests
         var ctx = CreateContext(settings);
         var desc = SettingsRegistry.All.First(s => s.Id == "ui.editor");
         desc.SetValue!(ctx, "Insiders");
-        Assert.Equal(VsCodeVariant.Insiders, settings.VsCodeVariant);
+        Assert.Equal(VsCodeVariant.Insiders, settings.Editor);
     }
 
     [Fact]
@@ -273,7 +273,7 @@ public class SettingsRegistryTests
         var ctx = CreateContext(settings);
         var desc = SettingsRegistry.All.First(s => s.Id == "ui.editor");
         desc.SetValue!(ctx, "garbage");
-        Assert.Equal(VsCodeVariant.Stable, settings.VsCodeVariant);
+        Assert.Equal(VsCodeVariant.Stable, settings.Editor);
     }
 
     [Fact]

--- a/PolyPilot/Components/Layout/SessionListItem.razor
+++ b/PolyPilot/Components/Layout/SessionListItem.razor
@@ -203,7 +203,7 @@
                 @if (PlatformHelper.IsDesktop && !string.IsNullOrEmpty(sessionDir))
                 {
                     <button class="menu-item" @onclick="() => { OnCloseMenu.InvokeAsync(); OpenInVSCode(); }">
-                        ⌨ @(CopilotService.VsCodeVariant == VsCodeVariant.Insiders ? "VS Code Insiders" : "VS Code")
+                        ⌨ @CopilotService.Editor.DisplayName()
                     </button>
                     <div class="menu-separator"></div>
                 }
@@ -390,7 +390,7 @@
         if (string.IsNullOrEmpty(dir)) return;
         try
         {
-            var cmd = CopilotService.VsCodeVariant == VsCodeVariant.Insiders ? "code-insiders" : "code";
+            var cmd = CopilotService.Editor.Command();
             // In remote mode, use --folder-uri with vscode-remote:// to open via Remote - Tunnels
             var remoteFolderUri = PlatformHelper.BuildVSCodeRemoteFolderUri(
                 CopilotService.IsRemoteMode, CopilotService.ServerMachineName, dir);

--- a/PolyPilot/Components/Pages/Settings.razor
+++ b/PolyPilot/Components/Pages/Settings.razor
@@ -582,7 +582,7 @@
                 cliSourceChanged = settings.CliSource != _initialCliSource;
                 break;
             case "ui.editor":
-                CopilotService.VsCodeVariant = settings.VsCodeVariant;
+                CopilotService.Editor = settings.Editor;
                 CopilotService.NotifyStateChanged();
                 break;
         }

--- a/PolyPilot/Models/ConnectionSettings.cs
+++ b/PolyPilot/Models/ConnectionSettings.cs
@@ -47,6 +47,21 @@ public enum VsCodeVariant
     Insiders   // Use 'code-insiders' command
 }
 
+public static class VsCodeVariantExtensions
+{
+    public static string Command(this VsCodeVariant v) => v switch
+    {
+        VsCodeVariant.Insiders => "code-insiders",
+        _ => "code"
+    };
+
+    public static string DisplayName(this VsCodeVariant v) => v switch
+    {
+        VsCodeVariant.Insiders => "VS Code Insiders",
+        _ => "VS Code"
+    };
+}
+
 public class ConnectionSettings
 {
     public ConnectionMode Mode { get; set; } = PlatformHelper.DefaultMode;
@@ -66,7 +81,7 @@ public class ConnectionSettings
     public UiTheme Theme { get; set; } = UiTheme.System;
     public bool AutoUpdateFromMain { get; set; } = false;
     public CliSourceMode CliSource { get; set; } = CliSourceMode.BuiltIn;
-    public VsCodeVariant VsCodeVariant { get; set; } = VsCodeVariant.Stable;
+    public VsCodeVariant Editor { get; set; } = VsCodeVariant.Stable;
     public List<string> DisabledMcpServers { get; set; } = new();
     public List<string> DisabledPlugins { get; set; } = new();
     public bool EnableSessionNotifications { get; set; } = false;
@@ -166,8 +181,8 @@ public class ConnectionSettings
     {
         if (!Enum.IsDefined(settings.CliSource))
             settings.CliSource = CliSourceMode.BuiltIn;
-        if (!Enum.IsDefined(settings.VsCodeVariant))
-            settings.VsCodeVariant = VsCodeVariant.Stable;
+        if (!Enum.IsDefined(settings.Editor))
+            settings.Editor = VsCodeVariant.Stable;
     }
 
     private static ConnectionSettings DefaultSettings()

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -209,7 +209,7 @@ public partial class CopilotService : IAsyncDisposable
     public ChatLayout ChatLayout { get; set; } = ChatLayout.Default;
     public ChatStyle ChatStyle { get; set; } = ChatStyle.Normal;
     public UiTheme Theme { get; set; } = UiTheme.System;
-    public VsCodeVariant VsCodeVariant { get; set; } = VsCodeVariant.Stable;
+    public VsCodeVariant Editor { get; set; } = VsCodeVariant.Stable;
 
     /// <summary>In-memory flag: user dismissed the holiday theme for this app session.</summary>
     public bool HolidayThemeDismissed { get; set; }
@@ -414,7 +414,7 @@ public partial class CopilotService : IAsyncDisposable
         ChatLayout = settings.ChatLayout;
         ChatStyle = settings.ChatStyle;
         Theme = settings.Theme;
-        VsCodeVariant = settings.VsCodeVariant;
+        Editor = settings.Editor;
 
         // On mobile with Remote mode and no URL configured, skip initialization
         if (settings.Mode == ConnectionMode.Remote && string.IsNullOrWhiteSpace(settings.RemoteUrl) && string.IsNullOrWhiteSpace(settings.LanUrl))

--- a/PolyPilot/Services/SettingsRegistry.cs
+++ b/PolyPilot/Services/SettingsRegistry.cs
@@ -323,11 +323,11 @@ public static class SettingsRegistry
                 new SettingOption("Stable", "VS Code"),
                 new SettingOption("Insiders", "VS Code Insiders"),
             },
-            GetValue = ctx => ctx.Settings.VsCodeVariant.ToString(),
+            GetValue = ctx => ctx.Settings.Editor.ToString(),
             SetValue = (ctx, v) =>
             {
                 if (v is string s && Enum.TryParse<VsCodeVariant>(s, out var variant))
-                    ctx.Settings.VsCodeVariant = variant;
+                    ctx.Settings.Editor = variant;
             },
             IsVisible = ctx => ctx.IsDesktop
         });


### PR DESCRIPTION
## Summary

Add a **VS Code variant** setting that lets users choose between **VS Code (Stable)** and **VS Code Insiders** across the app. 

### Changes

| File | Change |
|------|--------|
| `Models/ConnectionSettings.cs` | Add `VsCodeVariant` enum (`Stable`/`Insiders`) + property + validation |
| `Services/CopilotService.cs` | Expose + load `VsCodeVariant` from settings |
| `Components/Layout/SessionListItem.razor` | Dynamic label ("VS Code" / "VS Code Insiders") + command (`code` / `code-insiders`) |
| `Services/SettingsRegistry.cs` | Add `ui.editor` CardEnum setting (desktop only) |
| `Components/Pages/Settings.razor` | Handle `ui.editor` change → sync to CopilotService |
| `Tests/ConnectionSettingsTests.cs` | 5 new tests: default, enum values, round-trip, backward compat, invalid value |
| `Tests/SettingsRegistryTests.cs` | 3 new tests: get/set value, desktop-only visibility |

### Behavior

- **Default**: `Stable` (existing behavior unchanged)
- **Settings → UI → Editor**: Card picker with two options (desktop only, hidden on mobile)
- **Session menu**: Label and command update based on setting
- **Persistence**: Survives app restarts via `settings.json`
- **Backward compat**: Old settings files without `VsCodeVariant` default to `Stable`
- **Corrupt guard**: Invalid enum values normalize to `Stable` (same pattern as `CliSource`)

Closes #251