### PR TITLE
Fix Copilot Console for built-in CLI mode

### DIFF
--- a/PolyPilot/Components/Layout/SessionListItem.razor
+++ b/PolyPilot/Components/Layout/SessionListItem.razor
@@ -366,6 +366,12 @@
         var sessionId = Session.SessionId;
         if (string.IsNullOrEmpty(sessionId)) return;
         var dir = GetSessionDirectory() ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        // Resolve the actual CLI binary path instead of assuming 'copilot' is on PATH
+        var settings = ConnectionSettings.Load();
+        var cliPath = CopilotService.ResolveCopilotCliPath(settings.CliSource);
+        if (string.IsNullOrEmpty(cliPath)) return;
+
         try
         {
             if (OperatingSystem.IsWindows())
@@ -374,13 +380,14 @@
                 var psDir = dir.Replace("'", "''");
                 var psName = Session.Name.Replace("'", "''");
                 var psId = sessionId.Replace("'", "''");
+                var psCli = cliPath.Replace("'", "''");
                 var psScript = Path.Combine(Path.GetTempPath(), $"polypilot-copilot-{Guid.NewGuid():N}.ps1");
                 File.WriteAllText(psScript,
                     $"Set-Location '{psDir}'\n" +
                     $"Write-Host '🔗 Resuming session: {psName} ({psId})'\n" +
                     "Write-Host '─────────────────────────────────────────'\n" +
                     "Write-Host ''\n" +
-                    $"copilot --resume '{psId}' --yolo\n");
+                    $"& '{psCli}' --resume '{psId}' --yolo\n");
                 Process.Start(new ProcessStartInfo("powershell.exe",
                     $"-ExecutionPolicy Bypass -NoExit -File \"{psScript}\"")
                 {
@@ -393,6 +400,7 @@
                 var safeDir = PlatformHelper.ShellEscape(dir);
                 var safeName = PlatformHelper.ShellEscape(Session.Name);
                 var safeId = PlatformHelper.ShellEscape(sessionId);
+                var safeCli = PlatformHelper.ShellEscape(cliPath);
 
                 var shellScript = Path.Combine(Path.GetTempPath(), $"polypilot-copilot-{Guid.NewGuid():N}.sh");
                 File.WriteAllText(shellScript,
@@ -401,7 +409,7 @@
                     $"echo '🔗 Resuming session:' {safeName} '('{safeId}')'\n" +
                     "echo '─────────────────────────────────────────'\n" +
                     "echo ''\n" +
-                    $"copilot --resume {safeId} --yolo\n");
+                    $"{safeCli} --resume {safeId} --yolo\n");
                 Process.Start("chmod", $"+x \"{shellScript}\"")?.WaitForExit();
                 Process.Start(new ProcessStartInfo("open", $"-a Terminal \"{shellScript}\"")
                 {

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -774,7 +774,7 @@ public partial class CopilotService : IAsyncDisposable
     /// BuiltIn: bundled binary first, then system fallback.
     /// System: system-installed binary first, then bundled fallback.
     /// </summary>
-    private static string? ResolveCopilotCliPath(CliSourceMode source = CliSourceMode.BuiltIn)
+    internal static string? ResolveCopilotCliPath(CliSourceMode source = CliSourceMode.BuiltIn)
     {
         if (source == CliSourceMode.System)
         {


### PR DESCRIPTION
When CliSource is set to BuiltIn (the default), the bundled copilot binary isn't on PATH, so the Copilot Console menu item's generated terminal script would fail silently.

**Fix:** OpenInCopilotConsole() now resolves the actual binary path via CopilotService.ResolveCopilotCliPath() and uses the full path in the spawned terminal script.

**Changes:**
- SessionListItem.razor: Resolve CLI path before writing script
- CopilotService.cs: Changed ResolveCopilotCliPath from private to internal