### PR TITLE
fix: recognize "Client not connected" as connection error for auto-reconnect

### DIFF
--- a/PolyPilot.Tests/ConnectionRecoveryTests.cs
+++ b/PolyPilot.Tests/ConnectionRecoveryTests.cs
@@ -177,4 +177,39 @@ public class ConnectionRecoveryTests
         var aggregate = new AggregateException("A Task's exception(s) were not observed", socketEx);
         Assert.True(CopilotService.IsConnectionError(aggregate));
     }
+
+    // ===== Regression: "Client not connected. Call StartAsync() first." =====
+    // This error is thrown by the SDK as InvalidOperationException when the
+    // underlying CopilotClient connection is lost. Without this detection,
+    // SendPromptAsync skips client recreation during reconnect, causing
+    // cascading failures in multi-agent orchestrator dispatch.
+
+    [Theory]
+    [InlineData("Client not connected. Call StartAsync() first.")]
+    [InlineData("Client not connected")]
+    [InlineData("Server not connected")]
+    public void IsConnectionError_DetectsNotConnectedErrors(string message)
+    {
+        var ex = new InvalidOperationException(message);
+        Assert.True(CopilotService.IsConnectionError(ex));
+    }
+
+    [Fact]
+    public void IsConnectionError_DetectsNotConnectedWrappedInAggregate()
+    {
+        // Simulate the exact exception chain from the bug report:
+        // AggregateException → InvalidOperationException("Client not connected...")
+        var inner = new InvalidOperationException("Client not connected. Call StartAsync() first.");
+        var aggregate = new AggregateException("One or more errors occurred.", inner);
+        Assert.True(CopilotService.IsConnectionError(aggregate));
+    }
+
+    [Fact]
+    public void IsConnectionError_DetectsNotConnectedAsInnerException()
+    {
+        // InvalidOperationException wrapping another InvalidOperationException
+        var inner = new InvalidOperationException("Client not connected. Call StartAsync() first.");
+        var outer = new InvalidOperationException("Send failed", inner);
+        Assert.True(CopilotService.IsConnectionError(outer));
+    }
 }

--- a/PolyPilot/Services/CopilotService.Utilities.cs
+++ b/PolyPilot/Services/CopilotService.Utilities.cs
@@ -300,7 +300,8 @@ public partial class CopilotService
             || msg.Contains("connection lost", StringComparison.OrdinalIgnoreCase)
             || msg.Contains("transport connection", StringComparison.OrdinalIgnoreCase)
             || msg.Contains("transport is closed", StringComparison.OrdinalIgnoreCase)
-            || msg.Contains("JSON-RPC connection", StringComparison.OrdinalIgnoreCase))
+            || msg.Contains("JSON-RPC connection", StringComparison.OrdinalIgnoreCase)
+            || msg.Contains("not connected", StringComparison.OrdinalIgnoreCase))
             return true;
         // Walk the full exception chain, including all AggregateException inner exceptions
         if (ex is AggregateException agg)


### PR DESCRIPTION
## Bug

Multi-agent orchestrator dispatch fails with:
```
⚠️ Session disconnected and reconnect failed: Client not connected. Call StartAsync() first.
```

## Root Cause

When the SDK throws `InvalidOperationException("Client not connected. Call StartAsync() first.")`, `SendPromptAsync`'s reconnection logic calls `IsConnectionError(ex)` to determine whether to recreate the `CopilotClient`. This error was **not recognized** as a connection error because:

- It's an `InvalidOperationException` (not `IOException`/`SocketException`/`ObjectDisposedException`)
- The message "Client not connected" doesn't match any existing patterns (`"connection refused"`, `"connection lost"`, `"JSON-RPC connection"`, etc.)

Without recognition, the reconnect skips client recreation and tries `ResumeSessionAsync` on the broken client — which also fails, surfacing the error to the user.

## Fix

Added `"not connected"` to the message pattern list in `IsConnectionError()` (1 line in `CopilotService.Utilities.cs`).

This enables the existing reconnection flow to:
1. Recognize the error as a connection error
2. Recreate the `CopilotClient` (restart persistent server if needed)
3. Resume/create the session
4. Retry the send

## Tests

Added 5 regression tests to `ConnectionRecoveryTests.cs`:
- Direct `InvalidOperationException("Client not connected...")` detection
- Variations: "Client not connected", "Server not connected"
- Wrapped in `AggregateException`
- Wrapped as `InnerException`

All 2278 passing tests continue to pass (1 pre-existing failure on main unrelated to this change).