### PR TITLE
fix: widen ReconnectState test window to fix CI failure

### DIFF
--- a/PolyPilot.Tests/MultiAgentRegressionTests.cs
+++ b/PolyPilot.Tests/MultiAgentRegressionTests.cs
@@ -1462,7 +1462,8 @@ public class MultiAgentRegressionTests
         // Find the reconnect block where HasUsedToolsThisTurn is carried forward
         var reconnectBlock = source.Substring(source.IndexOf("newState.HasUsedToolsThisTurn = state.HasUsedToolsThisTurn"));
         // IsMultiAgentSession must be carried forward in the same block
-        Assert.Contains("newState.IsMultiAgentSession = state.IsMultiAgentSession", reconnectBlock.Substring(0, 200));
+        // Use 400 chars to accommodate intermediate carry-forward lines (e.g. SuccessfulToolCountThisTurn)
+        Assert.Contains("newState.IsMultiAgentSession = state.IsMultiAgentSession", reconnectBlock.Substring(0, 400));
     }
 
     [Fact]


### PR DESCRIPTION
## CI Failure

`ReconnectState_ShouldCarryIsMultiAgentSession` fails in CI ([run](https://github.com/PureWeen/PolyPilot/actions/runs/22836953792/job/66235226971)) with:

```
Assert.Contains() Failure: Sub-string not found
String:    "newState.HasUsedToolsThisTurn = state.Has"···
Not found: "newState.IsMultiAgentSession = state.IsMu"···
```

## Root Cause

This source-scanning test checks that `IsMultiAgentSession` is carried forward near `HasUsedToolsThisTurn` in the reconnect block of `SendPromptAsync`. The test uses a 200-char search window, but the `SuccessfulToolCountThisTurn` carry-forward line (added in a later PR between the two) pushed `IsMultiAgentSession` beyond that window.

The production code is correct — `IsMultiAgentSession` IS properly carried forward at line 2471.

## Fix

Widened the search window from 200 → 400 chars to accommodate intermediate carry-forward lines.

All 2279 tests pass.