### PR TITLE
fix: relaunch.sh — prefer ~/.dotnet SDK and skip Xcode version check

### DIFF
--- a/PolyPilot/relaunch.sh
+++ b/PolyPilot/relaunch.sh
@@ -30,7 +30,9 @@ OLD_PIDS=$(ps -eo pid,comm | grep "PolyPilot" | grep -v grep | grep -v "PolyPilo
 echo "🔨 Building..."
 cd "$PROJECT_DIR"
 
-# -p:ValidateXcodeVersion=false handles Xcode minor version mismatches
+# -p:ValidateXcodeVersion=false bypasses the .NET SDK's Xcode version-string gate.
+# Safe for minor version skew (Apple ships Xcode faster than .NET certifies it).
+# A major Xcode incompatibility will still surface as a compile/link error.
 BUILD_OUTPUT=$(dotnet build PolyPilot.csproj -f net10.0-maccatalyst -p:ValidateXcodeVersion=false 2>&1)
 BUILD_EXIT_CODE=$?
 


### PR DESCRIPTION
## Problem

`relaunch.sh` fails on machines where:

1. **.NET 10 SDK is installed via `dotnet-install.sh`** — installs to `~/.dotnet/`, but the system `dotnet` at `/usr/local/share/dotnet/` is an older version (e.g. 7.0). The script's bare `dotnet build` picks the wrong one.

2. **Xcode is a minor version ahead** of what the .NET MacCatalyst SDK expects (e.g. Xcode 26.3 vs expected 26.2), causing the build to fail with a version mismatch error.

## Fix

- **PATH**: Prepend `~/.dotnet` to PATH if `~/.dotnet/dotnet` exists. Conditional — no-op on machines with a single system-wide install.
- **Xcode**: Pass `-p:ValidateXcodeVersion=false` to `dotnet build`. Apple ships Xcode updates faster than .NET SDK updates, so this mismatch is common.