### PR TITLE
Fix settings code blocks using Bootstrap red instead of theme colors

### DIFF
--- a/PolyPilot.Tests/Scenarios/mode-switch-scenarios.json
+++ b/PolyPilot.Tests/Scenarios/mode-switch-scenarios.json
@@ -1493,11 +1493,19 @@
         },
         {
           "action": "evaluate",
-          "script": "Array.from(document.querySelectorAll('.section-desc code')).every(el => { const s = getComputedStyle(el); return s.color !== 'rgb(214, 51, 132)'; })",
+          "script": "document.querySelectorAll('.section-desc code').length > 0",
           "expect": {
             "equals": true
           },
-          "note": "No .section-desc code element should have Bootstrap's --bs-code-color (#d63384 = rgb(214,51,132))"
+          "note": "Settings page should render at least one .section-desc code element"
+        },
+        {
+          "action": "evaluate",
+          "script": "(() => { const codes = Array.from(document.querySelectorAll('.section-desc code')); const probe = document.createElement('span'); probe.style.color = 'var(--text-bright)'; probe.style.position = 'absolute'; probe.style.visibility = 'hidden'; document.body.appendChild(probe); const expected = getComputedStyle(probe).color; probe.remove(); return codes.every(el => getComputedStyle(el).color === expected); })()",
+          "expect": {
+            "equals": true
+          },
+          "note": "All .section-desc code elements should resolve to the theme's --text-bright color"
         },
         {
           "action": "evaluate",

--- a/PolyPilot.Tests/SettingsCodeBlockThemeTests.cs
+++ b/PolyPilot.Tests/SettingsCodeBlockThemeTests.cs
@@ -26,9 +26,32 @@ public class SettingsCodeBlockThemeTests
     private static string? ExtractCssBlock(string css, string selector)
     {
         var escaped = Regex.Escape(selector);
-        var pattern = new Regex(escaped + @"\s*\{([^}]*)\}", RegexOptions.Singleline);
-        var match = pattern.Match(css);
-        return match.Success ? match.Groups[1].Value : null;
+        var pattern = new Regex(escaped + @"\s*\{", RegexOptions.Singleline);
+        var matches = pattern.Matches(css);
+        if (matches.Count == 0)
+            return null;
+
+        var match = matches[matches.Count - 1];
+        var blockStart = match.Index + match.Length;
+        var depth = 1;
+
+        for (var i = blockStart; i < css.Length; i++)
+        {
+            if (css[i] == '{')
+            {
+                depth++;
+                continue;
+            }
+
+            if (css[i] != '}')
+                continue;
+
+            depth--;
+            if (depth == 0)
+                return css.Substring(blockStart, i - blockStart);
+        }
+
+        return null;
     }
 
     [Fact]
@@ -64,7 +87,7 @@ public class SettingsCodeBlockThemeTests
         var css = File.ReadAllText(SettingsCssPath);
         var block = ExtractCssBlock(css, ".tunnel-warning code");
         Assert.NotNull(block);
-        Assert.Contains("color:", block);
+        Assert.Contains("color: var(--accent-warning)", block);
     }
 
     [Fact]
@@ -73,7 +96,7 @@ public class SettingsCodeBlockThemeTests
         var css = File.ReadAllText(SettingsCssPath);
         var block = ExtractCssBlock(css, ".tunnel-url code");
         Assert.NotNull(block);
-        Assert.Contains("color:", block);
+        Assert.Contains("color: var(--accent-primary)", block);
     }
 
     [Fact]

--- a/PolyPilot/Components/Pages/Settings.razor.css
+++ b/PolyPilot/Components/Pages/Settings.razor.css
@@ -640,7 +640,7 @@
     padding: 0.15rem 0.4rem;
     border-radius: 4px;
     font-family: monospace;
-    color: #fbbf24;
+    color: var(--accent-warning);
 }
 
 .tunnel-warning .hint {


### PR DESCRIPTION
## Problem
The \<code>\ elements inside \.section-desc\ in the Settings page (e.g. \origin/main\, \~/.polypilot/plugins/\, \plugin.json\) were inheriting Bootstrap's \--bs-code-color\ (\#d63384\, pinkish-red) because no explicit \color\ was set in the CSS. This was jarring and hard to read in Dark mode.

## Root Cause
Bootstrap sets \code { color: var(--bs-code-color); }\ globally with \--bs-code-color: #d63384\. The chat output had already been fixed to override this with \ar(--text-bright)\ in \ChatMessageList.razor.css\, but \.section-desc code\ in \Settings.razor.css\ only had \ackground\ and \padding\ — no color override.

## Fix
Added \color: var(--text-bright)\ and \order: 1px solid var(--border-subtle)\ to \.section-desc code\ in \Settings.razor.css\, matching the approach used in \ChatMessageList.razor.css\ for markdown code blocks.

## Tests
- 7 new unit tests in \SettingsCodeBlockThemeTests.cs\ verifying theme variables are used and Bootstrap red is not present
- 1 new UI scenario in \mode-switch-scenarios.json\ to verify computed styles at runtime