### PR TITLE
fix: remove secrets context from step if condition in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -736,14 +736,16 @@ jobs:
           echo "sha256=$SHA256" >> $GITHUB_OUTPUT
 
       - name: Update Homebrew tap
-        if: "!contains(github.ref, '-') && secrets.HOMEBREW_TAP_TOKEN != ''"
+        if: "!contains(github.ref, '-')"
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "HOMEBREW_TAP_TOKEN not set, skipping"
+            exit 0
+          fi
           VERSION="${GITHUB_REF#refs/tags/v}"
           MAC_SHA256="${{ steps.mac_sha.outputs.sha256 }}"
-          gh api repos/PureWeen/homebrew-tap/dispatches \
-            --method POST --input - <<EOF
-          {"event_type":"release-published","client_payload":{"version":"$VERSION","mac_sha256":"$MAC_SHA256"}}
-          EOF
+          echo "{\"event_type\":\"release-published\",\"client_payload\":{\"version\":\"$VERSION\",\"mac_sha256\":\"$MAC_SHA256\"}}" | \
+            gh api repos/PureWeen/homebrew-tap/dispatches --method POST --input -


### PR DESCRIPTION
## Problem

Every push to main since PR #313 (Homebrew tap auto-update) has failed with **"This run likely failed because of a workflow file issue"** — zero jobs created.

**Root cause:** The step-level `if` condition on the "Update Homebrew tap" step used `secrets.HOMEBREW_TAP_TOKEN != ''`, which causes GitHub Actions to reject the entire workflow at parse time.

## Fix

1. **Remove `secrets` from the `if` condition** — use a runtime shell guard (`if [ -z "$GH_TOKEN" ]`) instead
2. **Replace indented heredoc with piped echo** — the original `EOF` delimiter was indented (wouldn't terminate properly in a YAML block scalar)

## Verification

- Last green build: [#22873258217](https://github.com/PureWeen/PolyPilot/actions/runs/22873258217) (before PR #313)
- First red build: [#22876701610](https://github.com/PureWeen/PolyPilot/actions/runs/22876701610) (PR #313 merge)
- All 16+ subsequent pushes to main have failed with the same workflow parse error