### PR TITLE
fix: clean up stale server.pid in relaunch.ps1

### DIFF
--- a/PolyPilot/relaunch.ps1
+++ b/PolyPilot/relaunch.ps1
@@ -15,6 +15,37 @@ $ExeName = 'PolyPilot.exe'
 
 $MaxLaunchAttempts = 2
 $StabilitySeconds = 8
+$ServerPidFile = Join-Path $env:USERPROFILE '.polypilot\server.pid'
+$ServerPort = 4321
+
+# Check if the persistent copilot server is actually running.
+# If server.pid exists but the server is dead/not listening, clean up the stale file
+# so PolyPilot will auto-start a fresh server on launch.
+function Test-ServerListening {
+    param([int]$Port)
+    try {
+        $tcp = New-Object System.Net.Sockets.TcpClient
+        $tcp.Connect("127.0.0.1", $Port)
+        $tcp.Close()
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+if (Test-Path $ServerPidFile) {
+    $lines = Get-Content $ServerPidFile -ErrorAction SilentlyContinue
+    if ($lines -and $lines.Count -ge 2) {
+        $ServerPort = [int]$lines[1]
+    }
+    
+    if (-not (Test-ServerListening -Port $ServerPort)) {
+        Write-Host "[!] Stale server.pid detected (port $ServerPort not listening) — cleaning up"
+        Remove-Item $ServerPidFile -Force -ErrorAction SilentlyContinue
+    } else {
+        Write-Host "[OK] Persistent server running on port $ServerPort"
+    }
+}
 
 # Capture PIDs of currently running instances BEFORE build
 $OldPids = @(Get-Process -Name 'PolyPilot' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Id)


### PR DESCRIPTION
## Problem

When the persistent copilot server dies unexpectedly, the \server.pid\ file can become stale — referencing a dead process. This causes PolyPilot to fail to connect on relaunch because it thinks a server exists but port 4321 isn't actually listening.

## Solution

Now \elaunch.ps1\ checks if the server is actually listening before build. If \server.pid\ exists but the port isn't responding, the stale file is removed so PolyPilot will auto-start a fresh server on launch.

## Testing

1. Kill the copilot server manually (without deleting server.pid)
2. Run \elaunch.ps1\
3. Verify it detects the stale PID and cleans up
4. Verify PolyPilot starts a fresh server and connects successfully