### PR TITLE
fix: make MessageQueue thread-safe with SynchronizedMessageQueue wrapper

### DIFF
--- a/PolyPilot.Tests/PolyPilot.Tests.csproj
+++ b/PolyPilot.Tests/PolyPilot.Tests.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <Compile Include="../PolyPilot/Models/ChatMessage.cs" Link="Shared/ChatMessage.cs" />
     <Compile Include="../PolyPilot/Models/AgentSessionInfo.cs" Link="Shared/AgentSessionInfo.cs" />
+    <Compile Include="../PolyPilot/Models/SynchronizedMessageQueue.cs" Link="Shared/SynchronizedMessageQueue.cs" />
     <Compile Include="../PolyPilot/Models/BridgeMessages.cs" Link="Shared/BridgeMessages.cs" />
     <Compile Include="../PolyPilot/Models/ConnectionSettings.cs" Link="Shared/ConnectionSettings.cs" />
     <Compile Include="../PolyPilot/Models/PlatformHelper.cs" Link="Shared/PlatformHelper.cs" />

--- a/PolyPilot.Tests/SynchronizedMessageQueueTests.cs
+++ b/PolyPilot.Tests/SynchronizedMessageQueueTests.cs
@@ -1,0 +1,204 @@
+using PolyPilot.Models;
+
+namespace PolyPilot.Tests;
+
+public class SynchronizedMessageQueueTests
+{
+    [Fact]
+    public void Add_And_Count_AreConsistent()
+    {
+        var queue = new SynchronizedMessageQueue();
+        queue.Add("a");
+        queue.Add("b");
+        Assert.Equal(2, queue.Count);
+        Assert.Equal("a", queue[0]);
+        Assert.Equal("b", queue[1]);
+    }
+
+    [Fact]
+    public void TryDequeue_ReturnsFirstItem()
+    {
+        var queue = new SynchronizedMessageQueue();
+        queue.Add("first");
+        queue.Add("second");
+
+        var item = queue.TryDequeue();
+        Assert.Equal("first", item);
+        Assert.Single(queue);
+        Assert.Equal("second", queue[0]);
+    }
+
+    [Fact]
+    public void TryDequeue_ReturnsNull_WhenEmpty()
+    {
+        var queue = new SynchronizedMessageQueue();
+        Assert.Null(queue.TryDequeue());
+    }
+
+    [Fact]
+    public void TryRemoveAt_ReturnsFalse_ForInvalidIndex()
+    {
+        var queue = new SynchronizedMessageQueue();
+        queue.Add("only");
+        Assert.False(queue.TryRemoveAt(-1));
+        Assert.False(queue.TryRemoveAt(1));
+        Assert.True(queue.TryRemoveAt(0));
+        Assert.Empty(queue);
+    }
+
+    [Fact]
+    public void AddAndGetCount_ReturnsNewCount()
+    {
+        var queue = new SynchronizedMessageQueue();
+        Assert.Equal(1, queue.AddAndGetCount("a"));
+        Assert.Equal(2, queue.AddAndGetCount("b"));
+        Assert.Equal(3, queue.AddAndGetCount("c"));
+    }
+
+    [Fact]
+    public void Clear_RemovesAllItems()
+    {
+        var queue = new SynchronizedMessageQueue();
+        queue.Add("a");
+        queue.Add("b");
+        queue.Clear();
+        Assert.Empty(queue);
+    }
+
+    [Fact]
+    public void Insert_PlacesAtCorrectIndex()
+    {
+        var queue = new SynchronizedMessageQueue();
+        queue.Add("a");
+        queue.Add("c");
+        queue.Insert(1, "b");
+        Assert.Equal(3, queue.Count);
+        Assert.Equal("b", queue[1]);
+    }
+
+    [Fact]
+    public void RemoveAll_FiltersMatchingItems()
+    {
+        var queue = new SynchronizedMessageQueue();
+        queue.Add("keep");
+        queue.Add("remove-1");
+        queue.Add("keep-2");
+        queue.Add("remove-2");
+        queue.RemoveAll(s => s.StartsWith("remove"));
+        Assert.Equal(2, queue.Count);
+        Assert.Equal("keep", queue[0]);
+        Assert.Equal("keep-2", queue[1]);
+    }
+
+    [Fact]
+    public void Snapshot_ReturnsIndependentCopy()
+    {
+        var queue = new SynchronizedMessageQueue();
+        queue.Add("a");
+        queue.Add("b");
+        var snap = queue.Snapshot();
+        queue.Clear();
+        Assert.Equal(2, snap.Count);
+        Assert.Empty(queue);
+    }
+
+    [Fact]
+    public void Enumeration_IteratesSnapshot()
+    {
+        var queue = new SynchronizedMessageQueue();
+        queue.Add("x");
+        queue.Add("y");
+        var items = queue.ToList();
+        Assert.Equal(new[] { "x", "y" }, items);
+    }
+
+    [Fact]
+    public void Any_ReflectsState()
+    {
+        var queue = new SynchronizedMessageQueue();
+        Assert.False(queue.Any());
+        queue.Add("item");
+        Assert.True(queue.Any());
+    }
+
+    [Fact]
+    public async Task ConcurrentAddAndDequeue_DoesNotCorruptList()
+    {
+        var queue = new SynchronizedMessageQueue();
+        const int iterations = 1000;
+        var dequeued = new List<string>();
+        var dequeueLock = new object();
+
+        var addTask = Task.Run(() =>
+        {
+            for (int i = 0; i < iterations; i++)
+                queue.Add($"msg-{i}");
+        });
+
+        var dequeueTask = Task.Run(() =>
+        {
+            for (int i = 0; i < iterations; i++)
+            {
+                var item = queue.TryDequeue();
+                if (item != null)
+                {
+                    lock (dequeueLock)
+                        dequeued.Add(item);
+                }
+                else
+                {
+                    // Small delay to let producer add items
+                    Thread.SpinWait(10);
+                    i--; // retry
+                }
+            }
+        });
+
+        await Task.WhenAll(addTask, dequeueTask);
+
+        // All items produced should have been consumed
+        Assert.Empty(queue);
+        Assert.Equal(iterations, dequeued.Count);
+    }
+
+    [Fact]
+    public async Task ConcurrentAddClearSnapshot_NoExceptions()
+    {
+        var queue = new SynchronizedMessageQueue();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var exceptions = new List<Exception>();
+
+        var tasks = new[]
+        {
+            Task.Run(() =>
+            {
+                while (!cts.Token.IsCancellationRequested)
+                    queue.Add("item");
+            }),
+            Task.Run(() =>
+            {
+                while (!cts.Token.IsCancellationRequested)
+                    queue.Clear();
+            }),
+            Task.Run(() =>
+            {
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    try { _ = queue.Snapshot(); }
+                    catch (Exception ex) { lock (exceptions) exceptions.Add(ex); }
+                }
+            }),
+            Task.Run(() =>
+            {
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    try { _ = queue.Count; _ = queue.Any(); }
+                    catch (Exception ex) { lock (exceptions) exceptions.Add(ex); }
+                }
+            }),
+        };
+
+        await Task.WhenAll(tasks);
+        Assert.Empty(exceptions);
+    }
+}

--- a/PolyPilot/Components/ExpandedSessionView.razor
+++ b/PolyPilot/Components/ExpandedSessionView.razor
@@ -186,17 +186,20 @@
         {
             <div class="intent-pill">💭 @Intent</div>
         }
-        @if (Session.MessageQueue.Any())
+        @{
+            var queueSnapshot = Session.MessageQueue.Snapshot();
+        }
+        @if (queueSnapshot.Count > 0)
         {
             <div class="message-queue">
                 <div class="queue-header">
-                    <span>📋 Queued (@Session.MessageQueue.Count)</span>
+                    <span>📋 Queued (@queueSnapshot.Count)</span>
                     <button class="queue-clear-btn" @onclick="() => OnClearQueue.InvokeAsync(Session.Name)">Clear</button>
                 </div>
-                @for (var i = 0; i < Session.MessageQueue.Count; i++)
+                @for (var i = 0; i < queueSnapshot.Count; i++)
                 {
                     var index = i;
-                    var msg = Session.MessageQueue[i];
+                    var msg = queueSnapshot[i];
                     <div class="queue-item">
                         <span class="queue-index">@(index + 1)</span>
                         <span class="queue-text">@Truncate(msg, 80)</span>

--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -3131,8 +3131,7 @@
     private void RemoveQueuedMessage(string sessionName, int index)
     {
         var session = sessions.FirstOrDefault(s => s.Name == sessionName);
-        if (session != null && index >= 0 && index < session.MessageQueue.Count)
-            session.MessageQueue.RemoveAt(index);
+        session?.MessageQueue.TryRemoveAt(index);
     }
 
     private async Task CopyToClipboard(string text)

--- a/PolyPilot/Models/AgentSessionInfo.cs
+++ b/PolyPilot/Models/AgentSessionInfo.cs
@@ -8,7 +8,7 @@ public class AgentSessionInfo
     public int MessageCount { get; set; }
     public bool IsProcessing { get; set; }
     public List<ChatMessage> History { get; } = new();
-    public List<string> MessageQueue { get; } = new();
+    public SynchronizedMessageQueue MessageQueue { get; } = new();
     
     public string? WorkingDirectory { get; set; }
     public string? GitBranch { get; set; }

--- a/PolyPilot/Models/SynchronizedMessageQueue.cs
+++ b/PolyPilot/Models/SynchronizedMessageQueue.cs
@@ -1,0 +1,110 @@
+using System.Collections;
+
+namespace PolyPilot.Models;
+
+/// <summary>
+/// Thread-safe message queue for session prompts. Wraps a <see cref="List{T}"/>
+/// with internal locking so that concurrent reads/writes from UI, SDK event,
+/// and WebSocket threads do not corrupt the backing list.
+/// Implements <see cref="IReadOnlyList{T}"/> for backward-compatible enumeration
+/// (enumerator operates on a snapshot).
+/// </summary>
+public class SynchronizedMessageQueue : IReadOnlyList<string>
+{
+    private readonly List<string> _items = new();
+    private readonly object _lock = new();
+
+    public int Count
+    {
+        get { lock (_lock) return _items.Count; }
+    }
+
+    public string this[int index]
+    {
+        get { lock (_lock) return _items[index]; }
+    }
+
+    public void Add(string item)
+    {
+        lock (_lock) _items.Add(item);
+    }
+
+    /// <summary>
+    /// Adds an item and returns the new count atomically.
+    /// Use when the count is needed immediately after adding (e.g., to align parallel queues).
+    /// </summary>
+    public int AddAndGetCount(string item)
+    {
+        lock (_lock)
+        {
+            _items.Add(item);
+            return _items.Count;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_lock) _items.Clear();
+    }
+
+    public void Insert(int index, string item)
+    {
+        lock (_lock) _items.Insert(index, item);
+    }
+
+    public void RemoveAt(int index)
+    {
+        lock (_lock) _items.RemoveAt(index);
+    }
+
+    public void RemoveAll(Predicate<string> match)
+    {
+        lock (_lock) _items.RemoveAll(match);
+    }
+
+    /// <summary>
+    /// Atomically removes and returns the first item, or null if the queue is empty.
+    /// Replaces the non-atomic pattern: if (Count > 0) { var x = [0]; RemoveAt(0); }
+    /// </summary>
+    public string? TryDequeue()
+    {
+        lock (_lock)
+        {
+            if (_items.Count == 0) return null;
+            var item = _items[0];
+            _items.RemoveAt(0);
+            return item;
+        }
+    }
+
+    /// <summary>
+    /// Atomically removes the item at the given index if valid. Returns true if removed.
+    /// </summary>
+    public bool TryRemoveAt(int index)
+    {
+        lock (_lock)
+        {
+            if (index < 0 || index >= _items.Count) return false;
+            _items.RemoveAt(index);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Returns a point-in-time copy safe for iteration outside any lock.
+    /// </summary>
+    public List<string> Snapshot()
+    {
+        lock (_lock) return new List<string>(_items);
+    }
+
+    public bool Any()
+    {
+        lock (_lock) return _items.Count > 0;
+    }
+
+    /// <summary>Enumerates a snapshot — safe for concurrent use.</summary>
+    public IEnumerator<string> GetEnumerator() => Snapshot().GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/PolyPilot/Services/CopilotService.Events.cs
+++ b/PolyPilot/Services/CopilotService.Events.cs
@@ -966,10 +966,9 @@ public partial class CopilotService
 
         // Auto-dispatch next queued message — send immediately on the current
         // synchronization context to prevent other actors from racing for the session.
-        if (state.Info.MessageQueue.Count > 0)
+        var nextPrompt = state.Info.MessageQueue.TryDequeue();
+        if (nextPrompt != null)
         {
-            var nextPrompt = state.Info.MessageQueue[0];
-            state.Info.MessageQueue.RemoveAt(0);
             // Retrieve any queued image paths for this message
             List<string>? nextImagePaths = null;
             lock (_imageQueueLock)
@@ -1285,56 +1284,57 @@ public partial class CopilotService
 
             // If the session is idle (evaluator ran asynchronously after CompleteResponse),
             // dispatch the queued message immediately.
-            if (!state.Info.IsProcessing && state.Info.MessageQueue.Count > 0)
+            if (!state.Info.IsProcessing)
             {
-                var nextPrompt = state.Info.MessageQueue[0];
-                state.Info.MessageQueue.RemoveAt(0);
-
-                // Consume any queued agent mode to keep alignment
-                string? nextAgentMode2 = null;
-                lock (_imageQueueLock)
+                var nextPrompt2 = state.Info.MessageQueue.TryDequeue();
+                if (nextPrompt2 != null)
                 {
-                    if (_queuedAgentModes.TryGetValue(state.Info.Name, out var modeQueue2) && modeQueue2.Count > 0)
+                    // Consume any queued agent mode to keep alignment
+                    string? nextAgentMode2 = null;
+                    lock (_imageQueueLock)
                     {
-                        nextAgentMode2 = modeQueue2[0];
-                        modeQueue2.RemoveAt(0);
-                        if (modeQueue2.Count == 0)
-                            _queuedAgentModes.TryRemove(state.Info.Name, out _);
-                    }
-                }
-
-                var skipHistory = state.Info.ReflectionCycle is { IsActive: true } &&
-                                  ReflectionCycle.IsReflectionFollowUpPrompt(nextPrompt);
-
-                _ = Task.Run(async () =>
-                {
-                    try
-                    {
-                        await Task.Delay(100);
-                        if (_syncContext != null)
+                        if (_queuedAgentModes.TryGetValue(state.Info.Name, out var modeQueue2) && modeQueue2.Count > 0)
                         {
-                            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                            _syncContext.Post(async _ =>
-                            {
-                                try
-                                {
-                                    await SendPromptAsync(state.Info.Name, nextPrompt, skipHistoryMessage: skipHistory, agentMode: nextAgentMode2);
-                                    tcs.TrySetResult();
-                                }
-                                catch (Exception ex)
-                                {
-                                    Debug($"Error dispatching evaluator follow-up: {ex.Message}");
-                                    tcs.TrySetException(ex);
-                                }
-                            }, null);
-                            await tcs.Task;
+                            nextAgentMode2 = modeQueue2[0];
+                            modeQueue2.RemoveAt(0);
+                            if (modeQueue2.Count == 0)
+                                _queuedAgentModes.TryRemove(state.Info.Name, out _);
                         }
                     }
-                    catch (Exception ex)
+
+                    var skipHistory = state.Info.ReflectionCycle is { IsActive: true } &&
+                                      ReflectionCycle.IsReflectionFollowUpPrompt(nextPrompt2);
+
+                    _ = Task.Run(async () =>
                     {
-                        Debug($"Error dispatching queued message after evaluation: {ex.Message}");
-                    }
-                });
+                        try
+                        {
+                            await Task.Delay(100);
+                            if (_syncContext != null)
+                            {
+                                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                                _syncContext.Post(async _ =>
+                                {
+                                    try
+                                    {
+                                        await SendPromptAsync(state.Info.Name, nextPrompt2, skipHistoryMessage: skipHistory, agentMode: nextAgentMode2);
+                                        tcs.TrySetResult();
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        Debug($"Error dispatching evaluator follow-up: {ex.Message}");
+                                        tcs.TrySetException(ex);
+                                    }
+                                }, null);
+                                await tcs.Task;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug($"Error dispatching queued message after evaluation: {ex.Message}");
+                        }
+                    });
+                }
             }
         }
         else if (!cycle.IsActive)

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -2011,10 +2011,9 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
 
         // Drain any messages queued while IsCreating was true.
         // The user may have typed and sent a message before SDK creation finished.
-        if (state.Info.MessageQueue.Count > 0)
+        var nextPrompt = state.Info.MessageQueue.TryDequeue();
+        if (nextPrompt != null)
         {
-            var nextPrompt = state.Info.MessageQueue[0];
-            state.Info.MessageQueue.RemoveAt(0);
             List<string>? nextImagePaths = null;
             lock (_imageQueueLock)
             {
@@ -3018,7 +3017,7 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
         if (!_sessions.TryGetValue(sessionName, out var state))
             throw new InvalidOperationException($"Session '{sessionName}' not found.");
 
-        state.Info.MessageQueue.Add(prompt);
+        var queueCount = state.Info.MessageQueue.AddAndGetCount(prompt);
         
         // Track image paths alongside the queued message
         if (imagePaths != null && imagePaths.Count > 0)
@@ -3026,7 +3025,7 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
             lock (_imageQueueLock)
             {
                 var queue = _queuedImagePaths.GetOrAdd(sessionName, _ => new List<List<string>>());
-                while (queue.Count < state.Info.MessageQueue.Count - 1)
+                while (queue.Count < queueCount - 1)
                     queue.Add(new List<string>());
                 queue.Add(imagePaths);
             }
@@ -3038,7 +3037,7 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
             lock (_imageQueueLock)
             {
                 var modes = _queuedAgentModes.GetOrAdd(sessionName, _ => new List<string?>());
-                while (modes.Count < state.Info.MessageQueue.Count - 1)
+                while (modes.Count < queueCount - 1)
                     modes.Add(null);
                 modes.Add(agentMode);
             }
@@ -3090,9 +3089,8 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
         if (!_sessions.TryGetValue(sessionName, out var state))
             return;
         
-        if (index >= 0 && index < state.Info.MessageQueue.Count)
+        if (state.Info.MessageQueue.TryRemoveAt(index))
         {
-            state.Info.MessageQueue.RemoveAt(index);
             // Keep queued image paths in sync
             lock (_imageQueueLock)
             {


### PR DESCRIPTION
## Problem

`AgentSessionInfo.MessageQueue` is a plain `List<string>` accessed concurrently from multiple threads without synchronization:

| Thread | Operation | Location |
|--------|-----------|----------|
| WsBridge background | `MessageQueue.Count` read | WsBridgeServer.cs:994 |
| WsBridge background | `EnqueueMessage()` → `Add()` | WsBridgeServer.cs:464 |
| Orchestrator Task.WhenAll | `EnqueueMessage()` → `Add()` | CopilotService.Organization.cs:981 |
| UI thread | Blazor iteration `[i]`, `Count` | ExpandedSessionView.razor |
| UI thread (via Invoke) | `CompleteResponse` dequeue | Events.cs:966 |

`List<T>` is not thread-safe — concurrent access corrupts its internal array, causing `ArgumentOutOfRangeException`, silent data loss, or `InvalidOperationException`.

## Fix

Replace `List<string>` with `SynchronizedMessageQueue` — an internally-locked wrapper exposing the same operations:

- **`TryDequeue()`** — atomic check-and-remove-first, replaces 3 non-atomic `if (Count > 0) { var x = [0]; RemoveAt(0); }` patterns
- **`TryRemoveAt(index)`** — atomic bounds-check-and-remove, replaces `if (index >= 0 && index < Count) RemoveAt(index)`
- **`AddAndGetCount()`** — atomic add + count return, keeps image/mode parallel queues aligned in `EnqueueMessage`
- **`Snapshot()`** — point-in-time copy for safe Blazor iteration
- **`IReadOnlyList<string>`** — backward-compatible enumeration (enumerator operates on snapshot)

## Changes

| File | Change |
|------|--------|
| `Models/SynchronizedMessageQueue.cs` | **New** — thread-safe wrapper with internal lock |
| `Models/AgentSessionInfo.cs` | Type change: `List<string>` → `SynchronizedMessageQueue` |
| `Services/CopilotService.cs` | `TryDequeue()` in CreateSession drain, `AddAndGetCount()` in EnqueueMessage, `TryRemoveAt()` in RemoveQueuedMessage |
| `Services/CopilotService.Events.cs` | `TryDequeue()` in CompleteResponse and reflection follow-up dispatch |
| `Components/ExpandedSessionView.razor` | `Snapshot()` for iteration |
| `Components/Pages/Dashboard.razor` | `TryRemoveAt()` in local RemoveQueuedMessage |
| `Tests/SynchronizedMessageQueueTests.cs` | **New** — 12 tests including concurrent stress |
| `Tests/PolyPilot.Tests.csproj` | Compile include for new model |

## Testing

- All 2411 existing tests pass (3 pre-existing CliPath failures unrelated)
- 12 new tests: basic ops, TryDequeue, TryRemoveAt, AddAndGetCount, Snapshot isolation, concurrent add/dequeue, concurrent add/clear/snapshot stress

Closes #346