### PR TITLE
fix: make _activeSessionName volatile for cross-thread visibility

### DIFF
--- a/PolyPilot.Tests/VolatileFieldGuardTests.cs
+++ b/PolyPilot.Tests/VolatileFieldGuardTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using PolyPilot.Services;
+
+namespace PolyPilot.Tests;
+
+/// <summary>
+/// Guards that fields accessed from multiple threads are declared volatile.
+/// Prevents regressions where someone removes the volatile modifier.
+/// </summary>
+public class VolatileFieldGuardTests
+{
+    [Fact]
+    public void ActiveSessionName_IsDeclaredVolatile_OnCopilotService()
+    {
+        // _activeSessionName is read by WsBridge background threads (SyncRemoteSessions),
+        // restore background threads, and written by UI thread (SetActiveSession, CloseSession).
+        // Must be volatile for cross-thread visibility on ARM (iOS/Android).
+        var field = typeof(CopilotService)
+            .GetField("_activeSessionName", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        Assert.NotNull(field);
+        Assert.True(
+            field.GetRequiredCustomModifiers().Any(m => m == typeof(IsVolatile)),
+            "_activeSessionName must be declared volatile for cross-thread visibility");
+    }
+
+    [Fact]
+    public void ActiveSessionName_IsDeclaredVolatile_OnDemoService()
+    {
+        var field = typeof(DemoService)
+            .GetField("_activeSessionName", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        Assert.NotNull(field);
+        Assert.True(
+            field.GetRequiredCustomModifiers().Any(m => m == typeof(IsVolatile)),
+            "DemoService._activeSessionName must be declared volatile for consistency");
+    }
+}

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -51,7 +51,7 @@ public partial class CopilotService : IAsyncDisposable
     // Cached dotfiles status — checked once when first SetupRequired state is encountered
     private CodespaceService.DotfilesStatus? _dotfilesStatus;
     private ConnectionSettings? _currentSettings;
-    private string? _activeSessionName;
+    private volatile string? _activeSessionName;
     private SynchronizationContext? _syncContext;
     // Serializes the IsConnectionError reconnect path so concurrent workers
     // don't destroy each other's freshly-created client (thundering herd fix).

--- a/PolyPilot/Services/DemoService.cs
+++ b/PolyPilot/Services/DemoService.cs
@@ -10,7 +10,7 @@ namespace PolyPilot.Services;
 public class DemoService : IDemoService
 {
     private readonly ConcurrentDictionary<string, AgentSessionInfo> _sessions = new();
-    private string? _activeSessionName;
+    private volatile string? _activeSessionName;
     private int _sessionCounter;
 
     public event Action? OnStateChanged;


### PR DESCRIPTION
## Problem

`_activeSessionName` is a plain `string?` accessed from multiple threads without memory barriers:

| Thread | Operation | Location |
|--------|-----------|----------|
| UI thread | Write (SetActiveSession, CloseSession, RenameSession) | CopilotService.cs |
| WsBridge background | Read + conditional write (SyncRemoteSessions) | Bridge.cs:532 |
| Restore background | Conditional write (`??=`) | Persistence.cs:380 |
| SDK event handler | Read comparison | Events.cs:876 |
| SaveActiveSessionsToDisk | Read | Persistence.cs:457 |

On ARM (iOS/Android), without `volatile`, writes may sit in a CPU store buffer and never become visible to reads on other cores — causing stale active session name in bridge sync, persistence, and event handling.

## Fix

```diff
- private string? _activeSessionName;
+ private volatile string? _activeSessionName;
```

Applied to both `CopilotService` and `DemoService`.

All compound patterns (`??=`, compare-then-swap in Close/Rename) are either on the UI thread or benign (first-write-wins on restore/bridge sync).

## Testing

- 2 new reflection-based guard tests in `VolatileFieldGuardTests.cs` verify the `volatile` modifier is present (same pattern as PR #344 for `HasUsedToolsThisTurn`)
- All existing tests pass

Closes #348