### PR TITLE
fix: pass Plan/Autopilot agent mode through to SDK MessageOptions.Mode

### DIFF
--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -2467,12 +2467,14 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
                 Prompt = prompt
             };
 
-            // NOTE: MessageOptions.Mode is reserved for routing ("immediate" = steer-without-abort,
-            // null = default enqueue). Do NOT set Mode to an agent mode string here.
-            // The .NET SDK has no public mechanism to set session agent mode (autopilot/plan/interactive).
-            // Agent mode is controlled by session-level configuration (system message, available tools)
-            // set at session creation time via SessionConfig. The agentMode parameter is preserved
-            // in the pipeline for queue dispatch, bridge forwarding, and future SDK support.
+            // MessageOptions.Mode supports interaction modes: "plan", "autopilot", "edit",
+            // or "immediate" (used by SteerSessionAsync for soft-steer).
+            // When the user selects Plan or Autopilot in the UI, pass it through to the SDK.
+            if (!string.IsNullOrEmpty(agentMode))
+            {
+                messageOptions.Mode = agentMode;
+                Debug($"[SEND] '{sessionName}' agentMode={agentMode}");
+            }
             
             // Attach images via SDK if available
             if (imagePaths != null && imagePaths.Count > 0)
@@ -2692,6 +2694,8 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
                     {
                         Prompt = prompt
                     };
+                    if (!string.IsNullOrEmpty(agentMode))
+                        retryOptions.Mode = agentMode;
                     // WORKAROUND: Pass CancellationToken.None (same reason as primary send path).
                     // Same watchdog limitation applies here.
                     await state.Session.SendAsync(retryOptions, CancellationToken.None);


### PR DESCRIPTION
## Summary

The UI mode buttons (Chat/Plan/Autopilot) were correctly wired through the entire pipeline but the SDK's MessageOptions.Mode was never actually set. The agentMode parameter was silently dropped at the final SDK call.

## What Changed

**PolyPilot/Services/CopilotService.cs:**
- Set messageOptions.Mode = agentMode when non-null in the primary send path
- Set messageOptions.Mode = agentMode in the reconnect retry path
- Updated an incorrect comment that claimed the SDK had no mechanism for setting agent mode

## Verification

- Unit tests: All 7 AgentModeTests pass; full suite 2421/2422 (1 pre-existing failure)
- End-to-end via MauiDevFlow CDP:
  - Plan mode: agentMode=plan confirmed in diagnostic log
  - Autopilot mode: agentMode=autopilot confirmed in diagnostic log
  - Chat mode: No agentMode set (correct, maps to null)
- UI buttons: All three toggle correctly with visual feedback
