### PR TITLE
feat: clean up multi-agent UI — preset-only groups, worker child hierarchy in sidebar

### DIFF
--- a/PolyPilot/Components/ExpandedSessionView.razor
+++ b/PolyPilot/Components/ExpandedSessionView.razor
@@ -254,7 +254,6 @@
                 <button class="mode-btn @(InputMode == "chat" ? "active" : "")" @onclick='() => OnSetInputMode.InvokeAsync("chat")' title="Chat mode — interactive conversation">Chat</button>
                 <button class="mode-btn @(InputMode == "plan" ? "active" : "")" @onclick='() => OnSetInputMode.InvokeAsync("plan")' title="Plan mode — create a plan before implementing">Plan</button>
                 <button class="mode-btn @(InputMode == "autopilot" ? "active" : "")" @onclick='() => OnSetInputMode.InvokeAsync("autopilot")' title="Autopilot mode — auto-approve tool calls">Autopilot</button>
-
             </div>
             @if (Session.ReflectionCycle is null || !Session.ReflectionCycle.IsActive)
             {

--- a/PolyPilot/Components/ExpandedSessionView.razor.css
+++ b/PolyPilot/Components/ExpandedSessionView.razor.css
@@ -672,3 +672,5 @@
     .expanded-card .input-area textarea { font-size: var(--type-callout, 0.8rem); max-height: 30dvh; }
     .input-status-bar { gap: 0.4rem; }
 }
+
+

--- a/PolyPilot/Components/Layout/SessionListItem.razor
+++ b/PolyPilot/Components/Layout/SessionListItem.razor
@@ -15,6 +15,7 @@
                    IsCompleted ? "completed" :
                    Session.IsProcessing ? "busy" : "";
     if (IsDisabled) cssClass += " cs-disconnected";
+    if (IsWorkerChild) cssClass += " worker-child";
     // Prefer SDK-reported context window; fall back to accumulated totals
     var hasContextWindow = Session.ContextCurrentTokens > 0 && Session.ContextTokenLimit > 0;
     var totalTokens = Session.TotalInputTokens + Session.TotalOutputTokens;
@@ -160,19 +161,6 @@
                 @if (currentGroup is { IsMultiAgent: true })
                 {
                     <div class="menu-separator"></div>
-                    @if (Meta?.Role == MultiAgentRole.Orchestrator)
-                    {
-                        <button class="menu-item" @onclick="() => { OnCloseMenu.InvokeAsync(); CopilotService.SetSessionRole(Session.Name, MultiAgentRole.Worker); }">
-                            👷 Set as Worker
-                        </button>
-                    }
-                    else
-                    {
-                        <button class="menu-item" @onclick="() => { OnCloseMenu.InvokeAsync(); CopilotService.SetSessionRole(Session.Name, MultiAgentRole.Orchestrator); }">
-                            🎯 Set as Orchestrator
-                        </button>
-                    }
-                    <div class="menu-separator"></div>
                     <span class="menu-item submenu-label">🧠 Model</span>
                     <div class="model-picker-inline" @onclick:stopPropagation="true">
                         <select value="@(Meta?.PreferredModel ?? "")" @onchange="OnPreferredModelChanged">
@@ -249,6 +237,7 @@
     [Parameter] public int ShortcutIndex { get; set; }
     [Parameter] public List<SessionGroup>? Groups { get; set; }
     [Parameter] public SessionUsageInfo? UsageInfo { get; set; }
+    [Parameter] public bool IsWorkerChild { get; set; }
 
     [Parameter] public EventCallback OnSelect { get; set; }
     [Parameter] public EventCallback OnClose { get; set; }

--- a/PolyPilot/Components/Layout/SessionListItem.razor.css
+++ b/PolyPilot/Components/Layout/SessionListItem.razor.css
@@ -426,3 +426,16 @@
     pointer-events: none;
     cursor: default;
 }
+
+/* Worker child: indented under orchestrator */
+.session-item.worker-child {
+    margin-left: 16px;
+    padding-left: 8px;
+    border-left: 2px solid var(--control-border);
+    font-size: 0.85em;
+    opacity: 0.85;
+}
+.session-item.worker-child .session-name-text::before {
+    content: "👷 ";
+    font-size: 0.85em;
+}

--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -330,11 +330,7 @@ else
                             </button>
                         }
                     }
-                    <div class="preset-divider">or create empty team:</div>
-                    <input type="text" class="new-group-input" id="newGroupInput"
-                           placeholder="Custom team name..."
-                           @onblur="CommitNewGroup"
-                           @onkeydown="HandleNewGroupKeyDown" />
+                    @* Ad-hoc creation removed — users must select a preset *@
                 </div>
             }
             else
@@ -681,6 +677,89 @@ else
                                 </div>
                             }
                         }
+                        @if (group.IsMultiAgent)
+                        {
+                            @* Multi-agent: orchestrator first, then workers as children.
+                               GetFilteredSessions (pin-based splitting) is intentionally skipped here —
+                               workers are presented as a collapsible unit under the orchestrator rather than
+                               individually pin-filtered. The UnpinnedCollapsed flag drives the worker toggle. *@
+                            var orchName = CopilotService.GetOrchestratorSession(group.Id);
+                            var orchSession = orchName != null ? groupSessions.FirstOrDefault(s => s.Name == orchName) : null;
+                            if (orchSession != null)
+                            {
+                                sessionIndex++;
+                                var orchIdx = sessionIndex;
+                                var orchMeta = CopilotService.GetSessionMeta(orchSession.Name);
+                                var orchSName = orchSession.Name;
+                                <SessionListItem Session="orchSession"
+                                                 Meta="orchMeta"
+                                                 IsActive="@(orchSession.Name == CopilotService.ActiveSessionName)"
+                                                 IsCompleted="@completedSessions.Contains(orchSession.Name)"
+                                                 IsDisabled="@(group.IsCodespace && group.ConnectionState != CodespaceConnectionState.Connected)"
+                                                 IsRenaming="@(renamingSession == orchSession.Name)"
+                                                 IsMenuOpen="@(openMenuSession == orchSession.Name)"
+                                                 ShortcutIndex="orchIdx"
+                                                 Groups="CopilotService.Organization.Groups"
+                                                 UsageInfo="@(usageBySession.TryGetValue(orchSession.Name, out var orchUsg) ? orchUsg : null)"
+                                                 OnSelect="() => SelectSession(orchSName)"
+                                                 OnClose="() => CloseSession(orchSName)"
+                                                 OnCloseWithOptions="(opts) => CloseSessionWithOptions(orchSName, opts.DeleteWorktree, opts.DeleteBranch)"
+                                                 OnPin="(pinned) => { CopilotService.PinSession(orchSName, pinned); }"
+                                                 OnMove="(groupId) => CopilotService.MoveSession(orchSName, groupId)"
+                                                 OnStartRename="() => StartRename(orchSName)"
+                                                 OnCommitRename="CommitRename"
+                                                 OnToggleMenu="() => ToggleSessionMenu(orchSName)"
+                                                 OnCloseMenu="() => { openMenuSession = null; }"
+                                                 OnReportBug="() => OpenBugReportForSession(orchSName)"
+                                                 OnFixWithCopilot="() => OpenFixItForSession(orchSName)"
+                                                 OnAnalyze="() => AnalyzeSessionEfficiency(orchSName)" />
+                            }
+                            var workerSessions = groupSessions.Where(s => s.Name != orchName).ToList();
+                            var workerCount = workerSessions.Count;
+                            if (workerCount > 0)
+                            {
+                                var wToggleGroupId = group.Id;
+                                <div class="unpinned-toggle worker-toggle" @onclick="() => CopilotService.ToggleUnpinnedCollapsed(wToggleGroupId)" @onclick:stopPropagation="true">
+                                    <span class="unpinned-chevron">@(group.UnpinnedCollapsed ? "▶" : "▼")</span>
+                                    <span class="unpinned-label">👷 @workerCount @(workerCount != 1 ? "workers" : "worker")</span>
+                                </div>
+                                @if (!group.UnpinnedCollapsed)
+                                {
+                                    @foreach (var session in workerSessions)
+                                    {
+                                        sessionIndex++;
+                                        var wIdx = sessionIndex;
+                                        var wMeta = CopilotService.GetSessionMeta(session.Name);
+                                        var wSName = session.Name;
+                                        <SessionListItem Session="session"
+                                                         Meta="wMeta"
+                                                         IsActive="@(session.Name == CopilotService.ActiveSessionName)"
+                                                         IsCompleted="@completedSessions.Contains(session.Name)"
+                                                         IsDisabled="@(group.IsCodespace && group.ConnectionState != CodespaceConnectionState.Connected)"
+                                                         IsWorkerChild="true"
+                                                         IsRenaming="@(renamingSession == session.Name)"
+                                                         IsMenuOpen="@(openMenuSession == session.Name)"
+                                                         ShortcutIndex="wIdx"
+                                                         Groups="CopilotService.Organization.Groups"
+                                                         UsageInfo="@(usageBySession.TryGetValue(session.Name, out var wUsg) ? wUsg : null)"
+                                                         OnSelect="() => SelectSession(wSName)"
+                                                         OnClose="() => CloseSession(wSName)"
+                                                         OnCloseWithOptions="(opts) => CloseSessionWithOptions(wSName, opts.DeleteWorktree, opts.DeleteBranch)"
+                                                         OnPin="(pinned) => { CopilotService.PinSession(wSName, pinned); }"
+                                                         OnMove="(groupId) => CopilotService.MoveSession(wSName, groupId)"
+                                                         OnStartRename="() => StartRename(wSName)"
+                                                         OnCommitRename="CommitRename"
+                                                         OnToggleMenu="() => ToggleSessionMenu(wSName)"
+                                                         OnCloseMenu="() => { openMenuSession = null; }"
+                                                         OnReportBug="() => OpenBugReportForSession(wSName)"
+                                                         OnFixWithCopilot="() => OpenFixItForSession(wSName)"
+                                                         OnAnalyze="() => AnalyzeSessionEfficiency(wSName)" />
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
                         @foreach (var session in GetFilteredSessions(groupSessions, group, true))
                         {
                             sessionIndex++;
@@ -746,6 +825,7 @@ else
                                              OnReportBug="() => OpenBugReportForSession(sName)"
                                              OnFixWithCopilot="() => OpenFixItForSession(sName)"
                                              OnAnalyze="() => AnalyzeSessionEfficiency(sName)" />
+                        }
                         }
                     }
                 }

--- a/PolyPilot/Components/Layout/SessionSidebar.razor.css
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor.css
@@ -255,6 +255,9 @@
     user-select: none;
 }
 .unpinned-toggle:hover { background: var(--hover-bg); }
+.unpinned-toggle.worker-toggle {
+    padding-left: 1.6rem;
+}
 
 .unpinned-chevron {
     font-size: 0.55rem;


### PR DESCRIPTION
## Summary

Simplifies the multi-agent UX by enforcing preset-based group creation and restructuring the sidebar to show workers as children of their orchestrator.

## Changes

### 1. Remove ad-hoc multi-agent team creation
- Removed the \or create empty team:\ divider and custom team name input from the sidebar
- Users must now select a preset (built-in, user-saved, or repo \.squad/\) to start a multi-agent group
- Prevents misconfigured ad-hoc groups with no routing logic

### 2. Remove Set as Worker / Set as Orchestrator role-switching
- Removed the 'Set as Worker' / 'Set as Orchestrator' toggle buttons from the session context menu in multi-agent groups
- Roles are defined by presets at group creation and should not change at runtime
- The orchestrator badge remains as read-only info display

### 3. Worker child hierarchy in sidebar
- Multi-agent groups now render the orchestrator first, followed by workers indented below with a \👷\ prefix
- A collapsible toggle shows worker count (e.g. \👷 3 workers\) — uses the existing \UnpinnedCollapsed\ flag
- Workers receive the \worker-child\ CSS class for visual indentation
- Workers remain fully interactive (users can send steering messages directly)

## Files Changed
- \SessionSidebar.razor\ / \.css\ — orchestrator-first rendering, worker toggle, ad-hoc input removed
- \SessionListItem.razor\ / \.css\ — \IsWorkerChild\ parameter + CSS class, role-switch menu items removed
- \ExpandedSessionView.razor\ / \.css\ — minor whitespace cleanup in mode buttons area