### PR TITLE
fix: correct BuildDir path in relaunch.ps1

### DIFF
--- a/PolyPilot/relaunch.ps1
+++ b/PolyPilot/relaunch.ps1
@@ -10,7 +10,7 @@
 $ErrorActionPreference = 'Stop'
 
 $ProjectDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$BuildDir = Join-Path $ProjectDir 'bin\Debug\net10.0-windows10.0.19041.0\win-x64'
+$BuildDir = Join-Path $ProjectDir 'bin\Debug\net10.0-windows10.0.19041.0'
 $ExeName = 'PolyPilot.exe'
 
 $MaxLaunchAttempts = 2


### PR DESCRIPTION
## Problem

\elaunch.ps1\ was looking for the exe in \in\Debug\net10.0-windows10.0.19041.0\win-x64\ but the build command doesn't specify \-r win-x64\, so dotnet outputs to \in\Debug\net10.0-windows10.0.19041.0\ (no RID subfolder).

This bug was introduced in the original script creation (PR #130) and caused launch failures:
\\\
Start-Process: This command cannot be run due to the error: The system cannot find the file specified.
\\\

## Root Cause

The script hardcoded \\win-x64\ in \\\ but the build command was:
\\\powershell
dotnet build PolyPilot.csproj -f net10.0-windows10.0.19041.0
\\\

Without \-r win-x64\, the output goes to the framework folder directly.

## Fix

Remove \\win-x64\ from \\\ to match the actual build output location.

## Testing

Verified the fix works - build succeeds and app launches correctly.