### PR TITLE
fix: increase watchdog Case B freshness for multi-agent sessions

### DIFF
--- a/PolyPilot.Tests/ProcessingWatchdogTests.cs
+++ b/PolyPilot.Tests/ProcessingWatchdogTests.cs
@@ -2592,4 +2592,75 @@ public class ProcessingWatchdogTests
         Assert.True(reconnectBlock.Contains("ActiveToolCallCount") && reconnectBlock.Contains("0"),
             "Reconnect block must reset ActiveToolCallCount to 0 for the new connection.");
     }
+
+    // ===== Multi-agent Case B extended freshness (issue #365 fix) =====
+
+    [Fact]
+    public void WatchdogCaseBFreshnessSeconds_StandardValue()
+    {
+        // Standard (non-multi-agent) freshness is 300s (5 min).
+        Assert.Equal(300, CopilotService.WatchdogCaseBFreshnessSeconds);
+    }
+
+    [Fact]
+    public void WatchdogMultiAgentCaseBFreshnessSeconds_ExtendedValue()
+    {
+        // Multi-agent sessions get 1800s (30 min) to accommodate long server-side tool execution.
+        Assert.Equal(1800, CopilotService.WatchdogMultiAgentCaseBFreshnessSeconds);
+        Assert.True(CopilotService.WatchdogMultiAgentCaseBFreshnessSeconds >
+                    CopilotService.WatchdogCaseBFreshnessSeconds,
+            "Multi-agent freshness must be longer than standard freshness");
+    }
+
+    [Fact]
+    public void WatchdogMultiAgentCaseBFreshnessSeconds_WithinWorkerTimeout()
+    {
+        // The extended freshness must be less than the worker execution timeout (60 min = 3600s).
+        // It's a safety net, not an override of the ultimate backstop.
+        Assert.True(CopilotService.WatchdogMultiAgentCaseBFreshnessSeconds <
+                    CopilotService.WatchdogMaxProcessingTimeSeconds,
+            "Multi-agent Case B freshness must be shorter than the absolute max processing time");
+    }
+
+    [Fact]
+    public void WatchdogCaseB_UsesMultiAgentFreshness_InSource()
+    {
+        // Case B freshness check must select threshold based on isMultiAgentSession.
+        // This prevents premature force-completion of worker sessions (issue #365).
+        var source = File.ReadAllText(
+            Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.Events.cs"));
+        var methodIdx = source.IndexOf("private async Task RunProcessingWatchdogAsync");
+        var endIdx = source.IndexOf("    private readonly ConcurrentDictionary", methodIdx);
+        var watchdogBody = source.Substring(methodIdx, endIdx - methodIdx);
+
+        // The freshness threshold must be conditional on isMultiAgentSession
+        Assert.True(watchdogBody.Contains("WatchdogMultiAgentCaseBFreshnessSeconds"),
+            "Case B must reference WatchdogMultiAgentCaseBFreshnessSeconds for multi-agent sessions");
+        Assert.True(watchdogBody.Contains("WatchdogCaseBFreshnessSeconds"),
+            "Case B must reference WatchdogCaseBFreshnessSeconds for standard sessions");
+
+        // The age comparison must use the parameterized threshold, not a hardcoded 300
+        Assert.True(watchdogBody.Contains("age < freshnessSeconds"),
+            "Case B must compare age against the parameterized freshnessSeconds, not a hardcoded value");
+        Assert.False(watchdogBody.Contains("age < 300"),
+            "Case B must NOT use hardcoded 300 — must use named constant via freshnessSeconds variable");
+    }
+
+    [Fact]
+    public void WatchdogCaseB_FreshnessThresholdSelection_InSource()
+    {
+        // Verify that the freshness threshold is selected based on isMultiAgentSession
+        // using a ternary before the events.jsonl check.
+        var source = File.ReadAllText(
+            Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.Events.cs"));
+        var methodIdx = source.IndexOf("private async Task RunProcessingWatchdogAsync");
+        var endIdx = source.IndexOf("    private readonly ConcurrentDictionary", methodIdx);
+        var watchdogBody = source.Substring(methodIdx, endIdx - methodIdx);
+
+        // The threshold selection must use isMultiAgentSession ternary
+        Assert.True(watchdogBody.Contains("isMultiAgentSession")
+            && watchdogBody.Contains("WatchdogMultiAgentCaseBFreshnessSeconds")
+            && watchdogBody.Contains("WatchdogCaseBFreshnessSeconds"),
+            "Case B must select freshness threshold based on isMultiAgentSession");
+    }
 }

--- a/PolyPilot/Services/CopilotService.Events.cs
+++ b/PolyPilot/Services/CopilotService.Events.cs
@@ -1489,6 +1489,18 @@ public partial class CopilotService
     /// of additional time beyond the initial 120s inactivity timeout.</summary>
     internal const int WatchdogMaxCaseBResets = 40;
 
+    /// <summary>Maximum age (in seconds) of events.jsonl for Case B to consider the session still active.
+    /// If events.jsonl was modified after the turn started AND within this window, the CLI is still
+    /// writing — defer completion. 300s (5 min) is appropriate for interactive sessions.</summary>
+    internal const int WatchdogCaseBFreshnessSeconds = 300;
+
+    /// <summary>Extended freshness window for multi-agent sessions. Worker sessions perform long
+    /// server-side tool executions (builds, tests, complex code analysis) where the SDK may pause
+    /// event delivery for 10+ minutes while the tool runs. The standard 300s window causes premature
+    /// force-completion, sending truncated results to the orchestrator (issue #365).
+    /// 1800s (30 min) aligns with the 60-min worker execution timeout as the ultimate backstop.</summary>
+    internal const int WatchdogMultiAgentCaseBFreshnessSeconds = 1800;
+
     /// <summary>
     /// Milliseconds after a tool starts to perform the first health check. If no events have
     /// arrived since tool start, we verify the connection is still alive. This detects dead
@@ -1945,6 +1957,9 @@ public partial class CopilotService
                                 // - "after turn start" alone stays true forever once any event is written
                                 // - "recent" alone could match stale files from a previous turn
                                 var caseBEventsActive = false;
+                                var freshnessSeconds = isMultiAgentSession
+                                    ? WatchdogMultiAgentCaseBFreshnessSeconds
+                                    : WatchdogCaseBFreshnessSeconds;
                                 try
                                 {
                                     var sid = state.Info.SessionId;
@@ -1956,8 +1971,10 @@ public partial class CopilotService
                                             var lastWrite = File.GetLastWriteTimeUtc(ep);
                                             var age = (DateTime.UtcNow - lastWrite).TotalSeconds;
                                             // File must be: (1) written after this turn started AND
-                                            // (2) written within last 5 minutes (CLI is still active)
-                                            caseBEventsActive = lastWrite > startedAt.Value && age < 300;
+                                            // (2) written within the freshness window (CLI is still active).
+                                            // Multi-agent workers get a much longer window because the SDK
+                                            // can pause event delivery for 10+ min during long tool runs.
+                                            caseBEventsActive = lastWrite > startedAt.Value && age < freshnessSeconds;
                                         }
                                     }
                                 }
@@ -1969,12 +1986,13 @@ public partial class CopilotService
                                     if (caseBResets <= WatchdogMaxCaseBResets)
                                     {
                                         Debug($"[WATCHDOG] '{sessionName}' Case B deferred — events.jsonl modified since turn start, session still active " +
-                                              $"(elapsed={elapsed:F0}s, totalProcessing={totalProcessingSeconds:F0}s, deferral={caseBResets}/{WatchdogMaxCaseBResets})");
+                                              $"(elapsed={elapsed:F0}s, totalProcessing={totalProcessingSeconds:F0}s, deferral={caseBResets}/{WatchdogMaxCaseBResets}, " +
+                                              $"freshness={freshnessSeconds}s{(isMultiAgentSession ? " [multi-agent]" : "")})");
                                         Interlocked.Exchange(ref state.LastEventAtTicks, DateTime.UtcNow.Ticks);
                                         continue;
                                     }
                                     Debug($"[WATCHDOG] '{sessionName}' Case B deferral cap reached ({caseBResets}/{WatchdogMaxCaseBResets}) — completing despite fresh events.jsonl " +
-                                          $"(elapsed={elapsed:F0}s, totalProcessing={totalProcessingSeconds:F0}s)");
+                                          $"(elapsed={elapsed:F0}s, totalProcessing={totalProcessingSeconds:F0}s, freshness={freshnessSeconds}s{(isMultiAgentSession ? " [multi-agent]" : "")})");
                                 }
                             }
 


### PR DESCRIPTION
## Problem

The watchdog Case B uses a hardcoded 300s (5 min) `events.jsonl` freshness threshold. When multi-agent worker sessions perform long server-side tool executions where the SDK pauses event delivery for >5 min, Case B force-completes the worker with truncated output. The orchestrator then synthesizes from incomplete results.

**Observed timeline from diagnostic logs:**
- 21:18:44 — Last SDK event (TurnEnd/TurnStart pair)
- 21:21:58 (194s later) — Case B fires, events.jsonl still fresh → deferred (1/40)
- 21:24:58 (180s after deferral) — Case B fires again, events.jsonl age > 300s → **force-completes with only 166 chars**
- 21:25:41–21:32:58 — SDK **resumes streaming** with IsProcessing=False (orphaned content)

## Fix

- Extract hardcoded `300` to `WatchdogCaseBFreshnessSeconds` constant
- Add `WatchdogMultiAgentCaseBFreshnessSeconds = 1800` (30 min) for multi-agent sessions
- Use the longer threshold when `isMultiAgentSession` is true
- Enhanced debug logging with freshness threshold and `[multi-agent]` tag

Workers are non-interactive and have a 60-min execution timeout — a 5-min freshness window was far too aggressive.

## Tests

5 new tests added (all 2487 tests pass):
- Constant value verification
- Multi-agent > standard threshold
- Multi-agent < max processing time (safety net)
- Structural: constants referenced in Case B code
- Structural: ternary selection pattern present

Fixes #365