### PR TITLE
fix: flush active-sessions.json after restore to persist recreated session IDs

### DIFF
--- a/PolyPilot.Tests/ChatExperienceSafetyTests.cs
+++ b/PolyPilot.Tests/ChatExperienceSafetyTests.cs
@@ -857,7 +857,7 @@ public class ChatExperienceSafetyTests
             Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.cs"));
 
         // After extraction to BuildFreshSessionConfig, verify the reconnect path calls the helper
-        var sessionNotFoundIdx = source.IndexOf("Session not found", StringComparison.OrdinalIgnoreCase);
+        var sessionNotFoundIdx = source.IndexOf("resumeEx.Message.Contains(\"Session not found\"", StringComparison.Ordinal);
         Assert.True(sessionNotFoundIdx > 0);
         var afterNotFound = source.Substring(sessionNotFoundIdx, Math.Min(1000, source.Length - sessionNotFoundIdx));
         Assert.Contains("BuildFreshSessionConfig", afterNotFound);

--- a/PolyPilot.Tests/ConnectionRecoveryTests.cs
+++ b/PolyPilot.Tests/ConnectionRecoveryTests.cs
@@ -280,8 +280,8 @@ public class ConnectionRecoveryTests
         var source = File.ReadAllText(Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.cs"));
 
         // Verify the reconnect path calls the helper
-        var sessionNotFoundIdx = source.IndexOf("Session not found", StringComparison.OrdinalIgnoreCase);
-        Assert.True(sessionNotFoundIdx > 0, "Could not find 'Session not found' in reconnect path");
+        var sessionNotFoundIdx = source.IndexOf("resumeEx.Message.Contains(\"Session not found\"", StringComparison.Ordinal);
+        Assert.True(sessionNotFoundIdx > 0, "Could not find 'Session not found' catch clause in reconnect path");
         var afterNotFound = source.Substring(sessionNotFoundIdx, Math.Min(1000, source.Length - sessionNotFoundIdx));
         Assert.Contains("BuildFreshSessionConfig", afterNotFound);
 

--- a/PolyPilot.Tests/SessionPersistenceTests.cs
+++ b/PolyPilot.Tests/SessionPersistenceTests.cs
@@ -541,7 +541,7 @@ public class SessionPersistenceTests
         var fallbackIdx = source.IndexOf("Falling back to CreateSessionAsync", StringComparison.Ordinal);
         Assert.True(fallbackIdx > 0);
 
-        var afterFallback = source.Substring(fallbackIdx, Math.Min(7000, source.Length - fallbackIdx));        Assert.Contains("History.Add", afterFallback);
+        var afterFallback = source.Substring(fallbackIdx, Math.Min(8000, source.Length - fallbackIdx));        Assert.Contains("History.Add", afterFallback);
         Assert.Contains("MessageCount", afterFallback);
         Assert.Contains("LastReadMessageCount", afterFallback);
     }
@@ -557,7 +557,7 @@ public class SessionPersistenceTests
         var fallbackIdx = source.IndexOf("Falling back to CreateSessionAsync", StringComparison.Ordinal);
         Assert.True(fallbackIdx > 0);
 
-        var afterFallback = source.Substring(fallbackIdx, Math.Min(7000, source.Length - fallbackIdx));
+        var afterFallback = source.Substring(fallbackIdx, Math.Min(8000, source.Length - fallbackIdx));
         Assert.Contains("RestoreUsageStats", afterFallback);
     }
 
@@ -572,7 +572,7 @@ public class SessionPersistenceTests
         var fallbackIdx = source.IndexOf("Falling back to CreateSessionAsync", StringComparison.Ordinal);
         Assert.True(fallbackIdx > 0);
 
-        var afterFallback = source.Substring(fallbackIdx, Math.Min(7000, source.Length - fallbackIdx));
+        var afterFallback = source.Substring(fallbackIdx, Math.Min(8000, source.Length - fallbackIdx));
         Assert.Contains("BulkInsertAsync", afterFallback);
     }
 
@@ -588,7 +588,7 @@ public class SessionPersistenceTests
         var fallbackIdx = source.IndexOf("Falling back to CreateSessionAsync", StringComparison.Ordinal);
         Assert.True(fallbackIdx > 0);
 
-        var afterFallback = source.Substring(fallbackIdx, Math.Min(7000, source.Length - fallbackIdx));
+        var afterFallback = source.Substring(fallbackIdx, Math.Min(8000, source.Length - fallbackIdx));
         Assert.Contains("events.jsonl", afterFallback);
         // Must sanitize old events (skip corrupt JSON lines)
         Assert.Contains("JsonDocument.Parse", afterFallback);
@@ -609,7 +609,7 @@ public class SessionPersistenceTests
         var fallbackIdx = source.IndexOf("Falling back to CreateSessionAsync", StringComparison.Ordinal);
         Assert.True(fallbackIdx > 0);
 
-        var afterFallback = source.Substring(fallbackIdx, Math.Min(7000, source.Length - fallbackIdx));
+        var afterFallback = source.Substring(fallbackIdx, Math.Min(8000, source.Length - fallbackIdx));
         Assert.Contains("ChatMessageType.ToolCall", afterFallback);
         Assert.Contains("ChatMessageType.Reasoning", afterFallback);
         Assert.Contains("msg.IsComplete = true", afterFallback);
@@ -627,7 +627,7 @@ public class SessionPersistenceTests
         var fallbackIdx = source.IndexOf("Falling back to CreateSessionAsync", StringComparison.Ordinal);
         Assert.True(fallbackIdx > 0);
 
-        var afterFallback = source.Substring(fallbackIdx, Math.Min(7000, source.Length - fallbackIdx));
+        var afterFallback = source.Substring(fallbackIdx, Math.Min(8000, source.Length - fallbackIdx));
         Assert.Contains("Session recreated", afterFallback);
         Assert.Contains("SystemMessage", afterFallback);
     }
@@ -645,7 +645,7 @@ public class SessionPersistenceTests
         var fallbackIdx = source.IndexOf("Falling back to CreateSessionAsync", StringComparison.Ordinal);
         Assert.True(fallbackIdx > 0);
 
-        var afterFallback = source.Substring(fallbackIdx, Math.Min(7000, source.Length - fallbackIdx));
+        var afterFallback = source.Substring(fallbackIdx, Math.Min(8000, source.Length - fallbackIdx));
         var systemMsgIdx = afterFallback.IndexOf("Session recreated", StringComparison.Ordinal);
         var messageCountIdx = afterFallback.IndexOf("MessageCount = recreatedState.Info.History.Count", StringComparison.Ordinal);
 

--- a/PolyPilot/Services/CopilotService.Persistence.cs
+++ b/PolyPilot/Services/CopilotService.Persistence.cs
@@ -450,7 +450,8 @@ public partial class CopilotService
 
                                                     if (oldLines.Count > 0)
                                                     {
-                                                        if (!File.Exists(newEvents))
+                                                        var existed = File.Exists(newEvents);
+                                                        if (!existed)
                                                         {
                                                             // New session has no events yet — write old events directly
                                                             File.WriteAllLines(newEvents, oldLines);
@@ -459,16 +460,21 @@ public partial class CopilotService
                                                         {
                                                             // New session already has events (SDK created it).
                                                             // Prepend old events so history is preserved on future restarts.
+                                                            // Write to temp file then atomic-move to avoid data loss on crash.
                                                             var newLines = File.ReadAllLines(newEvents);
-                                                            using var writer = new StreamWriter(newEvents, append: false);
-                                                            foreach (var line in oldLines) writer.WriteLine(line);
-                                                            foreach (var line in newLines) writer.WriteLine(line);
+                                                            var tmpFile = newEvents + ".tmp";
+                                                            using (var writer = new StreamWriter(tmpFile, append: false))
+                                                            {
+                                                                foreach (var line in oldLines) writer.WriteLine(line);
+                                                                foreach (var line in newLines) writer.WriteLine(line);
+                                                            }
+                                                            File.Move(tmpFile, newEvents, overwrite: true);
                                                         }
 
                                                         if (skippedLines > 0)
                                                             Debug($"Sanitized events.jsonl copy from {entry.SessionId} to {recreatedState.Info.SessionId}: {oldLines.Count} valid, {skippedLines} corrupt lines skipped");
                                                         else
-                                                            Debug($"Copied events.jsonl from {entry.SessionId} to {recreatedState.Info.SessionId}: {oldLines.Count} lines (prepended={File.Exists(newEvents)})");
+                                                            Debug($"Copied events.jsonl from {entry.SessionId} to {recreatedState.Info.SessionId}: {oldLines.Count} lines (prepended={existed})");
                                                     }
                                                 }
                                             }

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -787,9 +787,9 @@ public partial class CopilotService : IAsyncDisposable
         IsRestoring = false;
 
         // Flush session list immediately after restore so that any session IDs changed
-        // during fallback recreation (e.g., "Session not found" → CreateSessionAsync)
-        // are persisted. Without this, active-sessions.json retains stale IDs and
-        // LoadHistoryFromDisk reads the wrong events.jsonl on the next restart.
+        // during fallback recreation (resume failed → CreateSessionAsync) are persisted.
+        // Without this, active-sessions.json retains stale IDs and LoadHistoryFromDisk
+        // reads the wrong events.jsonl on the next restart.
         FlushSaveActiveSessionsToDisk();
 
         // Start health check loop for any codespace groups (regardless of whether sessions were restored)


### PR DESCRIPTION
## Bug

The **AndroidShellHandler** session loses all history every time PolyPilot restarts. Investigation revealed 21 orphaned session directories all containing AndroidShellHandler events — the session was being recreated from scratch on every launch.

## Root Cause

When `RestorePreviousSessionsAsync` fails to resume a session ("Session not found" from the persistent CLI server), it falls back to `CreateSessionAsync` which creates a new GUID. However:

1. `SaveActiveSessionsToDisk()` is blocked by `IsRestoring = true` during the restore loop
2. After restore completes and `IsRestoring = false`, **no flush was called**
3. `active-sessions.json` retained the stale old session ID
4. On next restart: stale ID → resume fails → creates yet another new session → loads old history

Evidence from disk:
- `f9447779` (in active-sessions.json): 517 lines, last modified Mar 13
- `e0073386` (NOT in active-sessions.json): 10,488 lines, modified Mar 15 — the real active session

## Fix

1. **Add `FlushSaveActiveSessionsToDisk()`** after `RestorePreviousSessionsAsync` in both `InitializeAsync` and `ReconnectAsync` — ensures fallback-recreated session IDs are immediately persisted
2. **Improve events.jsonl copy logic** — when the new session directory already has an events.jsonl (SDK created it), prepend the old events instead of skipping the copy

## Tests

Added 6 new tests in `SessionPersistenceTests.cs`:
- `Merge_RecreatedSessionWithNewId_OverridesOldEntry` — verifies merge doesn't resurrect stale IDs
- `Merge_RecreatedSessionNewId_OldIdNotResurrected` — verifies active entry wins
- `EventsCopy_PrependOldEventsWhenNewExists` — verifies old events prepended
- `EventsCopy_WritesOldEventsWhenNewDoesNotExist` — verifies old events written fresh
- `InitializeAsync_FlushesSessionsAfterRestore` — structural guard
- `ReconnectAsync_FlushesSessionsAfterRestore` — structural guard

All 2577 tests pass (2 pre-existing failures unrelated to this change).