### PR TITLE
Fix session history loss on restart: detect session ID mismatch and find best events source

### DIFF
--- a/PolyPilot.Tests/SessionPersistenceTests.cs
+++ b/PolyPilot.Tests/SessionPersistenceTests.cs
@@ -1383,8 +1383,8 @@ public class SessionPersistenceTests
         // Verify the session ID mismatch detection block exists
         Assert.Contains("[RESUME-REMAP] Session ID changed", serviceFile);
 
-        // Verify the AgentSessionInfo uses actualSessionId, not bare sessionId
-        Assert.Contains("SessionId = actualSessionId ?? sessionId", serviceFile);
+        // Verify sessionId is reassigned to actualSessionId before use
+        Assert.Contains("sessionId = actualSessionId;", serviceFile);
 
         // Verify CopyEventsToNewSession is called on mismatch
         Assert.Contains("CopyEventsToNewSession(sessionId, actualSessionId)", serviceFile);
@@ -1425,5 +1425,165 @@ public class SessionPersistenceTests
 
         // The fallback path should use the helper instead of inline copy
         Assert.Contains("CopyEventsToNewSession(bestSourceId, recreatedState.Info.SessionId)", persistenceFile);
+    }
+
+    // --- WorkspaceYamlMatchesCwd: exact cwd matching ---
+
+    [Fact]
+    public void FindBestEventsSource_DoesNotMatchSubstringPaths()
+    {
+        // Regression test: "/project" must NOT match "/project-2".
+        // The old yaml.Contains() approach had false positives with path substrings.
+        var tempBase = Path.Combine(Path.GetTempPath(), $"polypilot-test-{Guid.NewGuid():N}");
+        var stateDir = Path.Combine(tempBase, "session-state");
+        try
+        {
+            var originalId = Guid.NewGuid().ToString("D");
+            var decoyId = Guid.NewGuid().ToString("D");
+
+            // Original session: 2 lines, cwd = /project
+            var originalDir = Path.Combine(stateDir, originalId);
+            Directory.CreateDirectory(originalDir);
+            File.WriteAllText(Path.Combine(originalDir, "events.jsonl"),
+                """{"type":"user.message","data":{"content":"a"}}""" + "\n" +
+                """{"type":"user.message","data":{"content":"b"}}""" + "\n");
+            File.WriteAllText(Path.Combine(originalDir, "workspace.yaml"),
+                "cwd: /project\n");
+
+            // Decoy session: 100 lines, cwd = /project-2 (should NOT match /project)
+            var decoyDir = Path.Combine(stateDir, decoyId);
+            Directory.CreateDirectory(decoyDir);
+            var manyLines = string.Join("\n", Enumerable.Range(1, 100)
+                .Select(i => "{\"type\":\"user.message\",\"data\":{\"content\":\"msg" + i + "\"}}"));
+            File.WriteAllText(Path.Combine(decoyDir, "events.jsonl"), manyLines + "\n");
+            File.WriteAllText(Path.Combine(decoyDir, "workspace.yaml"),
+                "cwd: /project-2\n");
+
+            var service = CreateServiceForFindBest();
+            var result = service.FindBestEventsSource(originalId, "/project", stateDir);
+            // Must return originalId, NOT decoyId — exact cwd match required
+            Assert.Equal(originalId, result);
+        }
+        finally { try { Directory.Delete(tempBase, true); } catch { } }
+    }
+
+    [Fact]
+    public void FindBestEventsSource_HandlesEmptyEventsJsonl()
+    {
+        // Edge case: events.jsonl exists but is empty — should be treated as 0 lines.
+        var tempBase = Path.Combine(Path.GetTempPath(), $"polypilot-test-{Guid.NewGuid():N}");
+        var stateDir = Path.Combine(tempBase, "session-state");
+        try
+        {
+            var originalId = Guid.NewGuid().ToString("D");
+            var emptyId = Guid.NewGuid().ToString("D");
+            var cwd = "/Users/test/myproject";
+
+            // Original session: 5 lines
+            var originalDir = Path.Combine(stateDir, originalId);
+            Directory.CreateDirectory(originalDir);
+            var lines = string.Join("\n", Enumerable.Range(1, 5)
+                .Select(i => "{\"type\":\"user.message\",\"data\":{\"content\":\"msg" + i + "\"}}"));
+            File.WriteAllText(Path.Combine(originalDir, "events.jsonl"), lines + "\n");
+            File.WriteAllText(Path.Combine(originalDir, "workspace.yaml"), $"cwd: {cwd}\n");
+
+            // Empty session: 0 bytes in events.jsonl
+            var emptyDir = Path.Combine(stateDir, emptyId);
+            Directory.CreateDirectory(emptyDir);
+            File.WriteAllText(Path.Combine(emptyDir, "events.jsonl"), "");
+            File.WriteAllText(Path.Combine(emptyDir, "workspace.yaml"), $"cwd: {cwd}\n");
+
+            var service = CreateServiceForFindBest();
+            var result = service.FindBestEventsSource(originalId, cwd, stateDir);
+            // Original (5 lines) should still be preferred over empty (0 lines)
+            Assert.Equal(originalId, result);
+        }
+        finally { try { Directory.Delete(tempBase, true); } catch { } }
+    }
+
+    [Fact]
+    public void WorkspaceYamlMatchesCwd_ExactMatch()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "cwd: /Users/test/myproject\nbranch: main\n");
+            Assert.True(CopilotService.WorkspaceYamlMatchesCwd(tempFile, "/Users/test/myproject"));
+        }
+        finally { File.Delete(tempFile); }
+    }
+
+    [Fact]
+    public void WorkspaceYamlMatchesCwd_RejectsSubstringMatch()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "cwd: /Users/test/myproject-2\nbranch: main\n");
+            // "/Users/test/myproject" is a substring of the cwd, but NOT an exact match
+            Assert.False(CopilotService.WorkspaceYamlMatchesCwd(tempFile, "/Users/test/myproject"));
+        }
+        finally { File.Delete(tempFile); }
+    }
+
+    [Fact]
+    public void WorkspaceYamlMatchesCwd_CaseInsensitive()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "cwd: /Users/Test/MyProject\n");
+            Assert.True(CopilotService.WorkspaceYamlMatchesCwd(tempFile, "/users/test/myproject"));
+        }
+        finally { File.Delete(tempFile); }
+    }
+
+    [Fact]
+    public void WorkspaceYamlMatchesCwd_ReturnsFalse_WhenNoCwdLine()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "branch: main\nrepo: test\n");
+            Assert.False(CopilotService.WorkspaceYamlMatchesCwd(tempFile, "/some/path"));
+        }
+        finally { File.Delete(tempFile); }
+    }
+
+    [Fact]
+    public void WorkspaceYamlMatchesCwd_HandlesQuotedValue()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "cwd: \"/Users/test/my project\"\n");
+            Assert.True(CopilotService.WorkspaceYamlMatchesCwd(tempFile, "/Users/test/my project"));
+        }
+        finally { File.Delete(tempFile); }
+    }
+
+    [Fact]
+    public void FindBestEventsSource_LimitsDirectoryScan()
+    {
+        // Structural test: verify MaxSessionDirsToScan constant exists for performance bounding
+        var persistenceFile = File.ReadAllText(
+            Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.Persistence.cs"));
+
+        Assert.Contains("MaxSessionDirsToScan", persistenceFile);
+        Assert.Contains(".Take(MaxSessionDirsToScan)", persistenceFile);
+        Assert.Contains("OrderByDescending", persistenceFile);
+    }
+
+    [Fact]
+    public void CopyEventsToNewSession_CleansTempFileOnFailure()
+    {
+        // Structural test: verify temp file cleanup in catch block
+        var persistenceFile = File.ReadAllText(
+            Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.Persistence.cs"));
+
+        // Verify tmpFile is declared outside try and cleaned in catch
+        Assert.Contains("string? tmpFile = null;", persistenceFile);
+        Assert.Contains("tmpFile = null; // Move succeeded", persistenceFile);
+        Assert.Contains("File.Delete(tmpFile)", persistenceFile);
     }
 }

--- a/PolyPilot/Services/CopilotService.Persistence.cs
+++ b/PolyPilot/Services/CopilotService.Persistence.cs
@@ -839,6 +839,7 @@ public partial class CopilotService
     /// </summary>
     private void CopyEventsToNewSession(string oldSessionId, string newSessionId)
     {
+        string? tmpFile = null;
         try
         {
             var oldEvents = Path.Combine(SessionStatePath, oldSessionId, "events.jsonl");
@@ -871,13 +872,14 @@ public partial class CopilotService
             else
             {
                 var newLines = File.ReadAllLines(newEvents);
-                var tmpFile = newEvents + ".tmp";
+                tmpFile = newEvents + ".tmp";
                 using (var writer = new StreamWriter(tmpFile, append: false))
                 {
                     foreach (var line in oldLines) writer.WriteLine(line);
                     foreach (var line in newLines) writer.WriteLine(line);
                 }
                 File.Move(tmpFile, newEvents, overwrite: true);
+                tmpFile = null; // Move succeeded, no cleanup needed
             }
 
             Debug($"CopyEventsToNewSession: {oldSessionId} → {newSessionId}: {oldLines.Count} lines (prepended={existed}, skipped={skippedLines})");
@@ -885,16 +887,24 @@ public partial class CopilotService
         catch (Exception ex)
         {
             Debug($"CopyEventsToNewSession failed: {ex.Message}");
+            // Clean up temp file if File.Move failed
+            if (tmpFile != null)
+            {
+                try { File.Delete(tmpFile); } catch { }
+            }
         }
     }
 
     /// <summary>
     /// Search session-state directories for the best events.jsonl source matching a working directory.
-    /// Returns the session ID with the most event lines whose workspace.yaml cwd matches.
+    /// Returns the session ID with the most event lines whose workspace.yaml cwd matches exactly.
     /// Falls back to the original session ID if no better source is found.
     /// This handles the case where active-sessions.json has a stale session ID but
     /// intermediate fallback-recreated sessions accumulated more history.
+    /// Scans at most MaxSessionDirsToScan directories sorted by last-write-time (newest first).
     /// </summary>
+    internal const int MaxSessionDirsToScan = 200;
+
     internal string FindBestEventsSource(string originalSessionId, string? workingDirectory, string? statePath = null)
     {
         if (string.IsNullOrEmpty(workingDirectory))
@@ -917,22 +927,27 @@ public partial class CopilotService
             string bestId = originalSessionId;
             long bestLines = originalLines;
 
-            foreach (var sessionDir in stateDir.EnumerateDirectories())
+            // Sort by last-write-time descending so the most recent sessions are checked first.
+            // Limit to MaxSessionDirsToScan to bound scan time on large state directories.
+            var dirs = stateDir.EnumerateDirectories()
+                .OrderByDescending(d => d.LastWriteTimeUtc)
+                .Take(MaxSessionDirsToScan);
+
+            foreach (var sessionDir in dirs)
             {
                 if (sessionDir.Name == originalSessionId) continue;
 
                 var eventsFile = Path.Combine(sessionDir.FullName, "events.jsonl");
                 if (!File.Exists(eventsFile)) continue;
 
-                // Check if this session's working directory matches
                 var workspaceFile = Path.Combine(sessionDir.FullName, "workspace.yaml");
                 if (!File.Exists(workspaceFile)) continue;
 
                 try
                 {
-                    var yaml = File.ReadAllText(workspaceFile);
-                    // workspace.yaml contains "cwd: /path/to/dir" — simple string match
-                    if (!yaml.Contains(workingDirectory, StringComparison.OrdinalIgnoreCase))
+                    // Extract the exact cwd value from workspace.yaml line-by-line
+                    // to avoid false positives (e.g., "/project" matching "/project-2").
+                    if (!WorkspaceYamlMatchesCwd(workspaceFile, workingDirectory))
                         continue;
 
                     long lineCount = 0;
@@ -958,5 +973,23 @@ public partial class CopilotService
             Debug($"FindBestEventsSource failed: {ex.Message}");
             return originalSessionId;
         }
+    }
+
+    /// <summary>
+    /// Check whether a workspace.yaml file's cwd value matches the given working directory exactly.
+    /// Parses "cwd: /path/to/dir" lines and compares the extracted path, avoiding substring matches.
+    /// </summary>
+    internal static bool WorkspaceYamlMatchesCwd(string workspaceFile, string workingDirectory)
+    {
+        foreach (var line in File.ReadLines(workspaceFile))
+        {
+            var trimmed = line.TrimStart();
+            if (!trimmed.StartsWith("cwd:", StringComparison.OrdinalIgnoreCase))
+                continue;
+            // Extract the value after "cwd:" and trim whitespace/quotes
+            var value = trimmed.Substring(4).Trim().Trim('"', '\'');
+            return string.Equals(value, workingDirectory, StringComparison.OrdinalIgnoreCase);
+        }
+        return false;
     }
 }

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -1616,13 +1616,14 @@ public partial class CopilotService : IAsyncDisposable
         if (!string.IsNullOrEmpty(actualSessionId) && actualSessionId != sessionId)
         {
             Debug($"[RESUME-REMAP] Session ID changed: requested '{sessionId}', server returned '{actualSessionId}' for '{displayName}'");
+            // Copy old events to the new session dir BEFORE registering the event handler.
+            // The SDK may start writing events to the new dir after ResumeSessionAsync returns,
+            // but our copy runs immediately and the new dir typically has no events yet.
             CopyEventsToNewSession(sessionId, actualSessionId);
-            // Reload history from the actual session's events.jsonl if it has more content
             var actualHistory = LoadHistoryFromDisk(actualSessionId);
             if (actualHistory.Count >= history.Count)
                 history = actualHistory;
             sessionId = actualSessionId;
-            // Re-sync DB under the correct session ID
             if (history.Count > 0)
                 await _chatDb.BulkInsertAsync(sessionId, history);
         }
@@ -1634,7 +1635,7 @@ public partial class CopilotService : IAsyncDisposable
             Name = displayName,
             Model = resumeModel,
             CreatedAt = DateTime.UtcNow,
-            SessionId = actualSessionId ?? sessionId,
+            SessionId = sessionId,
             IsResumed = isStillProcessing,
             WorkingDirectory = resumeWorkingDirectory
         };
@@ -2796,7 +2797,8 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
                     try
                     {
                         newSession = await client.ResumeSessionAsync(state.Info.SessionId, reconnectConfig, cancellationToken);
-                        // Detect session ID mismatch on reconnect (same as ResumeSessionAsync)
+                        // Detect session ID mismatch on reconnect (same as ResumeSessionAsync).
+                        // Copy events before event handler registration to minimize race window.
                         var actualId = newSession.SessionId;
                         if (!string.IsNullOrEmpty(actualId) && actualId != state.Info.SessionId)
                         {


### PR DESCRIPTION
## Bug
The 'AndroidShellHandler' session loses all history on every PolyPilot restart. 181 messages show up, but they're always the same stale set from Mar 13 — work done since then is lost.

## Root Cause (follows PR #378)
PR #378 fixed the missing flush after restore, but there are two additional issues:

1. **Session ID mismatch in ResumeSessionAsync**: Line 1618 stored `sessionId` (the input) instead of `copilotSession.SessionId` (the actual ID returned by the SDK). If the persistent server returns a different session ID, events get written to the wrong directory.

2. **Stale events source in fallback path**: When `active-sessions.json` points to an old session ID (before PR #378 flush fix), the fallback always loads from that stale ID's events.jsonl (517 lines), ignoring intermediate sessions that accumulated more history (10,488+ lines).

## Fix
1. **ResumeSessionAsync**: Detect when `copilotSession.SessionId != sessionId`, copy events to the new directory, and use the actual session ID going forward.

2. **FindBestEventsSource()**: New method that scans session directories matching the working directory and picks the one with the most events. Used by the fallback restore path instead of blindly loading from the stale entry.

3. **CopyEventsToNewSession()**: Extracted from the inline copy logic into a shared helper, now used by ResumeSessionAsync, the reconnect path, and the fallback restore path.

## Tests
- 5 new functional tests for `FindBestEventsSource` (correct session found, different cwd ignored, null cwd, no workspace.yaml)
- 4 new structural regression tests ensuring session ID mismatch detection exists in resume, reconnect, and fallback paths
- All 2590 tests pass (1 pre-existing flaky test in ZeroIdleCaptureTests)
- Mac Catalyst build clean (0 errors)