### PR TITLE
Add keepalive ping to prevent server idle timeout (#396)

### DIFF
--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -530,9 +530,13 @@ public partial class CopilotService : IAsyncDisposable
 
     private void StartKeepalivePing()
     {
-        StopKeepalivePing();
         var cts = new CancellationTokenSource();
-        _keepaliveCts = cts;
+        var prev = Interlocked.Exchange(ref _keepaliveCts, cts);
+        if (prev != null)
+        {
+            try { prev.Cancel(); } catch { }
+            prev.Dispose();
+        }
         _ = RunKeepalivePingAsync(cts.Token);
     }
 
@@ -1092,6 +1096,7 @@ public partial class CopilotService : IAsyncDisposable
             Debug("[SERVER-RECOVERY] Attempting persistent server recovery (auth/connectivity failure suspected)...");
 
             // Stop the old server — it's running but broken (e.g., expired auth token cached in-process)
+            StopKeepalivePing();
             _serverManager.StopServer();
 
             // Wait for the old server to fully release the port
@@ -1125,6 +1130,7 @@ public partial class CopilotService : IAsyncDisposable
             FallbackNotice = "Persistent server was automatically restarted due to repeated failures. Your sessions should work again.";
             Interlocked.Exchange(ref _consecutiveWatchdogTimeouts, 0);
             _lastRecoveryCompletedAt = DateTime.UtcNow;
+            StartKeepalivePing();
             InvokeOnUI(() => OnStateChanged?.Invoke());
             return true;
         }
@@ -1162,6 +1168,7 @@ public partial class CopilotService : IAsyncDisposable
         {
             Debug("[SERVER-RESTART] Restarting headless server due to native module failure...");
             ServerHealthNotice = null;
+            StopKeepalivePing();
 
             // 1. Dispose all existing sessions (they hold broken connections)
             foreach (var state in _sessions.Values)
@@ -1231,6 +1238,7 @@ public partial class CopilotService : IAsyncDisposable
             await RestorePreviousSessionsAsync(cancellationToken);
             FlushSaveActiveSessionsToDisk();
             ReconcileOrganization();
+            StartKeepalivePing();
             OnStateChanged?.Invoke();
 
             Debug("[SERVER-RESTART] Server restart complete, all sessions restored");


### PR DESCRIPTION
## Problem

The headless Copilot server kills sessions after ~35 minutes of inactivity. Multi-agent workers that run long tool executions (PR reviews, code analysis) get killed mid-work, losing their results. This was observed repeatedly:

- `PR Review Squad-worker-1`: Killed after 23 min during PR review (16:15:53 `session.shutdown`)
- `PP- IC Things` workers: Multiple sessions killed overnight  
- `ci-agentic`: Server killed session at 20:13, user sent prompt at 20:14 to dead session

## Root Cause

The headless server has an idle timeout (~35 min) that kills sessions when no client messages arrive. During long tool executions, the client doesn't send any RPC messages — the SDK handles tool dispatch internally — so the server thinks the connection is idle.

## Fix

Add a background keepalive loop that calls `CopilotClient.PingAsync("keepalive")` every 15 minutes. This sends an RPC message to the server, resetting its idle timer.

```
[KEEPALIVE] Ping sent to headless server    ← every 15 min
```

**Lifecycle:**
- Starts after `InitializeAsync` and `ReconnectAsync` (non-demo, non-remote modes only)
- Stops on `ReconnectAsync` teardown and `DisposeAsync`
- Skips pings in Demo/Remote mode (no headless server)
- All exceptions caught — will not crash the app

## Safety

- Uses existing `CopilotClient.PingAsync()` SDK API — no new APIs
- Single background task with `CancellationToken` — clean shutdown
- No state mutations — only sends a ping and logs
- `[KEEPALIVE]` tag added to diagnostic log filter for traceability
- All 2716 tests pass

Closes #396