### PR TITLE
fix: add missing iOS privacy purpose strings (ITMS-90683)

### DIFF
--- a/PolyPilot/Platforms/iOS/Info.plist
+++ b/PolyPilot/Platforms/iOS/Info.plist
@@ -38,5 +38,14 @@
     <string>PolyPilot needs microphone access for speech-to-text input.</string>
     <key>UIViewControllerBasedStatusBarAppearance</key>
     <true/>
+    <!-- Required by App Store validation (ITMS-90683) — referenced by linked frameworks -->
+    <key>NSCalendarsUsageDescription</key>
+    <string>PolyPilot does not access your calendar data.</string>
+    <key>NSContactsUsageDescription</key>
+    <string>PolyPilot does not access your contacts.</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>PolyPilot does not use your location.</string>
+    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+    <string>PolyPilot does not use your location.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

App Store Connect sends ITMS-90683 warnings for PolyPilot.app because linked frameworks (likely ZXing.Net.MAUI or MAUI itself) reference APIs that require privacy purpose strings in Info.plist:

- **NSCalendarsUsageDescription** — Calendar access
- **NSContactsUsageDescription** — Contacts access  
- **NSLocationWhenInUseUsageDescription** — Location when in use
- **NSLocationAlwaysAndWhenInUseUsageDescription** — Location always

PolyPilot doesn't use any of these APIs, but Apple requires the keys because the linked binaries reference them.

## Fix

Added all 4 missing `NS*UsageDescription` keys to `Platforms/iOS/Info.plist` with explanatory strings indicating PolyPilot does not use these features.