### PR TITLE
fix: distinguish session lock vs SDK errors in resume handling

### DIFF
--- a/PolyPilot.Tests/ConnectionRecoveryTests.cs
+++ b/PolyPilot.Tests/ConnectionRecoveryTests.cs
@@ -629,7 +629,7 @@ public class ConnectionRecoveryTests
     public void ResumeSession_Structural_NeverAutoDeletesOnCorruptError()
     {
         // STRUCTURAL REGRESSION GUARD: The ResumeSession handler in SessionSidebar
-        // must NOT call DeletePersistedSession when a corrupt-session error occurs.
+        // must NOT call DeletePersistedSession when any error occurs.
         // Auto-deleting session data causes irreversible data loss.
         var source = File.ReadAllText(
             Path.Combine(GetRepoRoot(), "PolyPilot", "Components", "Layout", "SessionSidebar.razor"));
@@ -640,8 +640,11 @@ public class ConnectionRecoveryTests
         // Must NOT contain DeletePersistedSession call
         Assert.DoesNotContain("DeletePersistedSession", resumeMethod);
 
-        // Must still detect corrupt errors (for the error message)
-        Assert.Contains("IsCorruptSessionError", resumeMethod);
+        // Must check for active lock files before calling the SDK
+        Assert.Contains("FindLiveLockPid", resumeMethod);
+
+        // Must pass errors through FriendlyResumeError (not guess at causes)
+        Assert.Contains("FriendlyResumeError", resumeMethod);
     }
 
     [Fact]

--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -2073,6 +2073,22 @@ else
         resumeError = null;
         try
         {
+            // Pre-check: look for active lock files before calling the SDK.
+            // Clean up stale locks (dead PIDs) so they don't block future resumes.
+            var sessionDir = System.IO.Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".copilot", "session-state", persisted.SessionId);
+            if (Directory.Exists(sessionDir))
+            {
+                var lockPid = ExternalSessionScanner.FindLiveLockPid(sessionDir, cleanupStale: true);
+                if (lockPid.HasValue)
+                {
+                    resumeError = $"Session is locked by process {lockPid.Value} — a Copilot CLI is still connected. Close the CLI session first.";
+                    Console.WriteLine($"Resume blocked: session {persisted.SessionId} locked by PID {lockPid.Value}");
+                    return;
+                }
+            }
+
             var title = persisted.Title ?? "Untitled";
             var displayName = title.Length > 30 ? title[..27] + "..." : title;
             var sessionInfo = await CopilotService.ResumeSessionAsync(persisted.SessionId, displayName);
@@ -2082,15 +2098,8 @@ else
         catch (Exception ex)
         {
             // Never auto-delete session data — the user's conversation history is irreplaceable.
-            // Show an actionable error instead and let the user decide whether to delete.
-            if (IsCorruptSessionError(ex.Message))
-            {
-                resumeError = "Session is locked — likely in use by a Copilot CLI terminal session. Close the CLI session first, or delete the session data from ~/.copilot/session-state if it's stale.";
-            }
-            else
-            {
-                resumeError = FriendlyResumeError(ex.Message);
-            }
+            // Show the actual error — don't guess whether it's corruption, locking, etc.
+            resumeError = FriendlyResumeError(ex.Message);
             Console.WriteLine($"Error resuming session: {ex.Message}");
         }
         finally
@@ -2098,11 +2107,6 @@ else
             isCreating = false;
         }
     }
-
-    private static bool IsCorruptSessionError(string message) =>
-        message.Contains("session file is corrupted", StringComparison.OrdinalIgnoreCase) ||
-        message.Contains("session file", StringComparison.OrdinalIgnoreCase) &&
-        message.Contains("corrupt", StringComparison.OrdinalIgnoreCase);
 
     private string FriendlyResumeError(string message)
     {

--- a/PolyPilot/Services/ExternalSessionScanner.cs
+++ b/PolyPilot/Services/ExternalSessionScanner.cs
@@ -518,9 +518,55 @@ public class ExternalSessionScanner : IDisposable
     }
 
     /// <summary>
-    /// Check for any lock file with a live PID, without verifying the process name.
-    /// Used in Scan() where the lock file's existence in copilot's session-state
-    /// directory is sufficient evidence of a copilot-related process.
+    /// Check if a session directory has an active inuse.{PID}.lock file with a live
+    /// copilot-related process. Returns the PID or null. This is a static utility
+    /// usable outside the scanner (e.g., pre-resume lock checks).
+    /// Optionally cleans up stale lock files (dead process PIDs).
+    /// </summary>
+    internal static int? FindLiveLockPid(string sessionDir, IReadOnlySet<int>? excludedPids = null, bool cleanupStale = false)
+    {
+        try
+        {
+            foreach (var file in Directory.GetFiles(sessionDir, "inuse.*.lock"))
+            {
+                var fileName = Path.GetFileNameWithoutExtension(file);
+                var parts = fileName.Split('.');
+                if (parts.Length >= 2 && int.TryParse(parts[1], out var pid))
+                {
+                    if (excludedPids != null && excludedPids.Contains(pid)) continue;
+                    try
+                    {
+                        using var proc = System.Diagnostics.Process.GetProcessById(pid);
+                        if (proc.HasExited)
+                        {
+                            if (cleanupStale) try { File.Delete(file); } catch { }
+                            continue;
+                        }
+                        var name = proc.ProcessName?.ToLowerInvariant() ?? "";
+                        if (!name.Contains("copilot") && !name.Contains("node") &&
+                            !name.Contains("dotnet") && !name.Contains("github"))
+                        {
+                            if (cleanupStale) try { File.Delete(file); } catch { }
+                            continue;
+                        }
+                        return pid;
+                    }
+                    catch
+                    {
+                        // Process doesn't exist — stale lock
+                        if (cleanupStale) try { File.Delete(file); } catch { }
+                    }
+                }
+            }
+        }
+        catch { /* Directory not accessible */ }
+        return null;
+    }
+
+    /// <summary>
+    /// Check for any lock file with a live PID from a copilot-related process
+    /// (copilot/node/dotnet/github). Used in Scan() as a fallback when the
+    /// process-first discovery didn't find the session.
     /// </summary>
     private static int? FindAnyLiveLockPid(string sessionDir, IReadOnlySet<int>? excludedPids)
     {


### PR DESCRIPTION
## Problem
Resuming a closed Copilot CLI session showed **Session is locked** even when no lock files existed. The old code pattern-matched SDK error messages for session file + corrupt and then displayed a misleading locked message. We don't actually know why the SDK failed.

## Fix
- **Pre-resume lock file check**: New static FindLiveLockPid() checks inuse.*.lock files for live copilot-related processes before calling the SDK. Only says locked when there is proof (a live PID holding a lock file).
- **Stale lock cleanup**: Deletes lock files from dead processes so they don't block future resumes.
- **Remove IsCorruptSessionError**: Stop guessing at SDK error causes. All SDK errors now pass through FriendlyResumeError which shows the actual message.
- **Fix misleading doc comment**: FindAnyLiveLockPid claimed without verifying the process name but the code does verify against copilot/node/dotnet/github.

## Files Changed
- PolyPilot/Components/Layout/SessionSidebar.razor - Pre-resume lock check, removed error guessing
- PolyPilot/Services/ExternalSessionScanner.cs - New FindLiveLockPid static method, fixed doc comment
- PolyPilot.Tests/ConnectionRecoveryTests.cs - Updated structural regression test

## Multi-model review
Reviewed by Claude Sonnet, Claude Opus 4.5, GPT-5.1, and Gemini 3 Pro. Cross-reviewed findings between models.
