### PR TITLE
fix: cleared input fields re-fill with stale draft text on re-render

### DIFF
--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -1102,7 +1102,7 @@
                         var result = {};
                         var active = document.activeElement;
                         document.querySelectorAll('.card-input input, .card-input textarea, .expanded-card .input-area textarea').forEach(function(el) {
-                            if (el.id && el.value) result[el.id] = el.value;
+                            if (el.id) result[el.id] = el.value || '';
                         });
                         if (active && active.id) result['__focused'] = active.id;
                         if (active) { result['__selStart'] = active.selectionStart || 0; result['__selEnd'] = active.selectionEnd || 0; }
@@ -1120,6 +1120,8 @@
                             var sessionName = id.Replace("input-", "").Replace("-", " ");
                             if (!string.IsNullOrEmpty(val))
                                 draftBySession[sessionName] = val;
+                            else
+                                draftBySession.Remove(sessionName);
                         }
                         if (saved.TryGetValue("__focused", out var fid))
                             _focusedInputId = fid;


### PR DESCRIPTION
## Problem

When a user clears text from a chat input field (backspace/select-all-delete), the old text immediately reappears on the next Blazor render cycle. Typing new text also gets overwritten by the stale draft.

## Root Cause

The draft capture JS (line 1096) only saved inputs with **truthy** values:
```js
if (el.id && el.value) result[el.id] = el.value;
```

When the user cleared an input, `el.value` was `""` (falsy), so the empty value was **never captured**. But `draftBySession` in C# still held the old text from a previous capture. On the next render, `restoreDraftsAndFocus` re-applied it.

## Fix

1. **JS**: Always capture input values, even empty strings
2. **C#**: Remove the session from `draftBySession` when captured value is empty

Two lines changed.