### PR TITLE
fix: Windows worktree creation falls back gracefully instead of using temp dirs

### DIFF
--- a/PolyPilot.Tests/RepoManagerTests.cs
+++ b/PolyPilot.Tests/RepoManagerTests.cs
@@ -6,6 +6,15 @@ namespace PolyPilot.Tests;
 [Collection("BaseDir")]
 public class RepoManagerTests
 {
+    /// <summary>
+    /// Create the minimal files a bare git repo needs so IsValidBareRepository returns true.
+    /// </summary>
+    private static void CreateFakeBareRepoSkeleton(string bareDir)
+    {
+        Directory.CreateDirectory(bareDir);
+        Directory.CreateDirectory(Path.Combine(bareDir, "refs"));
+        File.WriteAllText(Path.Combine(bareDir, "HEAD"), "ref: refs/heads/main\n");
+    }
     [Theory]
     [InlineData("https://github.com/Owner/Repo.git", "Owner-Repo")]
     [InlineData("https://github.com/Owner/Repo", "Owner-Repo")]
@@ -365,7 +374,7 @@ public class RepoManagerTests
         {
             // Create a fake bare clone directory with a git config
             var bareDir = Path.Combine(reposDir, "Owner-Repo.git");
-            Directory.CreateDirectory(bareDir);
+            CreateFakeBareRepoSkeleton(bareDir);
             File.WriteAllText(Path.Combine(bareDir, "config"),
                 "[remote \"origin\"]\n\turl = https://github.com/Owner/Repo\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n");
 
@@ -458,7 +467,7 @@ public class RepoManagerTests
             foreach (var name in new[] { "dotnet-maui.git", "PureWeen-PolyPilot.git", "github-sdk.git" })
             {
                 var dir = Path.Combine(reposDir, name);
-                Directory.CreateDirectory(dir);
+                CreateFakeBareRepoSkeleton(dir);
                 File.WriteAllText(Path.Combine(dir, "config"),
                     $"[remote \"origin\"]\n\turl = https://github.com/test/{name.Replace(".git", "")}\n");
             }
@@ -501,7 +510,7 @@ public class RepoManagerTests
         {
             // Create a bare clone on disk
             var bareDir = Path.Combine(reposDir, "Owner-Repo.git");
-            Directory.CreateDirectory(bareDir);
+            CreateFakeBareRepoSkeleton(bareDir);
             File.WriteAllText(Path.Combine(bareDir, "config"),
                 "[remote \"origin\"]\n\turl = https://github.com/Owner/Repo\n");
 

--- a/PolyPilot.Tests/RepoManagerTests.cs
+++ b/PolyPilot.Tests/RepoManagerTests.cs
@@ -15,6 +15,7 @@ public class RepoManagerTests
         Directory.CreateDirectory(Path.Combine(bareDir, "refs"));
         File.WriteAllText(Path.Combine(bareDir, "HEAD"), "ref: refs/heads/main\n");
     }
+
     [Theory]
     [InlineData("https://github.com/Owner/Repo.git", "Owner-Repo")]
     [InlineData("https://github.com/Owner/Repo", "Owner-Repo")]

--- a/PolyPilot.Tests/WorktreeStrategyTests.cs
+++ b/PolyPilot.Tests/WorktreeStrategyTests.cs
@@ -769,4 +769,149 @@ public class WorktreeStrategyTests
     }
 
     #endregion
+
+    #region Worktree Failure Fallback (Windows long-path / git failure scenarios)
+
+    [Fact]
+    public async Task GroupShared_WorktreeFailure_FallsBackToExistingWorktree()
+    {
+        // Simulate scenario: worktree creation fails (e.g., Windows long-path issue)
+        // but an existing worktree for the repo exists — should use it instead of temp dir.
+        var existingWt = new WorktreeInfo
+        {
+            Id = "existing-wt",
+            RepoId = "repo-1",
+            Branch = "main",
+            Path = "/existing/worktree/path"
+        };
+        var rm = new FailingRepoManagerWithExistingWorktree(
+            new() { new() { Id = "repo-1", Name = "Repo" } },
+            new() { existingWt });
+        var svc = CreateDemoService(rm);
+        var preset = MakePreset(2, WorktreeStrategy.GroupShared);
+
+        var group = await svc.CreateGroupFromPresetAsync(preset,
+            workingDirectory: null,
+            repoId: "repo-1");
+
+        Assert.NotNull(group);
+        // Should have fallen back to the existing worktree
+        Assert.Equal("existing-wt", group!.WorktreeId);
+
+        // Sessions should use the existing worktree path, not a temp dir
+        var organized = svc.GetOrganizedSessions();
+        var groupSessions = organized.FirstOrDefault(g => g.Group.Id == group!.Id).Sessions;
+        Assert.NotNull(groupSessions);
+        Assert.All(groupSessions, s =>
+        {
+            Assert.NotNull(s.WorkingDirectory);
+            Assert.Equal("/existing/worktree/path", s.WorkingDirectory);
+        });
+    }
+
+    [Fact]
+    public async Task GroupShared_WorktreeFailure_WithWorkingDirectory_UsesWorkingDirectory()
+    {
+        // When worktree creation fails but a workingDirectory was provided,
+        // sessions should use the workingDirectory (not temp)
+        var rm = new FailingRepoManager(new() { new() { Id = "repo-1", Name = "Repo" } });
+        var svc = CreateDemoService(rm);
+        var preset = MakePreset(2, WorktreeStrategy.GroupShared);
+
+        var group = await svc.CreateGroupFromPresetAsync(preset,
+            workingDirectory: "/provided/fallback",
+            repoId: "repo-1");
+
+        Assert.NotNull(group);
+
+        // orchWorkDir should still be /provided/fallback since worktree failed
+        var organized = svc.GetOrganizedSessions();
+        var groupSessions = organized.FirstOrDefault(g => g.Group.Id == group!.Id).Sessions;
+        Assert.NotNull(groupSessions);
+        Assert.All(groupSessions, s =>
+        {
+            Assert.NotNull(s.WorkingDirectory);
+            Assert.Equal("/provided/fallback", s.WorkingDirectory);
+        });
+    }
+
+    [Fact]
+    public async Task FullyIsolated_WorktreeFailure_FallsBackToExistingWorktree()
+    {
+        var existingWt = new WorktreeInfo
+        {
+            Id = "existing-wt",
+            RepoId = "repo-1",
+            Branch = "main",
+            Path = "/existing/worktree/path"
+        };
+        var rm = new FailingRepoManagerWithExistingWorktree(
+            new() { new() { Id = "repo-1", Name = "Repo" } },
+            new() { existingWt });
+        var svc = CreateDemoService(rm);
+        var preset = MakePreset(2, WorktreeStrategy.FullyIsolated);
+
+        var group = await svc.CreateGroupFromPresetAsync(preset,
+            workingDirectory: null,
+            repoId: "repo-1");
+
+        Assert.NotNull(group);
+        // Orchestrator should have fallen back to existing worktree
+        Assert.Equal("existing-wt", group!.WorktreeId);
+
+        // Sessions should still be created
+        var members = svc.Organization.Sessions
+            .Where(s => s.GroupId == group!.Id)
+            .ToList();
+        Assert.Equal(3, members.Count); // 1 orch + 2 workers
+    }
+
+    [Fact]
+    public async Task GroupShared_BranchName_UsesSharedPrefix()
+    {
+        // GroupShared should create a worktree with "-shared-" in the branch name,
+        // not "-orchestrator-" — this is the explicit handling fix.
+        var rm = new FakeRepoManager(new() { new() { Id = "repo-1", Name = "Repo" } });
+        var svc = CreateDemoService(rm);
+        var preset = MakePreset(2, WorktreeStrategy.GroupShared);
+
+        await svc.CreateGroupFromPresetAsync(preset,
+            workingDirectory: null,
+            repoId: "repo-1",
+            nameOverride: "MyTeam");
+
+        Assert.Single(rm.CreateCalls);
+        Assert.Contains("shared", rm.CreateCalls[0].BranchName);
+        Assert.DoesNotContain("orchestrator", rm.CreateCalls[0].BranchName);
+    }
+
+    /// <summary>
+    /// A FailingRepoManager that also has existing worktrees in its state,
+    /// so the fallback logic can find them.
+    /// </summary>
+    private class FailingRepoManagerWithExistingWorktree : RepoManager
+    {
+        public FailingRepoManagerWithExistingWorktree(List<RepositoryInfo> repos, List<WorktreeInfo> worktrees)
+        {
+            var stateField = typeof(RepoManager).GetField("_state",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var loadedField = typeof(RepoManager).GetField("_loaded",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            stateField.SetValue(this, new RepositoryState { Repositories = repos, Worktrees = worktrees });
+            loadedField.SetValue(this, true);
+        }
+
+        public override Task<WorktreeInfo> CreateWorktreeAsync(string repoId, string branchName,
+            string? baseBranch = null, bool skipFetch = false, CancellationToken ct = default)
+        {
+            throw new InvalidOperationException("Simulated Windows long-path failure");
+        }
+
+        public override Task FetchAsync(string repoId, CancellationToken ct = default)
+        {
+            return Task.CompletedTask; // Fetch succeeds, only worktree creation fails
+        }
+    }
+
+    #endregion
 }

--- a/PolyPilot.Tests/WorktreeStrategyTests.cs
+++ b/PolyPilot.Tests/WorktreeStrategyTests.cs
@@ -777,36 +777,45 @@ public class WorktreeStrategyTests
     {
         // Simulate scenario: worktree creation fails (e.g., Windows long-path issue)
         // but an existing worktree for the repo exists — should use it instead of temp dir.
-        var existingWt = new WorktreeInfo
+        var wtDir = Path.Combine(Path.GetTempPath(), $"wt-fallback-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(wtDir);
+        try
         {
-            Id = "existing-wt",
-            RepoId = "repo-1",
-            Branch = "main",
-            Path = "/existing/worktree/path"
-        };
-        var rm = new FailingRepoManagerWithExistingWorktree(
-            new() { new() { Id = "repo-1", Name = "Repo" } },
-            new() { existingWt });
-        var svc = CreateDemoService(rm);
-        var preset = MakePreset(2, WorktreeStrategy.GroupShared);
+            var existingWt = new WorktreeInfo
+            {
+                Id = "existing-wt",
+                RepoId = "repo-1",
+                Branch = "main",
+                Path = wtDir
+            };
+            var rm = new FailingRepoManagerWithExistingWorktree(
+                new() { new() { Id = "repo-1", Name = "Repo" } },
+                new() { existingWt });
+            var svc = CreateDemoService(rm);
+            var preset = MakePreset(2, WorktreeStrategy.GroupShared);
 
-        var group = await svc.CreateGroupFromPresetAsync(preset,
-            workingDirectory: null,
-            repoId: "repo-1");
+            var group = await svc.CreateGroupFromPresetAsync(preset,
+                workingDirectory: null,
+                repoId: "repo-1");
 
-        Assert.NotNull(group);
-        // Should have fallen back to the existing worktree
-        Assert.Equal("existing-wt", group!.WorktreeId);
+            Assert.NotNull(group);
+            // Borrowed worktree should NOT set group.WorktreeId (prevents DeleteGroup from destroying it)
+            Assert.Null(group!.WorktreeId);
 
-        // Sessions should use the existing worktree path, not a temp dir
-        var organized = svc.GetOrganizedSessions();
-        var groupSessions = organized.FirstOrDefault(g => g.Group.Id == group!.Id).Sessions;
-        Assert.NotNull(groupSessions);
-        Assert.All(groupSessions, s =>
+            // Sessions should use the existing worktree path, not a temp dir
+            var organized = svc.GetOrganizedSessions();
+            var groupSessions = organized.FirstOrDefault(g => g.Group.Id == group!.Id).Sessions;
+            Assert.NotNull(groupSessions);
+            Assert.All(groupSessions, s =>
+            {
+                Assert.NotNull(s.WorkingDirectory);
+                Assert.Equal(wtDir, s.WorkingDirectory);
+            });
+        }
+        finally
         {
-            Assert.NotNull(s.WorkingDirectory);
-            Assert.Equal("/existing/worktree/path", s.WorkingDirectory);
-        });
+            try { Directory.Delete(wtDir, true); } catch { }
+        }
     }
 
     [Fact]
@@ -838,32 +847,51 @@ public class WorktreeStrategyTests
     [Fact]
     public async Task FullyIsolated_WorktreeFailure_FallsBackToExistingWorktree()
     {
-        var existingWt = new WorktreeInfo
+        var wtDir = Path.Combine(Path.GetTempPath(), $"wt-fallback-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(wtDir);
+        try
         {
-            Id = "existing-wt",
-            RepoId = "repo-1",
-            Branch = "main",
-            Path = "/existing/worktree/path"
-        };
-        var rm = new FailingRepoManagerWithExistingWorktree(
-            new() { new() { Id = "repo-1", Name = "Repo" } },
-            new() { existingWt });
-        var svc = CreateDemoService(rm);
-        var preset = MakePreset(2, WorktreeStrategy.FullyIsolated);
+            var existingWt = new WorktreeInfo
+            {
+                Id = "existing-wt",
+                RepoId = "repo-1",
+                Branch = "main",
+                Path = wtDir
+            };
+            var rm = new FailingRepoManagerWithExistingWorktree(
+                new() { new() { Id = "repo-1", Name = "Repo" } },
+                new() { existingWt });
+            var svc = CreateDemoService(rm);
+            var preset = MakePreset(2, WorktreeStrategy.FullyIsolated);
 
-        var group = await svc.CreateGroupFromPresetAsync(preset,
-            workingDirectory: null,
-            repoId: "repo-1");
+            var group = await svc.CreateGroupFromPresetAsync(preset,
+                workingDirectory: null,
+                repoId: "repo-1");
 
-        Assert.NotNull(group);
-        // Orchestrator should have fallen back to existing worktree
-        Assert.Equal("existing-wt", group!.WorktreeId);
+            Assert.NotNull(group);
+            // Borrowed worktree should NOT set group.WorktreeId (prevents DeleteGroup from destroying it)
+            Assert.Null(group!.WorktreeId);
 
-        // Sessions should still be created
-        var members = svc.Organization.Sessions
-            .Where(s => s.GroupId == group!.Id)
-            .ToList();
-        Assert.Equal(3, members.Count); // 1 orch + 2 workers
+            // Sessions should still be created
+            var members = svc.Organization.Sessions
+                .Where(s => s.GroupId == group!.Id)
+                .ToList();
+            Assert.Equal(3, members.Count); // 1 orch + 2 workers
+
+            // All sessions should use the existing worktree path, not a temp dir
+            var organized = svc.GetOrganizedSessions();
+            var groupSessions = organized.FirstOrDefault(g => g.Group.Id == group!.Id).Sessions;
+            Assert.NotNull(groupSessions);
+            Assert.All(groupSessions, s =>
+            {
+                Assert.NotNull(s.WorkingDirectory);
+                Assert.Equal(wtDir, s.WorkingDirectory);
+            });
+        }
+        finally
+        {
+            try { Directory.Delete(wtDir, true); } catch { }
+        }
     }
 
     [Fact]

--- a/PolyPilot.Tests/WorktreeStrategyTests.cs
+++ b/PolyPilot.Tests/WorktreeStrategyTests.cs
@@ -802,6 +802,13 @@ public class WorktreeStrategyTests
             // Borrowed worktree should NOT set group.WorktreeId (prevents DeleteGroup from destroying it)
             Assert.Null(group!.WorktreeId);
 
+            // Session metadata WorktreeId must also be null — DeleteGroup collects from
+            // session metadata too, so borrowed IDs must not leak there.
+            var allMetas = svc.Organization.Sessions
+                .Where(s => s.GroupId == group!.Id)
+                .ToList();
+            Assert.All(allMetas, m => Assert.Null(m.WorktreeId));
+
             // Sessions should use the existing worktree path, not a temp dir
             var organized = svc.GetOrganizedSessions();
             var groupSessions = organized.FirstOrDefault(g => g.Group.Id == group!.Id).Sessions;
@@ -871,6 +878,11 @@ public class WorktreeStrategyTests
             Assert.NotNull(group);
             // Borrowed worktree should NOT set group.WorktreeId (prevents DeleteGroup from destroying it)
             Assert.Null(group!.WorktreeId);
+
+            // Session metadata WorktreeId must also be null — DeleteGroup collects from
+            // session metadata too, so borrowed IDs must not leak there.
+            Assert.All(svc.Organization.Sessions.Where(s => s.GroupId == group!.Id),
+                m => Assert.Null(m.WorktreeId));
 
             // Sessions should still be created
             var members = svc.Organization.Sessions

--- a/PolyPilot/Services/CopilotService.Organization.cs
+++ b/PolyPilot/Services/CopilotService.Organization.cs
@@ -3622,14 +3622,15 @@ public partial class CopilotService
         var orchWorkDir = workingDirectory;
         var orchWtId = worktreeId;
 
-        // Pre-fetch once to avoid parallel git lock contention (local mode only; server handles fetch in remote)
-        if (repoId != null && strategy != WorktreeStrategy.Shared && !IsRemoteMode)
+        // Pre-fetch once to avoid parallel git lock contention (local mode only; server handles fetch in remote).
+        // Shared and GroupShared fetch inside their own block below.
+        if (repoId != null && strategy != WorktreeStrategy.Shared && strategy != WorktreeStrategy.GroupShared && !IsRemoteMode)
         {
             try { await _repoManager.FetchAsync(repoId, ct); }
             catch (Exception ex) { Debug($"Pre-fetch failed (continuing): {ex.Message}"); }
         }
 
-        // For Shared strategy with a repo but no worktree, create a single shared worktree
+        // For Shared strategy with a repo but no worktree/dir, create a single shared worktree
         if (repoId != null && strategy == WorktreeStrategy.Shared && string.IsNullOrEmpty(worktreeId) && string.IsNullOrEmpty(workingDirectory))
         {
             try
@@ -3643,11 +3644,45 @@ public partial class CopilotService
             }
             catch (Exception ex)
             {
-                Debug($"Failed to create shared worktree (sessions will use temp dirs): {ex.Message}");
+                Debug($"[WorktreeStrategy] Failed to create shared worktree for strategy={strategy}, repoId={repoId}: {ex.GetType().Name}: {ex.Message}");
+                orchWorkDir = TryGetExistingWorktreePath(repoId, ref orchWtId, group);
+                if (orchWorkDir != null)
+                    Debug($"[WorktreeStrategy] Using existing worktree as fallback: {orchWorkDir}");
+                else
+                    Debug($"[WorktreeStrategy] No existing worktree found — sessions will use temp dirs");
             }
         }
 
-        if (repoId != null && strategy != WorktreeStrategy.Shared && string.IsNullOrEmpty(worktreeId))
+        // GroupShared: always create one shared worktree for the group (even if workingDirectory is set,
+        // because the group needs its own branch). Uses same naming as Shared.
+        if (repoId != null && strategy == WorktreeStrategy.GroupShared && string.IsNullOrEmpty(worktreeId))
+        {
+            try
+            {
+                if (!IsRemoteMode) await _repoManager.FetchAsync(repoId, ct);
+                var sharedWt = await CreateWorktreeLocalOrRemoteAsync(repoId, $"{branchPrefix}-shared-{Guid.NewGuid().ToString()[..4]}", ct);
+                orchWorkDir = sharedWt.Path;
+                orchWtId = sharedWt.Id;
+                group.WorktreeId = orchWtId;
+                group.CreatedWorktreeIds.Add(orchWtId);
+            }
+            catch (Exception ex)
+            {
+                Debug($"[WorktreeStrategy] Failed to create shared worktree for strategy={strategy}, repoId={repoId}: {ex.GetType().Name}: {ex.Message}");
+                // Try to fall back to an existing worktree for this repo instead of temp dir
+                if (orchWorkDir == null)
+                {
+                    orchWorkDir = TryGetExistingWorktreePath(repoId, ref orchWtId, group);
+                    if (orchWorkDir != null)
+                        Debug($"[WorktreeStrategy] Using existing worktree as fallback: {orchWorkDir}");
+                    else
+                        Debug($"[WorktreeStrategy] No existing worktree found — sessions will use temp dirs");
+                }
+            }
+        }
+
+        // OrchestratorIsolated / FullyIsolated: create a dedicated orchestrator worktree
+        if (repoId != null && strategy != WorktreeStrategy.Shared && strategy != WorktreeStrategy.GroupShared && string.IsNullOrEmpty(worktreeId))
         {
             try
             {
@@ -3659,7 +3694,15 @@ public partial class CopilotService
             }
             catch (Exception ex)
             {
-                Debug($"Failed to create orchestrator worktree (falling back to shared): {ex.Message}");
+                Debug($"[WorktreeStrategy] Failed to create orchestrator worktree for strategy={strategy}, repoId={repoId}: {ex.GetType().Name}: {ex.Message}");
+                if (orchWorkDir == null)
+                {
+                    orchWorkDir = TryGetExistingWorktreePath(repoId, ref orchWtId, group);
+                    if (orchWorkDir != null)
+                        Debug($"[WorktreeStrategy] Using existing worktree as fallback: {orchWorkDir}");
+                    else
+                        Debug($"[WorktreeStrategy] No existing worktree found — sessions will use temp dirs");
+                }
             }
         }
 
@@ -3679,7 +3722,7 @@ public partial class CopilotService
                 }
                 catch (Exception ex)
                 {
-                    Debug($"Failed to create worker-{i + 1} worktree (falling back to shared): {ex.Message}");
+                    Debug($"[WorktreeStrategy] Failed to create worker-{i + 1} worktree: {ex.GetType().Name}: {ex.Message}");
                 }
             }
         }
@@ -3697,7 +3740,7 @@ public partial class CopilotService
             }
             catch (Exception ex)
             {
-                Debug($"Failed to create shared worker worktree (falling back to shared): {ex.Message}");
+                Debug($"[WorktreeStrategy] Failed to create shared worker worktree: {ex.GetType().Name}: {ex.Message}");
             }
         }
 
@@ -4679,6 +4722,19 @@ public partial class CopilotService
             var wt = await _repoManager.CreateWorktreeAsync(repoId, branchName, skipFetch: true, ct: ct);
             return (wt.Id, wt.Path);
         }
+    }
+
+    /// <summary>
+    /// When worktree creation fails (e.g., long paths on Windows), try to find an existing
+    /// worktree for the repo so sessions get a real working directory instead of a temp dir.
+    /// </summary>
+    private string? TryGetExistingWorktreePath(string repoId, ref string? worktreeId, SessionGroup group)
+    {
+        var existing = _repoManager.Worktrees.FirstOrDefault(w => w.RepoId == repoId);
+        if (existing == null) return null;
+        worktreeId = existing.Id;
+        group.WorktreeId = existing.Id;
+        return existing.Path;
     }
 
     #endregion

--- a/PolyPilot/Services/CopilotService.Organization.cs
+++ b/PolyPilot/Services/CopilotService.Organization.cs
@@ -3723,6 +3723,7 @@ public partial class CopilotService
                 catch (Exception ex)
                 {
                     Debug($"[WorktreeStrategy] Failed to create worker-{i + 1} worktree: {ex.GetType().Name}: {ex.Message}");
+                    Debug($"[WorktreeStrategy] Worker-{i + 1} will fall back to orchestrator dir: {orchWorkDir}");
                 }
             }
         }
@@ -4727,13 +4728,16 @@ public partial class CopilotService
     /// <summary>
     /// When worktree creation fails (e.g., long paths on Windows), try to find an existing
     /// worktree for the repo so sessions get a real working directory instead of a temp dir.
+    /// Does NOT set group.WorktreeId — the worktree is borrowed, not owned. This prevents
+    /// DeleteGroup from destroying a worktree that belongs to another group.
     /// </summary>
     private string? TryGetExistingWorktreePath(string repoId, ref string? worktreeId, SessionGroup group)
     {
-        var existing = _repoManager.Worktrees.FirstOrDefault(w => w.RepoId == repoId);
+        var existing = _repoManager.Worktrees.FirstOrDefault(w => w.RepoId == repoId && Directory.Exists(w.Path));
         if (existing == null) return null;
         worktreeId = existing.Id;
-        group.WorktreeId = existing.Id;
+        // Intentionally not setting group.WorktreeId or CreatedWorktreeIds —
+        // this is a borrowed worktree. DeleteGroup only cleans up owned worktrees.
         return existing.Path;
     }
 

--- a/PolyPilot/Services/CopilotService.Organization.cs
+++ b/PolyPilot/Services/CopilotService.Organization.cs
@@ -3645,7 +3645,7 @@ public partial class CopilotService
             catch (Exception ex)
             {
                 Debug($"[WorktreeStrategy] Failed to create shared worktree for strategy={strategy}, repoId={repoId}: {ex.GetType().Name}: {ex.Message}");
-                orchWorkDir = TryGetExistingWorktreePath(repoId, ref orchWtId, group);
+                orchWorkDir = TryGetExistingWorktreePath(repoId);
                 if (orchWorkDir != null)
                     Debug($"[WorktreeStrategy] Using existing worktree as fallback: {orchWorkDir}");
                 else
@@ -3672,7 +3672,7 @@ public partial class CopilotService
                 // Try to fall back to an existing worktree for this repo instead of temp dir
                 if (orchWorkDir == null)
                 {
-                    orchWorkDir = TryGetExistingWorktreePath(repoId, ref orchWtId, group);
+                    orchWorkDir = TryGetExistingWorktreePath(repoId);
                     if (orchWorkDir != null)
                         Debug($"[WorktreeStrategy] Using existing worktree as fallback: {orchWorkDir}");
                     else
@@ -3697,7 +3697,7 @@ public partial class CopilotService
                 Debug($"[WorktreeStrategy] Failed to create orchestrator worktree for strategy={strategy}, repoId={repoId}: {ex.GetType().Name}: {ex.Message}");
                 if (orchWorkDir == null)
                 {
-                    orchWorkDir = TryGetExistingWorktreePath(repoId, ref orchWtId, group);
+                    orchWorkDir = TryGetExistingWorktreePath(repoId);
                     if (orchWorkDir != null)
                         Debug($"[WorktreeStrategy] Using existing worktree as fallback: {orchWorkDir}");
                     else
@@ -4728,17 +4728,14 @@ public partial class CopilotService
     /// <summary>
     /// When worktree creation fails (e.g., long paths on Windows), try to find an existing
     /// worktree for the repo so sessions get a real working directory instead of a temp dir.
-    /// Does NOT set group.WorktreeId — the worktree is borrowed, not owned. This prevents
-    /// DeleteGroup from destroying a worktree that belongs to another group.
+    /// Returns only the path — does NOT propagate the worktree ID. This prevents the borrowed
+    /// ID from leaking into session metadata, which would cause DeleteGroup to destroy a
+    /// worktree that belongs to another group (DeleteGroup collects IDs from session metadata).
     /// </summary>
-    private string? TryGetExistingWorktreePath(string repoId, ref string? worktreeId, SessionGroup group)
+    private string? TryGetExistingWorktreePath(string repoId)
     {
         var existing = _repoManager.Worktrees.FirstOrDefault(w => w.RepoId == repoId && Directory.Exists(w.Path));
-        if (existing == null) return null;
-        worktreeId = existing.Id;
-        // Intentionally not setting group.WorktreeId or CreatedWorktreeIds —
-        // this is a borrowed worktree. DeleteGroup only cleans up owned worktrees.
-        return existing.Path;
+        return existing?.Path;
     }
 
     #endregion


### PR DESCRIPTION
## Problem
On Windows, "Implement & Challenge" multi-agent groups end up with sessions pointing to temp directories instead of proper git worktrees. This works fine on Mac.

## Root Cause
CreateGroupFromPresetAsync has try/catch blocks around worktree creation that silently swallow exceptions (only Debug log). When worktree creation fails on Windows (long paths, file locking), orchWorkDir stays null, CreateSessionAsync gets null workingDirectory, and creates a temp dir.

Additionally, GroupShared strategy was falling into the wrong code path, creating -orchestrator- branches instead of -shared- branches.

## Fix
1. **RepoManager.cs**: Set core.longpaths on new worktrees for Windows
2. **CopilotService.Organization.cs**: 
   - Handle GroupShared strategy explicitly with -shared- branch naming
   - Fall back to existing worktree (TryGetExistingWorktreePath) when creation fails
   - Better error logging with exception type
3. **WorktreeStrategyTests.cs**: 4 new regression tests for fallback behavior

## Testing
- All 38 WorktreeStrategy tests pass (including 4 new ones)
- Tests cover: GroupShared failure fallback, fallback with existing workingDirectory, FullyIsolated failure fallback, and shared branch naming
