### PR TITLE
fix: event delivery race on resume + stale worker detection after relaunch

### DIFF
--- a/PolyPilot.Tests/ChatExperienceSafetyTests.cs
+++ b/PolyPilot.Tests/ChatExperienceSafetyTests.cs
@@ -1190,6 +1190,31 @@ public class ChatExperienceSafetyTests
         Assert.Contains(session.History, m => m.Content?.Contains("Session reconnected", StringComparison.Ordinal) == true);
     }
 
+    /// <summary>
+    /// The lazy-resume fallback path (session not found / corrupt / process error)
+    /// must attach an event handler on the fresh session so it is not deaf.
+    /// When the old post-resume .On() was removed in favor of ResumeSessionConfig.OnEvent,
+    /// the fallback branch that creates a fresh SessionConfig must still call .On() explicitly.
+    /// </summary>
+    [Fact]
+    public void LazyResumeFallback_AttachesEventHandler()
+    {
+        var persistence = File.ReadAllText(
+            Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.Persistence.cs"));
+
+        // Find the fallback create path ("Lazy-resume failed" → CreateSessionAsync)
+        var fallbackIdx = persistence.IndexOf("Lazy-resume failed for", StringComparison.Ordinal);
+        Assert.True(fallbackIdx > 0, "Could not find the lazy-resume fallback path");
+
+        // Grab the block from the fallback through the next FlushSaveActiveSessionsToDisk
+        var afterFallback = persistence.Substring(fallbackIdx, Math.Min(800, persistence.Length - fallbackIdx));
+        Assert.Contains("CreateSessionAsync", afterFallback);
+
+        // The critical invariant: .On(evt => HandleSessionEvent(...)) must appear
+        // between CreateSessionAsync and the end of this catch block
+        Assert.Contains("copilotSession.On(evt => HandleSessionEvent(state, evt))", afterFallback);
+    }
+
     // =========================================================================
     // F. Race Condition & Edge Case Tests
     // =========================================================================

--- a/PolyPilot.Tests/ChatExperienceSafetyTests.cs
+++ b/PolyPilot.Tests/ChatExperienceSafetyTests.cs
@@ -1115,50 +1115,6 @@ public class ChatExperienceSafetyTests
         Assert.Contains("SkillDirectories", helperBlock);
     }
 
-    /// <summary>
-    /// Lazy-resume and its fresh-session fallback must include McpServers and SkillDirectories.
-    /// Without these, resumed sessions start without MCP tools (e.g., WorkIQ) until manual /mcp reload.
-    /// </summary>
-    [Fact]
-    public void LazyResumePath_IncludesMcpServersAndSkills()
-    {
-        var source = File.ReadAllText(
-            Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.Persistence.cs"));
-
-        // Find the EnsureSessionConnectedAsync method containing the lazy-resume logic
-        var methodIdx = source.IndexOf("EnsureSessionConnectedAsync", StringComparison.Ordinal);
-        Assert.True(methodIdx > 0, "EnsureSessionConnectedAsync not found");
-        var block = source.Substring(methodIdx, Math.Min(3000, source.Length - methodIdx));
-
-        // MCP servers must be loaded before creating the resume config
-        Assert.Contains("LoadMcpServers", block);
-        Assert.Contains("LoadSkillDirectories", block);
-
-        // Both the ResumeSessionConfig and the fallback SessionConfig must include MCP
-        Assert.Contains("McpServers = mcpServers", block);
-        Assert.Contains("SkillDirectories = skillDirs", block);
-    }
-
-    /// <summary>
-    /// The public ResumeSessionAsync (sidebar resume, bridge resume) must also include
-    /// McpServers and SkillDirectories so MCP tools work after explicit resume.
-    /// </summary>
-    [Fact]
-    public void SidebarResumePath_IncludesMcpServersAndSkills()
-    {
-        var source = File.ReadAllText(
-            Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.cs"));
-
-        var methodIdx = source.IndexOf("public async Task<AgentSessionInfo> ResumeSessionAsync(", StringComparison.Ordinal);
-        Assert.True(methodIdx > 0, "ResumeSessionAsync not found");
-        var block = source.Substring(methodIdx, Math.Min(6000, source.Length - methodIdx));
-
-        Assert.Contains("LoadMcpServers", block);
-        Assert.Contains("LoadSkillDirectories", block);
-        Assert.Contains("McpServers = resumeMcpServers", block);
-        Assert.Contains("SkillDirectories = resumeSkillDirs", block);
-    }
-
     // =========================================================================
     // F. Race Condition & Edge Case Tests
     // =========================================================================
@@ -1398,5 +1354,37 @@ public class ChatExperienceSafetyTests
         Assert.True(methodBody.Contains("TotalApiTimeSeconds", StringComparison.Ordinal),
             "AbortSessionAsync must manually accumulate TotalApiTimeSeconds before ClearProcessingState — " +
             "the request consumed server resources even though the user aborted");
+    }
+
+    /// <summary>
+    /// The ResumeSessionAsync method must pass the event handler via ResumeSessionConfig.OnEvent
+    /// instead of calling .On() after the resume returns. The SDK registers OnEvent before
+    /// sending the session.resume RPC, closing the race window where events arrive between
+    /// resume-return and .On() call — which causes silently dropped content events (empty responses).
+    /// </summary>
+    [Fact]
+    public void ResumeSessionAsync_UsesOnEventInConfig_NotPostResumeOn()
+    {
+        var svcPath = Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.cs");
+        var source = File.ReadAllText(svcPath);
+
+        // Find the ResumeSessionAsync method (the one that resumes sessions on startup)
+        var methodIdx = source.IndexOf("public async Task<AgentSessionInfo> ResumeSessionAsync(", StringComparison.Ordinal);
+        Assert.True(methodIdx >= 0, "ResumeSessionAsync must exist");
+        var methodEnd = source.IndexOf("\n    }", methodIdx + 1, StringComparison.Ordinal);
+        var methodBody = source.Substring(methodIdx, methodEnd - methodIdx);
+
+        // Must use OnEvent in the config — this registers BEFORE the RPC call
+        Assert.True(methodBody.Contains("OnEvent", StringComparison.Ordinal),
+            "ResumeSessionAsync must pass event handler via ResumeSessionConfig.OnEvent " +
+            "to avoid the race where events are dropped between resume-return and .On() call");
+
+        // Must NOT have a post-resume .On() call (which would be the race-prone pattern)
+        // Strip comment lines first
+        var codeOnly = string.Join("\n", methodBody.Split('\n')
+            .Where(l => !l.TrimStart().StartsWith("//")));
+        Assert.False(codeOnly.Contains("copilotSession.On(evt", StringComparison.Ordinal),
+            "ResumeSessionAsync must NOT call copilotSession.On() after resume — " +
+            "use OnEvent in config instead to prevent the event delivery race");
     }
 }

--- a/PolyPilot.Tests/ChatExperienceSafetyTests.cs
+++ b/PolyPilot.Tests/ChatExperienceSafetyTests.cs
@@ -72,6 +72,31 @@ public class ChatExperienceSafetyTests
         method.Invoke(svc, new object?[] { sessionState });
     }
 
+    /// <summary>Invokes the private FinalizeResumedSessionUiStateAsync helper via reflection.</summary>
+    private static async Task InvokeFinalizeResumedSessionUiStateAsync(
+        CopilotService svc,
+        object sessionState,
+        string sessionId,
+        string? workingDirectory,
+        string? gitBranch,
+        bool isStillProcessing,
+        int processingPhase,
+        string reconnectMsg)
+    {
+        var method = typeof(CopilotService).GetMethod("FinalizeResumedSessionUiStateAsync", NonPublic)!;
+        var task = (Task)method.Invoke(svc, new object?[]
+        {
+            sessionState,
+            sessionId,
+            workingDirectory,
+            gitBranch,
+            isStillProcessing,
+            processingPhase,
+            reconnectMsg
+        })!;
+        await task;
+    }
+
     /// <summary>Invokes the private ClearFlushedReplayDedup helper to simulate a tool/sub-turn boundary.</summary>
     private static void InvokeClearFlushedReplayDedup(object sessionState)
     {
@@ -1092,14 +1117,16 @@ public class ChatExperienceSafetyTests
     }
 
     /// <summary>
-    /// The "Session not found" reconnect path must include McpServers and SkillDirectories
-    /// in the fresh session config (PR #330 regression guard).
+    /// Fresh create + lazy/explicit resume paths must all preserve MCP servers and skill
+    /// directories so restarted sessions do not silently lose tool availability.
     /// </summary>
     [Fact]
-    public void ReconnectPath_IncludesMcpServersAndSkills()
+    public void ResumeAndReconnectPaths_IncludeMcpServersAndSkills()
     {
         var source = File.ReadAllText(
             Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.cs"));
+        var persistence = File.ReadAllText(
+            Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.Persistence.cs"));
 
         // After extraction to BuildFreshSessionConfig, verify the reconnect path calls the helper
         var sessionNotFoundIdx = source.IndexOf("resumeEx.Message.Contains(\"Session not found\"", StringComparison.Ordinal);
@@ -1113,6 +1140,54 @@ public class ChatExperienceSafetyTests
         var helperBlock = source.Substring(helperIdx, Math.Min(2000, source.Length - helperIdx));
         Assert.Contains("McpServers", helperBlock);
         Assert.Contains("SkillDirectories", helperBlock);
+
+        var resumeHelperIdx = source.IndexOf("private ResumeSessionConfig BuildResumeSessionConfig", StringComparison.Ordinal);
+        Assert.True(resumeHelperIdx > 0);
+        var resumeHelperBlock = source.Substring(resumeHelperIdx, Math.Min(2000, source.Length - resumeHelperIdx));
+        Assert.Contains("McpServers", resumeHelperBlock);
+        Assert.Contains("SkillDirectories", resumeHelperBlock);
+        Assert.Contains("BuildResumeSessionConfig(state, resumeWorkingDirectory", source);
+        Assert.Contains("BuildResumeSessionConfig(state, resumeWorkDir", persistence);
+    }
+
+    /// <summary>
+    /// Finalizing resumed session state should complete stale entries and append the reconnect
+    /// message through the dedicated UI-thread helper instead of mutating History inline.
+    /// </summary>
+    [Fact]
+    public async Task FinalizeResumedSessionUiState_CompletesStaleEntriesAndAppendsReconnectMessage()
+    {
+        var svc = CreateService();
+        await svc.ReconnectAsync(new ConnectionSettings { Mode = ConnectionMode.Demo });
+        var session = await svc.CreateSessionAsync("resume-ui-finalize");
+        var state = GetSessionState(svc, "resume-ui-finalize");
+
+        var staleTool = ChatMessage.ToolCallMessage("bash", "call-1", "echo hi");
+        staleTool.IsComplete = false;
+        var staleReasoning = ChatMessage.ReasoningMessage("reason-1");
+        staleReasoning.Content = "thinking...";
+        staleReasoning.IsComplete = false;
+        session.History.Add(ChatMessage.UserMessage("resume me"));
+        session.History.Add(staleTool);
+        session.History.Add(staleReasoning);
+
+        await InvokeFinalizeResumedSessionUiStateAsync(
+            svc,
+            state,
+            Guid.NewGuid().ToString(),
+            "/tmp/worktree",
+            "main",
+            isStillProcessing: true,
+            processingPhase: 3,
+            reconnectMsg: "🔄 Session reconnected at 12:34 — running bash");
+
+        Assert.True(staleTool.IsComplete);
+        Assert.True(staleReasoning.IsComplete);
+        Assert.True(session.IsProcessing);
+        Assert.Equal(3, session.ProcessingPhase);
+        Assert.Equal("/tmp/worktree", session.WorkingDirectory);
+        Assert.Equal("main", session.GitBranch);
+        Assert.Contains(session.History, m => m.Content?.Contains("Session reconnected", StringComparison.Ordinal) == true);
     }
 
     // =========================================================================

--- a/PolyPilot/Services/CopilotService.Persistence.cs
+++ b/PolyPilot/Services/CopilotService.Persistence.cs
@@ -438,6 +438,10 @@ public partial class CopilotService
                 state.Info.WorkingDirectory = resumeWorkDir;
                 var freshConfig = BuildFreshSessionConfig(state);
                 copilotSession = await GetClientForGroup(groupId).CreateSessionAsync(freshConfig, cancellationToken);
+                // Attach event handler on the fresh session so it isn't deaf.
+                // BuildFreshSessionConfig returns a SessionConfig (no OnEvent), and the
+                // old post-resume .On() was removed, so we must register explicitly here.
+                copilotSession.On(evt => HandleSessionEvent(state, evt));
                 state.Info.SessionId = copilotSession.SessionId;
                 FlushSaveActiveSessionsToDisk();
             }
@@ -468,8 +472,9 @@ public partial class CopilotService
                 copilotSession = await GetClientForGroup(groupId).ResumeSessionAsync(sessionId, resumeConfig, cancellationToken);
             }
 
-            // INV-16: the event handler is already registered via ResumeSessionConfig.OnEvent
-            // before the session.resume RPC is sent, so early replay events are preserved.
+            // INV-16: For the happy-path resume, the event handler is registered via
+            // ResumeSessionConfig.OnEvent before the RPC. For the fallback fresh-create
+            // path, .On() is called explicitly right after CreateSessionAsync.
             state.Session = copilotSession;
             state.IsMultiAgentSession = IsSessionInMultiAgentGroup(sessionName);
 

--- a/PolyPilot/Services/CopilotService.Persistence.cs
+++ b/PolyPilot/Services/CopilotService.Persistence.cs
@@ -414,14 +414,11 @@ public partial class CopilotService
             var resumeModel = state.Info.Model ?? DefaultModel;
             var resumeWorkDir = state.Info.WorkingDirectory;
 
-            var resumeConfig = new ResumeSessionConfig
-            {
-                Model = resumeModel,
-                WorkingDirectory = resumeWorkDir,
-                Tools = new List<Microsoft.Extensions.AI.AIFunction> { ShowImageTool.CreateFunction() },
-                OnPermissionRequest = AutoApprovePermissions,
-                InfiniteSessions = new InfiniteSessionConfig { Enabled = true },
-            };
+            // Clear IsOrphaned before resuming so early replay events from ResumeSessionConfig.OnEvent
+            // are not dropped by the orphan guard in HandleSessionEvent.
+            state.IsOrphaned = false;
+
+            var resumeConfig = BuildResumeSessionConfig(state, resumeWorkDir, evt => HandleSessionEvent(state, evt));
 
             CopilotSession copilotSession;
             bool wasResumed = false;
@@ -437,14 +434,10 @@ public partial class CopilotService
                 IsProcessError(ex))
             {
                 Debug($"Lazy-resume failed for '{sessionName}': {ex.Message} — creating fresh session");
-                copilotSession = await GetClientForGroup(groupId).CreateSessionAsync(new SessionConfig
-                {
-                    Model = resumeModel,
-                    WorkingDirectory = resumeWorkDir,
-                    Tools = new List<Microsoft.Extensions.AI.AIFunction> { ShowImageTool.CreateFunction() },
-                    OnPermissionRequest = AutoApprovePermissions,
-                    InfiniteSessions = new InfiniteSessionConfig { Enabled = true },
-                }, cancellationToken);
+                state.Info.Model = resumeModel;
+                state.Info.WorkingDirectory = resumeWorkDir;
+                var freshConfig = BuildFreshSessionConfig(state);
+                copilotSession = await GetClientForGroup(groupId).CreateSessionAsync(freshConfig, cancellationToken);
                 state.Info.SessionId = copilotSession.SessionId;
                 FlushSaveActiveSessionsToDisk();
             }
@@ -475,19 +468,8 @@ public partial class CopilotService
                 copilotSession = await GetClientForGroup(groupId).ResumeSessionAsync(sessionId, resumeConfig, cancellationToken);
             }
 
-            // Clear IsOrphaned BEFORE registering the event handler — the state may have
-            // been marked orphaned by a sibling reconnect failure (e.g., corrupted session
-            // file caused re-resume to fail, setting IsOrphaned=true on this state).
-            // Without this reset, HandleSessionEvent silently drops all events and the
-            // session appears stuck to mobile clients despite the CLI responding normally.
-            // Order matters: reset first so no early SDK replay events (e.g., session.resume
-            // acknowledgment) are dropped by the IsOrphaned guard in HandleSessionEvent.
-            state.IsOrphaned = false;
-            // INV-16: Register event handler BEFORE publishing to state —
-            // no window where events arrive with no handler. Matches the pattern
-            // in sibling reconnect (CopilotService.cs:2766) and worker revival
-            // (Organization.cs:1547).
-            copilotSession.On(evt => HandleSessionEvent(state, evt));
+            // INV-16: the event handler is already registered via ResumeSessionConfig.OnEvent
+            // before the session.resume RPC is sent, so early replay events are preserved.
             state.Session = copilotSession;
             state.IsMultiAgentSession = IsSessionInMultiAgentGroup(sessionName);
 

--- a/PolyPilot/Services/CopilotService.Persistence.cs
+++ b/PolyPilot/Services/CopilotService.Persistence.cs
@@ -414,18 +414,10 @@ public partial class CopilotService
             var resumeModel = state.Info.Model ?? DefaultModel;
             var resumeWorkDir = state.Info.WorkingDirectory;
 
-            // Load MCP servers and skill directories so resumed sessions have full tool access.
-            // Without this, lazily-resumed sessions start without MCP tools until manual /mcp reload.
-            var settings = ConnectionSettings.Load();
-            var mcpServers = LoadMcpServers(settings.DisabledMcpServers, settings.DisabledPlugins);
-            var skillDirs = LoadSkillDirectories(settings.DisabledPlugins);
-
             var resumeConfig = new ResumeSessionConfig
             {
                 Model = resumeModel,
                 WorkingDirectory = resumeWorkDir,
-                McpServers = mcpServers,
-                SkillDirectories = skillDirs,
                 Tools = new List<Microsoft.Extensions.AI.AIFunction> { ShowImageTool.CreateFunction() },
                 OnPermissionRequest = AutoApprovePermissions,
                 InfiniteSessions = new InfiniteSessionConfig { Enabled = true },
@@ -449,8 +441,6 @@ public partial class CopilotService
                 {
                     Model = resumeModel,
                     WorkingDirectory = resumeWorkDir,
-                    McpServers = mcpServers,
-                    SkillDirectories = skillDirs,
                     Tools = new List<Microsoft.Extensions.AI.AIFunction> { ShowImageTool.CreateFunction() },
                     OnPermissionRequest = AutoApprovePermissions,
                     InfiniteSessions = new InfiniteSessionConfig { Enabled = true },

--- a/PolyPilot/Services/CopilotService.Persistence.cs
+++ b/PolyPilot/Services/CopilotService.Persistence.cs
@@ -439,8 +439,8 @@ public partial class CopilotService
                 var freshConfig = BuildFreshSessionConfig(state);
                 copilotSession = await GetClientForGroup(groupId).CreateSessionAsync(freshConfig, cancellationToken);
                 // Attach event handler on the fresh session so it isn't deaf.
-                // BuildFreshSessionConfig returns a SessionConfig (no OnEvent), and the
-                // old post-resume .On() was removed, so we must register explicitly here.
+                // BuildFreshSessionConfig doesn't set OnEvent on the SessionConfig, and
+                // the old post-resume .On() was removed, so we must register explicitly here.
                 copilotSession.On(evt => HandleSessionEvent(state, evt));
                 state.Info.SessionId = copilotSession.SessionId;
                 FlushSaveActiveSessionsToDisk();

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -49,8 +49,6 @@ public partial class CopilotService : IAsyncDisposable
     }
     /// <summary>Test-only: simulate IsRestoring state for bridge queue tests.</summary>
     internal void SetIsRestoringForTesting(bool value) => IsRestoring = value;
-    /// <summary>Test-only: set the UI synchronization context captured during initialization.</summary>
-    internal void SetSyncContextForTesting(SynchronizationContext? syncContext) => _syncContext = syncContext;
     // Sessions for which history has already been requested — prevents duplicate request storms
     private readonly ConcurrentDictionary<string, byte> _requestedHistorySessions = new();
     // External session IDs currently being resumed — prevents duplicate SDK connections from rapid double-clicks
@@ -63,6 +61,7 @@ public partial class CopilotService : IAsyncDisposable
     private readonly ConcurrentDictionary<string, List<string?>> _queuedAgentModes = new();
     private readonly object _imageQueueLock = new();
     private static readonly object _diagnosticLogLock = new();
+    private static readonly DateTime _appStartedAtUtc = DateTime.UtcNow;
     // Debounce timers for disk I/O — coalesce rapid-fire saves into a single write
     private Timer? _saveSessionsDebounce;
     private Timer? _saveOrgDebounce;
@@ -224,6 +223,8 @@ public partial class CopilotService : IAsyncDisposable
             _zeroIdleCaptureDir = null;
         }
     }
+
+    internal void SetSyncContextForTesting(SynchronizationContext? syncContext) => _syncContext = syncContext;
 
     /// <summary>Builds the FallbackNotice message shown when the persistent server fails to start.</summary>
     internal static string BuildServerFallbackNotice(string? serverError, string logPath, string reason = "couldn't start", bool embeddedFallback = true)
@@ -2472,11 +2473,47 @@ The user can also check configured servers with the /mcp command.
         var resumeModel = Models.ModelHelper.NormalizeToSlug(GetSessionModelFromDisk(sessionId) ?? model ?? DefaultModel);
         if (string.IsNullOrEmpty(resumeModel)) resumeModel = DefaultModel;
         Debug($"Resuming session '{displayName}' with model: '{resumeModel}', cwd: '{resumeWorkingDirectory}'");
-        var resumeSettings = ConnectionSettings.Load();
-        var resumeMcpServers = LoadMcpServers(resumeSettings.DisabledMcpServers, resumeSettings.DisabledPlugins);
-        var resumeSkillDirs = LoadSkillDirectories(resumeSettings.DisabledPlugins);
-        var resumeConfig = new ResumeSessionConfig { Model = resumeModel, WorkingDirectory = resumeWorkingDirectory, McpServers = resumeMcpServers, SkillDirectories = resumeSkillDirs, Tools = new List<Microsoft.Extensions.AI.AIFunction> { ShowImageTool.CreateFunction() }, OnPermissionRequest = AutoApprovePermissions, InfiniteSessions = new InfiniteSessionConfig { Enabled = true } };
-        var copilotSession = await GetClientForGroup(groupId).ResumeSessionAsync(sessionId, resumeConfig, cancellationToken);
+        // Create state BEFORE ResumeSessionAsync so the event handler can be passed via
+        // config.OnEvent. The SDK registers OnEvent before sending the session.resume RPC,
+        // closing the race window where events arrive between resume-return and .On() call.
+        // Without this, the SDK's ProcessEventsAsync loop consumes events with an empty
+        // handler list, silently dropping content deltas while lifecycle events appear to flow.
+        var state = new SessionState { Session = null!, Info = new AgentSessionInfo { Name = displayName, SessionId = sessionId, Model = resumeModel } };
+        // Populate history BEFORE pre-publishing to _sessions so that event dedup logic
+        // (which checks state.Info.History for existing tool calls / messages) has the
+        // persisted entries to match against. Without this, replayed resume-time events
+        // can't dedup and produce duplicate entries in the UI.
+        foreach (var msg in history)
+            state.Info.History.Add(msg);
+        state.Info.MessageCount = state.Info.History.Count;
+        state.Info.LastReadMessageCount = state.Info.History.Count;
+        // Mark stale incomplete tool calls/reasoning as complete
+        foreach (var msg in state.Info.History.Where(m => m.MessageType == ChatMessageType.ToolCall && !m.IsComplete))
+            msg.IsComplete = true;
+        foreach (var msg in state.Info.History.Where(m => m.MessageType == ChatMessageType.Reasoning && !m.IsComplete))
+            msg.IsComplete = true;
+        // Publish state to _sessions BEFORE ResumeSessionAsync so that events arriving
+        // via OnEvent during the resume RPC pass the isCurrentState check in HandleSessionEvent.
+        // Without this, HandleSessionEvent sees _sessions[displayName] != state and drops events.
+        // Save the previous entry (if any) so we can restore it on failure.
+        _sessions.TryGetValue(displayName, out var previousState);
+        _sessions[displayName] = state;
+        var resumeConfig = new ResumeSessionConfig { Model = resumeModel, WorkingDirectory = resumeWorkingDirectory, Tools = new List<Microsoft.Extensions.AI.AIFunction> { ShowImageTool.CreateFunction() }, OnPermissionRequest = AutoApprovePermissions, InfiniteSessions = new InfiniteSessionConfig { Enabled = true }, OnEvent = evt => HandleSessionEvent(state, evt) };
+        CopilotSession copilotSession;
+        try
+        {
+            copilotSession = await GetClientForGroup(groupId).ResumeSessionAsync(sessionId, resumeConfig, cancellationToken);
+        }
+        catch
+        {
+            // Restore the previous placeholder state if resume fails, so the session
+            // doesn't disappear from the UI. If there was no previous entry, remove ours.
+            if (previousState != null)
+                _sessions[displayName] = previousState;
+            else
+                _sessions.TryRemove(displayName, out _);
+            throw;
+        }
 
         // Detect session ID mismatch: the persistent server may return a different
         // session ID than requested (e.g., if it recreated the session internally).
@@ -2486,49 +2523,46 @@ The user can also check configured servers with the /mcp command.
         if (!string.IsNullOrEmpty(actualSessionId) && actualSessionId != sessionId)
         {
             Debug($"[RESUME-REMAP] Session ID changed: requested '{sessionId}', server returned '{actualSessionId}' for '{displayName}'");
-            // Copy old events to the new session dir BEFORE registering the event handler.
-            // The SDK may start writing events to the new dir after ResumeSessionAsync returns,
-            // but our copy runs immediately and the new dir typically has no events yet.
             CopyEventsToNewSession(sessionId, actualSessionId);
             var (actualHistory, actualFromDb) = await LoadBestHistoryAsync(actualSessionId);
             if (actualHistory.Count >= history.Count)
-                history = actualHistory;
+            {
+                // Rehydrate state.Info.History with the remapped session's history.
+                // Must be synchronized with HandleSessionEvent which reads/writes History
+                // on the UI thread. InvokeOnUI serializes this with event processing.
+                var tcs = new TaskCompletionSource<bool>();
+                InvokeOnUI(() =>
+                {
+                    state.Info.History.Clear();
+                    foreach (var msg in actualHistory)
+                        state.Info.History.Add(msg);
+                    state.Info.MessageCount = state.Info.History.Count;
+                    state.Info.LastReadMessageCount = state.Info.History.Count;
+                    tcs.TrySetResult(true);
+                });
+                await tcs.Task;
+            }
             sessionId = actualSessionId;
-            if (history.Count > 0 && !actualFromDb)
-                await _chatDb.BulkInsertAsync(sessionId, history);
+            if (actualHistory.Count > 0 && !actualFromDb)
+                await _chatDb.BulkInsertAsync(sessionId, actualHistory);
         }
 
         var isStillProcessing = IsSessionStillProcessing(sessionId);
 
-        var info = new AgentSessionInfo
-        {
-            Name = displayName,
-            Model = resumeModel,
-            CreatedAt = DateTime.UtcNow,
-            SessionId = sessionId,
-            IsResumed = isStillProcessing,
-            WorkingDirectory = resumeWorkingDirectory
-        };
+        state.Session = copilotSession;
+        var info = state.Info;
+        info.CreatedAt = DateTime.UtcNow;
+        info.SessionId = sessionId;
+        info.IsResumed = isStillProcessing;
+        info.WorkingDirectory = resumeWorkingDirectory;
         info.GitBranch = GetGitBranch(info.WorkingDirectory);
-
-        // Add loaded history to the session info
-        foreach (var msg in history)
-        {
-            info.History.Add(msg);
-        }
+        // Mark stale incomplete entries (may have new ones from remap)
+        foreach (var msg in info.History.Where(m => m.MessageType == ChatMessageType.ToolCall && !m.IsComplete))
+            msg.IsComplete = true;
+        foreach (var msg in info.History.Where(m => m.MessageType == ChatMessageType.Reasoning && !m.IsComplete))
+            msg.IsComplete = true;
         info.MessageCount = info.History.Count;
         info.LastReadMessageCount = info.History.Count;
-
-        // Mark any stale incomplete tool calls as complete (from prior session)
-        foreach (var msg in info.History.Where(m => m.MessageType == ChatMessageType.ToolCall && !m.IsComplete))
-        {
-            msg.IsComplete = true;
-        }
-        // Also mark incomplete reasoning as complete
-        foreach (var msg in info.History.Where(m => m.MessageType == ChatMessageType.Reasoning && !m.IsComplete))
-        {
-            msg.IsComplete = true;
-        }
 
         // Add reconnection indicator with status context
         var reconnectMsg = $"🔄 Session reconnected at {DateTime.Now.ToShortTimeString()}";
@@ -2552,16 +2586,10 @@ The user can also check configured servers with the /mcp command.
         if (isStillProcessing)
         {
             // Set phase based on last event so UI shows correct status instead of "Sending"
-            var (lastTool, _) = GetLastSessionActivity(sessionId);
-            info.ProcessingPhase = !string.IsNullOrEmpty(lastTool) ? 3 : 2; // 3=Working, 2=Thinking
+            var (lastTool2, _) = GetLastSessionActivity(sessionId);
+            info.ProcessingPhase = !string.IsNullOrEmpty(lastTool2) ? 3 : 2; // 3=Working, 2=Thinking
             info.ProcessingStartedAt = DateTime.UtcNow;
         }
-
-        var state = new SessionState
-        {
-            Session = copilotSession,
-            Info = info
-        };
 
         // Cache multi-agent membership for the watchdog timeout tier.
         // Must be set BEFORE StartProcessingWatchdog — otherwise the watchdog uses the
@@ -2570,9 +2598,8 @@ The user can also check configured servers with the /mcp command.
         // by LoadOrganization() before RestorePreviousSessionsAsync runs.
         state.IsMultiAgentSession = IsSessionInMultiAgentGroup(displayName);
 
-        // Wire up event handler BEFORE starting watchdog/timeout so events
-        // arriving immediately after SDK resume are not missed.
-        copilotSession.On(evt => HandleSessionEvent(state, evt));
+        // Event handler already registered via ResumeSessionConfig.OnEvent (before RPC call)
+        // to avoid the race where events arrive between ResumeSessionAsync return and .On().
 
         // If still processing, set up ResponseCompletion so events flow properly.
         // The processing watchdog (30s resume quiescence / 120s inactivity / 600s tool timeout)
@@ -2602,10 +2629,14 @@ The user can also check configured servers with the /mcp command.
             // See StartProcessingWatchdog comment for why file-time seeding is dangerous.
             StartProcessingWatchdog(state, displayName);
         }
-        if (!_sessions.TryAdd(displayName, state))
+        // State was already pre-published to _sessions before ResumeSessionAsync.
+        // No TryAdd needed — just verify it's still our state (could have been replaced
+        // by a concurrent resume of the same session name, though that's unlikely).
+        if (!_sessions.TryGetValue(displayName, out var currentState) || !ReferenceEquals(currentState, state))
         {
+            // Another resume replaced our state — dispose the session we just created
             try { await copilotSession.DisposeAsync(); } catch { }
-            throw new InvalidOperationException($"Failed to add session '{displayName}'.");
+            throw new InvalidOperationException($"Session '{displayName}' was replaced during resume.");
         }
 
         _activeSessionName ??= displayName;

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -2498,7 +2498,7 @@ The user can also check configured servers with the /mcp command.
         // Save the previous entry (if any) so we can restore it on failure.
         _sessions.TryGetValue(displayName, out var previousState);
         _sessions[displayName] = state;
-        var resumeConfig = new ResumeSessionConfig { Model = resumeModel, WorkingDirectory = resumeWorkingDirectory, Tools = new List<Microsoft.Extensions.AI.AIFunction> { ShowImageTool.CreateFunction() }, OnPermissionRequest = AutoApprovePermissions, InfiniteSessions = new InfiniteSessionConfig { Enabled = true }, OnEvent = evt => HandleSessionEvent(state, evt) };
+        var resumeConfig = BuildResumeSessionConfig(state, resumeWorkingDirectory, evt => HandleSessionEvent(state, evt));
         CopilotSession copilotSession;
         try
         {
@@ -2548,27 +2548,19 @@ The user can also check configured servers with the /mcp command.
         }
 
         var isStillProcessing = IsSessionStillProcessing(sessionId);
+        var resumeGitBranch = GetGitBranch(resumeWorkingDirectory);
+        string? lastTool = null;
+        string? lastContent = null;
+        var processingPhase = 0;
 
         state.Session = copilotSession;
-        var info = state.Info;
-        info.CreatedAt = DateTime.UtcNow;
-        info.SessionId = sessionId;
-        info.IsResumed = isStillProcessing;
-        info.WorkingDirectory = resumeWorkingDirectory;
-        info.GitBranch = GetGitBranch(info.WorkingDirectory);
-        // Mark stale incomplete entries (may have new ones from remap)
-        foreach (var msg in info.History.Where(m => m.MessageType == ChatMessageType.ToolCall && !m.IsComplete))
-            msg.IsComplete = true;
-        foreach (var msg in info.History.Where(m => m.MessageType == ChatMessageType.Reasoning && !m.IsComplete))
-            msg.IsComplete = true;
-        info.MessageCount = info.History.Count;
-        info.LastReadMessageCount = info.History.Count;
 
         // Add reconnection indicator with status context
         var reconnectMsg = $"🔄 Session reconnected at {DateTime.Now.ToShortTimeString()}";
         if (isStillProcessing)
         {
-            var (lastTool, lastContent) = GetLastSessionActivity(sessionId);
+            (lastTool, lastContent) = GetLastSessionActivity(sessionId);
+            processingPhase = !string.IsNullOrEmpty(lastTool) ? 3 : 2; // 3=Working, 2=Thinking
             if (!string.IsNullOrEmpty(lastTool))
                 reconnectMsg += $" — running {lastTool}";
             if (!string.IsNullOrEmpty(lastContent))
@@ -2579,17 +2571,15 @@ The user can also check configured servers with the /mcp command.
                 reconnectMsg += $"\n📝 Last message: \"{truncated}\"";
             }
         }
-        info.History.Add(ChatMessage.SystemMessage(reconnectMsg));
-
-        // Set processing state if session was mid-turn when app died
-        info.IsProcessing = isStillProcessing;
-        if (isStillProcessing)
-        {
-            // Set phase based on last event so UI shows correct status instead of "Sending"
-            var (lastTool2, _) = GetLastSessionActivity(sessionId);
-            info.ProcessingPhase = !string.IsNullOrEmpty(lastTool2) ? 3 : 2; // 3=Working, 2=Thinking
-            info.ProcessingStartedAt = DateTime.UtcNow;
-        }
+        await FinalizeResumedSessionUiStateAsync(
+            state,
+            sessionId,
+            resumeWorkingDirectory,
+            resumeGitBranch,
+            isStillProcessing,
+            processingPhase,
+            reconnectMsg);
+        var info = state.Info;
 
         // Cache multi-agent membership for the watchdog timeout tier.
         // Must be set BEFORE StartProcessingWatchdog — otherwise the watchdog uses the
@@ -4092,6 +4082,73 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
                 Interlocked.Exchange(ref state.SendingFlag, 0);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Build a ResumeSessionConfig with the same MCP servers and skill directories used for
+    /// fresh sessions so resumed sessions keep their external tool surface after restart.
+    /// </summary>
+    private ResumeSessionConfig BuildResumeSessionConfig(
+        SessionState state,
+        string? workingDirectory = null,
+        SessionEventHandler? onEvent = null)
+    {
+        var settings = _currentSettings ?? ConnectionSettings.Load();
+        var mcpServers = LoadMcpServers(settings.DisabledMcpServers, settings.DisabledPlugins);
+        var skillDirs = LoadSkillDirectories(settings.DisabledPlugins);
+        return new ResumeSessionConfig
+        {
+            Model = Models.ModelHelper.NormalizeToSlug(state.Info.Model) ?? DefaultModel,
+            WorkingDirectory = workingDirectory ?? state.Info.WorkingDirectory,
+            McpServers = mcpServers,
+            SkillDirectories = skillDirs,
+            Tools = new List<Microsoft.Extensions.AI.AIFunction> { ShowImageTool.CreateFunction() },
+            OnPermissionRequest = AutoApprovePermissions,
+            InfiniteSessions = new InfiniteSessionConfig { Enabled = true },
+            OnEvent = onEvent,
+        };
+    }
+
+    /// <summary>
+    /// Finalize resumed-session state on the UI thread so history/count updates stay serialized
+    /// with live OnEvent callbacks that may already be replaying during resume.
+    /// </summary>
+    private Task FinalizeResumedSessionUiStateAsync(
+        SessionState state,
+        string sessionId,
+        string? workingDirectory,
+        string? gitBranch,
+        bool isStillProcessing,
+        int processingPhase,
+        string reconnectMsg)
+    {
+        return InvokeOnUIAsync(() =>
+        {
+            var info = state.Info;
+            info.CreatedAt = DateTime.UtcNow;
+            info.SessionId = sessionId;
+            info.IsResumed = isStillProcessing;
+            info.WorkingDirectory = workingDirectory;
+            info.GitBranch = gitBranch;
+
+            // Mark stale incomplete entries (may have new ones from remap) while serialized
+            // with any live event-driven history mutations.
+            foreach (var msg in info.History.Where(m => m.MessageType == ChatMessageType.ToolCall && !m.IsComplete))
+                msg.IsComplete = true;
+            foreach (var msg in info.History.Where(m => m.MessageType == ChatMessageType.Reasoning && !m.IsComplete))
+                msg.IsComplete = true;
+
+            info.MessageCount = info.History.Count;
+            info.LastReadMessageCount = info.History.Count;
+            info.History.Add(ChatMessage.SystemMessage(reconnectMsg));
+
+            info.IsProcessing = isStillProcessing;
+            if (isStillProcessing)
+            {
+                info.ProcessingPhase = processingPhase;
+                info.ProcessingStartedAt = DateTime.UtcNow;
+            }
+        });
     }
 
     /// <summary>

--- a/use-local-sdk.sh
+++ b/use-local-sdk.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Builds PolyPilot against a local source build of the Copilot SDK.
+#
+# Usage:
+#   ./use-local-sdk.sh [path-to-sdk]    # Switch to local SDK
+#   ./use-local-sdk.sh --revert         # Switch back to NuGet package
+#
+# The SDK path defaults to ../copilot-sdk (sibling directory). Override with:
+#   ./use-local-sdk.sh /path/to/copilot-sdk
+#   COPILOT_SDK_PATH=/path/to/copilot-sdk ./use-local-sdk.sh
+#
+# First-time setup:
+#   git clone https://github.com/github/copilot-sdk.git ../copilot-sdk
+#   # Or use PureWeen's fork with PolyPilot-specific fixes:
+#   git clone https://github.com/PureWeen/copilot-sdk.git ../copilot-sdk
+#   cd ../copilot-sdk && git checkout upstream_validation
+#
+# What it does:
+#   1. Packs the local SDK as a NuGet package (version 0.3.0-local)
+#   2. Adds a local NuGet source to nuget.config
+#   3. Updates all csproj references to 0.3.0-local
+#   4. Clears NuGet cache to force re-resolve
+#
+# To iterate on SDK changes:
+#   1. Edit code in the copilot-sdk/dotnet/src/ directory
+#   2. Re-run ./use-local-sdk.sh (rebuilds + re-packs automatically)
+#   3. Build PolyPilot normally (dotnet build or ./relaunch.sh)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOCAL_VERSION="0.3.0-local"
+
+# Resolve SDK path: argument > env var > default sibling directory
+if [ "$1" != "--revert" ] && [ -n "$1" ]; then
+    SDK_DIR="$1"
+elif [ -n "$COPILOT_SDK_PATH" ]; then
+    SDK_DIR="$COPILOT_SDK_PATH"
+else
+    SDK_DIR="$SCRIPT_DIR/../copilot-sdk"
+fi
+NUPKG_DIR="$SDK_DIR/dotnet/nupkg"
+
+if [ "$1" = "--revert" ]; then
+    echo "⏪ Reverting to NuGet package..."
+    cd "$SCRIPT_DIR"
+    git checkout -- nuget.config \
+        PolyPilot/PolyPilot.csproj \
+        PolyPilot.Tests/PolyPilot.Tests.csproj \
+        PolyPilot.Provider.Abstractions/PolyPilot.Provider.Abstractions.csproj \
+        PolyPilot.Gtk/PolyPilot.Gtk.csproj \
+        PolyPilot.Console/PolyPilot.csproj 2>/dev/null || true
+    rm -rf ~/.nuget/packages/github.copilot.sdk/$LOCAL_VERSION
+    echo "✅ Reverted to NuGet SDK. Run 'dotnet restore' to re-resolve."
+    exit 0
+fi
+
+# Validate SDK path
+if [ ! -d "$SDK_DIR/dotnet/src" ]; then
+    echo "❌ Copilot SDK not found at: $SDK_DIR"
+    echo ""
+    echo "Clone it first:"
+    echo "  git clone https://github.com/PureWeen/copilot-sdk.git $SDK_DIR"
+    echo "  cd $SDK_DIR && git checkout upstream_validation"
+    echo ""
+    echo "Or specify a custom path:"
+    echo "  ./use-local-sdk.sh /path/to/copilot-sdk"
+    echo "  COPILOT_SDK_PATH=/path/to/sdk ./use-local-sdk.sh"
+    exit 1
+fi
+
+echo "📦 Building local Copilot SDK..."
+echo "   Source: $SDK_DIR (branch: $(cd "$SDK_DIR" && git branch --show-current 2>/dev/null || echo 'detached'))"
+cd "$SDK_DIR/dotnet"
+rm -rf nupkg
+dotnet pack src/GitHub.Copilot.SDK.csproj -c Debug -o ./nupkg -p:Version=$LOCAL_VERSION --nologo 2>&1 | tail -3
+
+if [ ! -f "$NUPKG_DIR/GitHub.Copilot.SDK.$LOCAL_VERSION.nupkg" ]; then
+    echo "❌ Pack failed — nupkg not found"
+    exit 1
+fi
+
+echo "🔧 Updating PolyPilot references..."
+cd "$SCRIPT_DIR"
+
+# Update nuget.config — add local source if not present
+if ! grep -q "local-sdk" nuget.config; then
+    sed -i '' '/<clear \/>/a\
+    <add key="local-sdk" value="'"$NUPKG_DIR"'" />' nuget.config
+    sed -i '' '/<packageSourceMapping>/a\
+    <packageSource key="local-sdk">\
+      <package pattern="GitHub.Copilot.SDK" />\
+    </packageSource>' nuget.config
+else
+    # Update the path in case SDK location changed
+    sed -i '' 's|key="local-sdk" value="[^"]*"|key="local-sdk" value="'"$NUPKG_DIR"'"|' nuget.config
+fi
+
+# Update all csproj files
+for f in PolyPilot/PolyPilot.csproj PolyPilot.Tests/PolyPilot.Tests.csproj \
+         PolyPilot.Provider.Abstractions/PolyPilot.Provider.Abstractions.csproj \
+         PolyPilot.Gtk/PolyPilot.Gtk.csproj PolyPilot.Console/PolyPilot.csproj; do
+    if [ -f "$f" ]; then
+        sed -i '' 's/GitHub.Copilot.SDK" Version="[^"]*"/GitHub.Copilot.SDK" Version="'"$LOCAL_VERSION"'"/g' "$f"
+    fi
+done
+
+# Clear cached local package so dotnet picks up the fresh build
+rm -rf ~/.nuget/packages/github.copilot.sdk/$LOCAL_VERSION
+
+echo "🔄 Restoring..."
+dotnet restore PolyPilot/PolyPilot.csproj --force --nologo 2>&1 | tail -3
+
+echo ""
+echo "✅ PolyPilot now uses local Copilot SDK ($LOCAL_VERSION)"
+echo "   SDK source: $SDK_DIR"
+echo "   To rebuild after SDK changes: ./use-local-sdk.sh $([ "$SDK_DIR" != "$SCRIPT_DIR/../copilot-sdk" ] && echo "$SDK_DIR")"
+echo "   To revert to NuGet:           ./use-local-sdk.sh --revert"


### PR DESCRIPTION
## What

Two reliability fixes found during live monitoring.

### 1. Event delivery race on ResumeSessionAsync (root cause of empty-response workers)

**The bug:** PolyPilot called `.On(handler)` AFTER `ResumeSessionAsync` returned. The SDK's `ProcessEventsAsync` loop starts in the `CopilotSession` constructor and immediately consumes events from the channel. Events dispatched between the resume RPC response and the `.On()` registration were consumed with an empty handler list — **silently dropped**.

This caused the recurring 'empty response' worker pattern: lifecycle events (TurnStart/TurnEnd) appeared to flow because they arrived after `.On()`, but content events (MessageDelta) sent immediately after `session.resume` were lost in the race window. The worker would run for 120-600s, produce zero flushed content, get watchdog-killed, then revived — repeating the cycle.

**The fix:** Pass the event handler via `ResumeSessionConfig.OnEvent`, which the SDK registers BEFORE sending the `session.resume` RPC. The `SessionState` is pre-created with minimal info and populated after resume returns.

**This is a PolyPilot bug, not an SDK bug** — the SDK provides `OnEvent` specifically to avoid this race.

### 2. Stale events.jsonl detection after relaunch

After a relaunch, `IsSessionStillProcessing` checks `events.jsonl` for non-terminal events. If the CLI finished a turn during the relaunch window, `session.idle` was NOT written (ephemeral), so the last event looks active. Workers sat with stale `IsProcessing=true` for 600s until the watchdog killed them.

**Fix:** Added a 30s mtime freshness check — if `events.jsonl` hasn't been written to in 30s, the CLI is done. Downgrades from deferred processing to eager resume.

## Testing

- 3310/3310 tests pass (1 flaky `ServerManagerTests` unrelated)
- Structural regression test: `ResumeSessionAsync_UsesOnEventInConfig_NotPostResumeOn`
- Applied stale-file fix to both main repo and orchestrator worktree