### PR TITLE
fix: load MCP servers on lazy-resume so tools work after restart

### DIFF
--- a/PolyPilot.Tests/ChatExperienceSafetyTests.cs
+++ b/PolyPilot.Tests/ChatExperienceSafetyTests.cs
@@ -1115,6 +1115,30 @@ public class ChatExperienceSafetyTests
         Assert.Contains("SkillDirectories", helperBlock);
     }
 
+    /// <summary>
+    /// Lazy-resume and its fresh-session fallback must include McpServers and SkillDirectories.
+    /// Without these, resumed sessions start without MCP tools (e.g., WorkIQ) until manual /mcp reload.
+    /// </summary>
+    [Fact]
+    public void LazyResumePath_IncludesMcpServersAndSkills()
+    {
+        var source = File.ReadAllText(
+            Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.Persistence.cs"));
+
+        // Find the EnsureSessionConnectedAsync method containing the lazy-resume logic
+        var methodIdx = source.IndexOf("EnsureSessionConnectedAsync", StringComparison.Ordinal);
+        Assert.True(methodIdx > 0, "EnsureSessionConnectedAsync not found");
+        var block = source.Substring(methodIdx, Math.Min(3000, source.Length - methodIdx));
+
+        // MCP servers must be loaded before creating the resume config
+        Assert.Contains("LoadMcpServers", block);
+        Assert.Contains("LoadSkillDirectories", block);
+
+        // Both the ResumeSessionConfig and the fallback SessionConfig must include MCP
+        Assert.Contains("McpServers = mcpServers", block);
+        Assert.Contains("SkillDirectories = skillDirs", block);
+    }
+
     // =========================================================================
     // F. Race Condition & Edge Case Tests
     // =========================================================================

--- a/PolyPilot.Tests/ChatExperienceSafetyTests.cs
+++ b/PolyPilot.Tests/ChatExperienceSafetyTests.cs
@@ -1139,6 +1139,26 @@ public class ChatExperienceSafetyTests
         Assert.Contains("SkillDirectories = skillDirs", block);
     }
 
+    /// <summary>
+    /// The public ResumeSessionAsync (sidebar resume, bridge resume) must also include
+    /// McpServers and SkillDirectories so MCP tools work after explicit resume.
+    /// </summary>
+    [Fact]
+    public void SidebarResumePath_IncludesMcpServersAndSkills()
+    {
+        var source = File.ReadAllText(
+            Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.cs"));
+
+        var methodIdx = source.IndexOf("public async Task<AgentSessionInfo> ResumeSessionAsync(", StringComparison.Ordinal);
+        Assert.True(methodIdx > 0, "ResumeSessionAsync not found");
+        var block = source.Substring(methodIdx, Math.Min(6000, source.Length - methodIdx));
+
+        Assert.Contains("LoadMcpServers", block);
+        Assert.Contains("LoadSkillDirectories", block);
+        Assert.Contains("McpServers = resumeMcpServers", block);
+        Assert.Contains("SkillDirectories = resumeSkillDirs", block);
+    }
+
     // =========================================================================
     // F. Race Condition & Edge Case Tests
     // =========================================================================

--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -2344,6 +2344,11 @@
                 break;
 
             case "reload":
+                if (CopilotService.IsRemoteMode)
+                {
+                    session.History.Add(ChatMessage.SystemMessage("⚠️ `/mcp reload` is not available in Remote mode. Use the desktop app to reload MCP servers."));
+                    break;
+                }
                 session.History.Add(ChatMessage.SystemMessage("🔄 Reloading MCP servers — replacing SDK session in-place (history preserved)..."));
                 _ = ReloadMcpServersAsync(session);
                 break;

--- a/PolyPilot/Services/CopilotService.Persistence.cs
+++ b/PolyPilot/Services/CopilotService.Persistence.cs
@@ -414,10 +414,18 @@ public partial class CopilotService
             var resumeModel = state.Info.Model ?? DefaultModel;
             var resumeWorkDir = state.Info.WorkingDirectory;
 
+            // Load MCP servers and skill directories so resumed sessions have full tool access.
+            // Without this, lazily-resumed sessions start without MCP tools until manual /mcp reload.
+            var settings = ConnectionSettings.Load();
+            var mcpServers = LoadMcpServers(settings.DisabledMcpServers, settings.DisabledPlugins);
+            var skillDirs = LoadSkillDirectories(settings.DisabledPlugins);
+
             var resumeConfig = new ResumeSessionConfig
             {
                 Model = resumeModel,
                 WorkingDirectory = resumeWorkDir,
+                McpServers = mcpServers,
+                SkillDirectories = skillDirs,
                 Tools = new List<Microsoft.Extensions.AI.AIFunction> { ShowImageTool.CreateFunction() },
                 OnPermissionRequest = AutoApprovePermissions,
                 InfiniteSessions = new InfiniteSessionConfig { Enabled = true },
@@ -441,6 +449,8 @@ public partial class CopilotService
                 {
                     Model = resumeModel,
                     WorkingDirectory = resumeWorkDir,
+                    McpServers = mcpServers,
+                    SkillDirectories = skillDirs,
                     Tools = new List<Microsoft.Extensions.AI.AIFunction> { ShowImageTool.CreateFunction() },
                     OnPermissionRequest = AutoApprovePermissions,
                     InfiniteSessions = new InfiniteSessionConfig { Enabled = true },

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -2472,7 +2472,10 @@ The user can also check configured servers with the /mcp command.
         var resumeModel = Models.ModelHelper.NormalizeToSlug(GetSessionModelFromDisk(sessionId) ?? model ?? DefaultModel);
         if (string.IsNullOrEmpty(resumeModel)) resumeModel = DefaultModel;
         Debug($"Resuming session '{displayName}' with model: '{resumeModel}', cwd: '{resumeWorkingDirectory}'");
-        var resumeConfig = new ResumeSessionConfig { Model = resumeModel, WorkingDirectory = resumeWorkingDirectory, Tools = new List<Microsoft.Extensions.AI.AIFunction> { ShowImageTool.CreateFunction() }, OnPermissionRequest = AutoApprovePermissions, InfiniteSessions = new InfiniteSessionConfig { Enabled = true } };
+        var resumeSettings = ConnectionSettings.Load();
+        var resumeMcpServers = LoadMcpServers(resumeSettings.DisabledMcpServers, resumeSettings.DisabledPlugins);
+        var resumeSkillDirs = LoadSkillDirectories(resumeSettings.DisabledPlugins);
+        var resumeConfig = new ResumeSessionConfig { Model = resumeModel, WorkingDirectory = resumeWorkingDirectory, McpServers = resumeMcpServers, SkillDirectories = resumeSkillDirs, Tools = new List<Microsoft.Extensions.AI.AIFunction> { ShowImageTool.CreateFunction() }, OnPermissionRequest = AutoApprovePermissions, InfiniteSessions = new InfiniteSessionConfig { Enabled = true } };
         var copilotSession = await GetClientForGroup(groupId).ResumeSessionAsync(sessionId, resumeConfig, cancellationToken);
 
         // Detect session ID mismatch: the persistent server may return a different


### PR DESCRIPTION
## Summary

Two fixes for MCP server availability:

### 1. MCP servers missing on lazy-resumed sessions
When sessions are lazily resumed after app restart, the `ResumeSessionConfig` was missing `McpServers` and `SkillDirectories`. This meant MCP tools (e.g., WorkIQ, Maestro) were unavailable until the user manually ran `/mcp reload`.

**Fix:** Load MCP servers and skill directories in `EnsureSessionConnectedAsync` before creating the resume config. Also applied to the fresh-session fallback path.

### 2. `/mcp reload` crashes on mobile
The command tried to access the local SDK session which doesn't exist in remote mode, throwing `InvalidOperationException`. The guard existed in `CopilotService` but the UI called through without checking first.

**Fix:** Guard in `Dashboard.razor` before calling `ReloadMcpServersAsync`, showing a friendly message.

## Test plan
- [x] `LazyResumePath_IncludesMcpServersAndSkills` — structural test verifying MCP servers in both resume and fallback configs
- [x] Full suite: 3320 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)