### PR TITLE
feat: build PolyPilot against local copilot-sdk from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ launchSettings.json
 
 ## .NET
 *.binlog
+Directory.Build.props.local
 
 ## Test results
 **/TestResults/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,4 +3,8 @@
     <!-- GitHub.Copilot.SDK's DownloadFile timeout is interpreted in milliseconds. -->
     <CopilotCliDownloadTimeout Condition="'$(CopilotCliDownloadTimeout)' == ''">600000</CopilotCliDownloadTimeout>
   </PropertyGroup>
+
+  <!-- Local-only build overrides (for example, a source checkout of copilot-sdk)
+       live in Directory.Build.props.local, which is gitignored. -->
+  <Import Project="Directory.Build.props.local" Condition="Exists('Directory.Build.props.local')" />
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,15 @@
+<Project>
+  <ItemGroup Condition="'$(CopilotSdkProjectPath)' != ''">
+    <PackageReference Remove="GitHub.Copilot.SDK" />
+    <ProjectReference Include="$(CopilotSdkProjectPath)" />
+  </ItemGroup>
+
+  <Target Name="_ValidateLocalCopilotSdkProject"
+          BeforeTargets="CollectPackageReferences;ResolveReferences"
+          Condition="'$(CopilotSdkProjectPath)' != ''">
+    <Error Condition="!Exists('$(CopilotSdkProjectPath)')"
+           Text="CopilotSdkProjectPath points to '$(CopilotSdkProjectPath)', but that project file was not found. Update Directory.Build.props.local or remove the override." />
+    <Message Importance="High"
+             Text="Using local GitHub.Copilot.SDK project reference: $(CopilotSdkProjectPath)" />
+  </Target>
+</Project>

--- a/use-local-sdk.sh
+++ b/use-local-sdk.sh
@@ -25,11 +25,33 @@
 #   1. Edit code in the copilot-sdk/dotnet/src/ directory
 #   2. Re-run ./use-local-sdk.sh (rebuilds + re-packs automatically)
 #   3. Build PolyPilot normally (dotnet build or ./relaunch.sh)
+#
+# NOTE: This modifies nuget.config and csproj files with machine-specific paths.
+#   These changes are marked --assume-unchanged so they won't appear in git status.
+#   Use --revert to undo all changes cleanly.
 
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOCAL_VERSION="0.3.0-local"
+
+# Cross-platform sed -i (BSD vs GNU)
+sedi() {
+    if sed --version 2>/dev/null | grep -q GNU; then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
+}
+
+MODIFIED_FILES=(
+    nuget.config
+    PolyPilot/PolyPilot.csproj
+    PolyPilot.Tests/PolyPilot.Tests.csproj
+    PolyPilot.Provider.Abstractions/PolyPilot.Provider.Abstractions.csproj
+    PolyPilot.Gtk/PolyPilot.Gtk.csproj
+    PolyPilot.Console/PolyPilot.csproj
+)
 
 # Resolve SDK path: argument > env var > default sibling directory
 if [ "$1" != "--revert" ] && [ -n "$1" ]; then
@@ -44,12 +66,11 @@ NUPKG_DIR="$SDK_DIR/dotnet/nupkg"
 if [ "$1" = "--revert" ]; then
     echo "⏪ Reverting to NuGet package..."
     cd "$SCRIPT_DIR"
-    git checkout -- nuget.config \
-        PolyPilot/PolyPilot.csproj \
-        PolyPilot.Tests/PolyPilot.Tests.csproj \
-        PolyPilot.Provider.Abstractions/PolyPilot.Provider.Abstractions.csproj \
-        PolyPilot.Gtk/PolyPilot.Gtk.csproj \
-        PolyPilot.Console/PolyPilot.csproj 2>/dev/null || true
+    # Unmark files before reverting so git checkout works
+    for f in "${MODIFIED_FILES[@]}"; do
+        git update-index --no-assume-unchanged "$f" 2>/dev/null || true
+    done
+    git checkout -- "${MODIFIED_FILES[@]}"
     rm -rf ~/.nuget/packages/github.copilot.sdk/$LOCAL_VERSION
     echo "✅ Reverted to NuGet SDK. Run 'dotnet restore' to re-resolve."
     exit 0
@@ -73,7 +94,7 @@ echo "📦 Building local Copilot SDK..."
 echo "   Source: $SDK_DIR (branch: $(cd "$SDK_DIR" && git branch --show-current 2>/dev/null || echo 'detached'))"
 cd "$SDK_DIR/dotnet"
 rm -rf nupkg
-dotnet pack src/GitHub.Copilot.SDK.csproj -c Debug -o ./nupkg -p:Version=$LOCAL_VERSION --nologo 2>&1 | tail -3
+dotnet pack src/GitHub.Copilot.SDK.csproj -c Debug -o ./nupkg -p:Version=$LOCAL_VERSION --nologo
 
 if [ ! -f "$NUPKG_DIR/GitHub.Copilot.SDK.$LOCAL_VERSION.nupkg" ]; then
     echo "❌ Pack failed — nupkg not found"
@@ -85,34 +106,41 @@ cd "$SCRIPT_DIR"
 
 # Update nuget.config — add local source if not present
 if ! grep -q "local-sdk" nuget.config; then
-    sed -i '' '/<clear \/>/a\
+    sedi '/<clear \/>/a\
     <add key="local-sdk" value="'"$NUPKG_DIR"'" />' nuget.config
-    sed -i '' '/<packageSourceMapping>/a\
+    sedi '/<packageSourceMapping>/a\
     <packageSource key="local-sdk">\
       <package pattern="GitHub.Copilot.SDK" />\
     </packageSource>' nuget.config
 else
     # Update the path in case SDK location changed
-    sed -i '' 's|key="local-sdk" value="[^"]*"|key="local-sdk" value="'"$NUPKG_DIR"'"|' nuget.config
+    sedi 's|key="local-sdk" value="[^"]*"|key="local-sdk" value="'"$NUPKG_DIR"'"|' nuget.config
 fi
 
 # Update all csproj files
-for f in PolyPilot/PolyPilot.csproj PolyPilot.Tests/PolyPilot.Tests.csproj \
-         PolyPilot.Provider.Abstractions/PolyPilot.Provider.Abstractions.csproj \
-         PolyPilot.Gtk/PolyPilot.Gtk.csproj PolyPilot.Console/PolyPilot.csproj; do
-    if [ -f "$f" ]; then
-        sed -i '' 's/GitHub.Copilot.SDK" Version="[^"]*"/GitHub.Copilot.SDK" Version="'"$LOCAL_VERSION"'"/g' "$f"
+for f in "${MODIFIED_FILES[@]}"; do
+    if [ -f "$f" ] && [ "$f" != "nuget.config" ]; then
+        sedi 's/GitHub.Copilot.SDK" Version="[^"]*"/GitHub.Copilot.SDK" Version="'"$LOCAL_VERSION"'"/g' "$f"
     fi
+done
+
+# Mark modified files as assume-unchanged so they don't appear in git status
+# and can't be accidentally committed with machine-specific paths
+for f in "${MODIFIED_FILES[@]}"; do
+    git update-index --assume-unchanged "$f" 2>/dev/null || true
 done
 
 # Clear cached local package so dotnet picks up the fresh build
 rm -rf ~/.nuget/packages/github.copilot.sdk/$LOCAL_VERSION
 
 echo "🔄 Restoring..."
-dotnet restore PolyPilot/PolyPilot.csproj --force --nologo 2>&1 | tail -3
+dotnet restore PolyPilot/PolyPilot.csproj --force --nologo
 
 echo ""
 echo "✅ PolyPilot now uses local Copilot SDK ($LOCAL_VERSION)"
 echo "   SDK source: $SDK_DIR"
 echo "   To rebuild after SDK changes: ./use-local-sdk.sh $([ "$SDK_DIR" != "$SCRIPT_DIR/../copilot-sdk" ] && echo "$SDK_DIR")"
 echo "   To revert to NuGet:           ./use-local-sdk.sh --revert"
+echo ""
+echo "⚠️  Modified files are hidden from git status (--assume-unchanged)."
+echo "   Do NOT commit while local SDK is active. Use --revert first."

--- a/use-local-sdk.sh
+++ b/use-local-sdk.sh
@@ -3,7 +3,8 @@
 #
 # Usage:
 #   ./use-local-sdk.sh [path-to-sdk]    # Switch to local SDK
-#   ./use-local-sdk.sh --revert         # Switch back to NuGet package
+#   ./use-local-sdk.sh --revert         # Switch back to NuGet package safely
+#   ./use-local-sdk.sh --force-revert   # Discard local edits to modified files
 #
 # The SDK path defaults to ../copilot-sdk (sibling directory). Override with:
 #   ./use-local-sdk.sh /path/to/copilot-sdk
@@ -34,6 +35,9 @@ set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOCAL_VERSION="0.3.0-local"
+STATE_DIR="$SCRIPT_DIR/.git/use-local-sdk"
+BACKUP_DIR="$STATE_DIR/original"
+APPLIED_DIR="$STATE_DIR/applied"
 
 # Cross-platform sed -i (BSD vs GNU)
 sedi() {
@@ -42,6 +46,17 @@ sedi() {
     else
         sed -i '' "$@"
     fi
+}
+
+escape_sed_replacement() {
+    printf '%s' "$1" | sed 's/[&|]/\\&/g'
+}
+
+copy_to_state_dir() {
+    local src="$1"
+    local dest_root="$2"
+    mkdir -p "$dest_root/$(dirname "$src")"
+    cp "$src" "$dest_root/$src"
 }
 
 MODIFIED_FILES=(
@@ -54,7 +69,7 @@ MODIFIED_FILES=(
 )
 
 # Resolve SDK path: argument > env var > default sibling directory
-if [ "$1" != "--revert" ] && [ -n "$1" ]; then
+if [ "$1" != "--revert" ] && [ "$1" != "--force-revert" ] && [ -n "$1" ]; then
     SDK_DIR="$1"
 elif [ -n "$COPILOT_SDK_PATH" ]; then
     SDK_DIR="$COPILOT_SDK_PATH"
@@ -63,14 +78,45 @@ else
 fi
 NUPKG_DIR="$SDK_DIR/dotnet/nupkg"
 
-if [ "$1" = "--revert" ]; then
+if [ "$1" = "--revert" ] || [ "$1" = "--force-revert" ]; then
+    FORCE_REVERT=false
+    if [ "$1" = "--force-revert" ]; then
+        FORCE_REVERT=true
+    fi
+
     echo "⏪ Reverting to NuGet package..."
     cd "$SCRIPT_DIR"
-    # Unmark files before reverting so git checkout works
+
+    if [ ! -d "$BACKUP_DIR" ]; then
+        echo "❌ No local SDK backup state found in $STATE_DIR"
+        echo "   Refusing to blindly reset tracked files."
+        echo "   If you really want to discard changes manually, review them first and use git yourself."
+        exit 1
+    fi
+
+    # Unmark files before restoring so git sees them normally again
     for f in "${MODIFIED_FILES[@]}"; do
         git update-index --no-assume-unchanged "$f" 2>/dev/null || true
     done
-    git checkout -- "${MODIFIED_FILES[@]}"
+
+    if [ "$FORCE_REVERT" != "true" ]; then
+        for f in "${MODIFIED_FILES[@]}"; do
+            if [ -f "$APPLIED_DIR/$f" ] && [ -f "$f" ] && ! cmp -s "$f" "$APPLIED_DIR/$f"; then
+                echo "❌ Refusing to revert because '$f' has changed since local SDK was activated."
+                echo "   Commit or stash those edits first, or run './use-local-sdk.sh --force-revert' to discard them."
+                exit 1
+            fi
+        done
+    fi
+
+    for f in "${MODIFIED_FILES[@]}"; do
+        if [ -f "$BACKUP_DIR/$f" ]; then
+            mkdir -p "$(dirname "$f")"
+            cp "$BACKUP_DIR/$f" "$f"
+        fi
+    done
+
+    rm -rf "$STATE_DIR"
     rm -rf ~/.nuget/packages/github.copilot.sdk/$LOCAL_VERSION
     echo "✅ Reverted to NuGet SDK. Run 'dotnet restore' to re-resolve."
     exit 0
@@ -104,6 +150,16 @@ fi
 echo "🔧 Updating PolyPilot references..."
 cd "$SCRIPT_DIR"
 
+rm -rf "$STATE_DIR"
+mkdir -p "$BACKUP_DIR" "$APPLIED_DIR"
+for f in "${MODIFIED_FILES[@]}"; do
+    if [ -f "$f" ]; then
+        copy_to_state_dir "$f" "$BACKUP_DIR"
+    fi
+done
+
+ESCAPED_NUPKG_DIR="$(escape_sed_replacement "$NUPKG_DIR")"
+
 # Update nuget.config — add local source if not present
 if ! grep -q "local-sdk" nuget.config; then
     sedi '/<clear \/>/a\
@@ -114,13 +170,20 @@ if ! grep -q "local-sdk" nuget.config; then
     </packageSource>' nuget.config
 else
     # Update the path in case SDK location changed
-    sedi 's|key="local-sdk" value="[^"]*"|key="local-sdk" value="'"$NUPKG_DIR"'"|' nuget.config
+    sedi 's|key="local-sdk" value="[^"]*"|key="local-sdk" value="'"$ESCAPED_NUPKG_DIR"'"|' nuget.config
 fi
 
 # Update all csproj files
 for f in "${MODIFIED_FILES[@]}"; do
     if [ -f "$f" ] && [ "$f" != "nuget.config" ]; then
         sedi 's/GitHub.Copilot.SDK" Version="[^"]*"/GitHub.Copilot.SDK" Version="'"$LOCAL_VERSION"'"/g' "$f"
+    fi
+done
+
+# Save the exact script-generated state so --revert can detect later user edits safely.
+for f in "${MODIFIED_FILES[@]}"; do
+    if [ -f "$f" ]; then
+        copy_to_state_dir "$f" "$APPLIED_DIR"
     fi
 done
 
@@ -141,6 +204,7 @@ echo "✅ PolyPilot now uses local Copilot SDK ($LOCAL_VERSION)"
 echo "   SDK source: $SDK_DIR"
 echo "   To rebuild after SDK changes: ./use-local-sdk.sh $([ "$SDK_DIR" != "$SCRIPT_DIR/../copilot-sdk" ] && echo "$SDK_DIR")"
 echo "   To revert to NuGet:           ./use-local-sdk.sh --revert"
+echo "   To discard local edits too:   ./use-local-sdk.sh --force-revert"
 echo ""
 echo "⚠️  Modified files are hidden from git status (--assume-unchanged)."
 echo "   Do NOT commit while local SDK is active. Use --revert first."

--- a/use-local-sdk.sh
+++ b/use-local-sdk.sh
@@ -85,6 +85,9 @@ if [ ! -f "$SDK_PROJECT" ]; then
     exit 1
 fi
 
+# Canonicalize to absolute path so MSBuild resolves it correctly from any project directory
+SDK_PROJECT="$(cd "$(dirname "$SDK_PROJECT")" && pwd)/$(basename "$SDK_PROJECT")"
+
 cd "$SCRIPT_DIR"
 
 cat > "$OVERRIDE_FILE" <<EOF

--- a/use-local-sdk.sh
+++ b/use-local-sdk.sh
@@ -1,210 +1,109 @@
 #!/bin/bash
-# Builds PolyPilot against a local source build of the Copilot SDK.
+# Opt in to building PolyPilot against a local copilot-sdk checkout via ProjectReference.
 #
 # Usage:
-#   ./use-local-sdk.sh [path-to-sdk]    # Switch to local SDK
-#   ./use-local-sdk.sh --revert         # Switch back to NuGet package safely
-#   ./use-local-sdk.sh --force-revert   # Discard local edits to modified files
+#   ./use-local-sdk.sh [path-to-sdk]    # Create/update Directory.Build.props.local
+#   ./use-local-sdk.sh --revert         # Remove the local override
+#   ./use-local-sdk.sh --help           # Show help
 #
-# The SDK path defaults to ../copilot-sdk (sibling directory). Override with:
+# The SDK path defaults to ../copilot-sdk (a sibling directory). Override with:
 #   ./use-local-sdk.sh /path/to/copilot-sdk
 #   COPILOT_SDK_PATH=/path/to/copilot-sdk ./use-local-sdk.sh
 #
-# First-time setup:
-#   git clone https://github.com/github/copilot-sdk.git ../copilot-sdk
-#   # Or use PureWeen's fork with PolyPilot-specific fixes:
-#   git clone https://github.com/PureWeen/copilot-sdk.git ../copilot-sdk
-#   cd ../copilot-sdk && git checkout upstream_validation
-#
-# What it does:
-#   1. Packs the local SDK as a NuGet package (version 0.3.0-local)
-#   2. Adds a local NuGet source to nuget.config
-#   3. Updates all csproj references to 0.3.0-local
-#   4. Clears NuGet cache to force re-resolve
-#
-# To iterate on SDK changes:
-#   1. Edit code in the copilot-sdk/dotnet/src/ directory
-#   2. Re-run ./use-local-sdk.sh (rebuilds + re-packs automatically)
-#   3. Build PolyPilot normally (dotnet build or ./relaunch.sh)
-#
-# NOTE: This modifies nuget.config and csproj files with machine-specific paths.
-#   These changes are marked --assume-unchanged so they won't appear in git status.
-#   Use --revert to undo all changes cleanly.
+# This is compile-time only: it changes which GitHub.Copilot.SDK project PolyPilot builds
+# against. Runtime CLI selection still comes from PolyPilot settings (Global vs Built-in).
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-LOCAL_VERSION="0.3.0-local"
-STATE_DIR="$SCRIPT_DIR/.git/use-local-sdk"
-BACKUP_DIR="$STATE_DIR/original"
-APPLIED_DIR="$STATE_DIR/applied"
+OVERRIDE_FILE="$SCRIPT_DIR/Directory.Build.props.local"
 
-# Cross-platform sed -i (BSD vs GNU)
-sedi() {
-    if sed --version 2>/dev/null | grep -q GNU; then
-        sed -i "$@"
+usage() {
+    cat <<EOF
+Build PolyPilot against a local copilot-sdk checkout from source.
+
+Usage:
+  ./use-local-sdk.sh [path-to-sdk]
+  ./use-local-sdk.sh --revert
+
+Examples:
+  ./use-local-sdk.sh
+  ./use-local-sdk.sh /Users/you/Projects/copilot-sdk
+  COPILOT_SDK_PATH=/Users/you/src/copilot-sdk ./use-local-sdk.sh
+
+What this does:
+  - writes a gitignored Directory.Build.props.local file
+  - sets CopilotSdkProjectPath to the local GitHub.Copilot.SDK.csproj
+  - runs dotnet restore so PolyPilot starts building the SDK from source
+
+What it does NOT do:
+  - it does not modify tracked csproj files or nuget.config
+  - it does not change PolyPilot's runtime CLI source (Global vs Built-in)
+EOF
+}
+
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    usage
+    exit 0
+fi
+
+if [ "$1" = "--revert" ]; then
+    echo "Removing local copilot-sdk override..."
+    cd "$SCRIPT_DIR"
+
+    if [ -f "$OVERRIDE_FILE" ]; then
+        rm "$OVERRIDE_FILE"
+        dotnet restore PolyPilot.slnx --force --nologo
+        echo "Done. PolyPilot is back to the normal package-based SDK reference."
     else
-        sed -i '' "$@"
+        echo "No Directory.Build.props.local file was present. Nothing to do."
     fi
-}
 
-escape_sed_replacement() {
-    printf '%s' "$1" | sed 's/[&|]/\\&/g'
-}
+    exit 0
+fi
 
-copy_to_state_dir() {
-    local src="$1"
-    local dest_root="$2"
-    mkdir -p "$dest_root/$(dirname "$src")"
-    cp "$src" "$dest_root/$src"
-}
-
-MODIFIED_FILES=(
-    nuget.config
-    PolyPilot/PolyPilot.csproj
-    PolyPilot.Tests/PolyPilot.Tests.csproj
-    PolyPilot.Provider.Abstractions/PolyPilot.Provider.Abstractions.csproj
-    PolyPilot.Gtk/PolyPilot.Gtk.csproj
-    PolyPilot.Console/PolyPilot.csproj
-)
-
-# Resolve SDK path: argument > env var > default sibling directory
-if [ "$1" != "--revert" ] && [ "$1" != "--force-revert" ] && [ -n "$1" ]; then
+if [ -n "$1" ]; then
     SDK_DIR="$1"
 elif [ -n "$COPILOT_SDK_PATH" ]; then
     SDK_DIR="$COPILOT_SDK_PATH"
 else
     SDK_DIR="$SCRIPT_DIR/../copilot-sdk"
 fi
-NUPKG_DIR="$SDK_DIR/dotnet/nupkg"
 
-if [ "$1" = "--revert" ] || [ "$1" = "--force-revert" ]; then
-    FORCE_REVERT=false
-    if [ "$1" = "--force-revert" ]; then
-        FORCE_REVERT=true
-    fi
+SDK_PROJECT="$SDK_DIR/dotnet/src/GitHub.Copilot.SDK.csproj"
 
-    echo "⏪ Reverting to NuGet package..."
-    cd "$SCRIPT_DIR"
-
-    if [ ! -d "$BACKUP_DIR" ]; then
-        echo "❌ No local SDK backup state found in $STATE_DIR"
-        echo "   Refusing to blindly reset tracked files."
-        echo "   If you really want to discard changes manually, review them first and use git yourself."
-        exit 1
-    fi
-
-    # Unmark files before restoring so git sees them normally again
-    for f in "${MODIFIED_FILES[@]}"; do
-        git update-index --no-assume-unchanged "$f" 2>/dev/null || true
-    done
-
-    if [ "$FORCE_REVERT" != "true" ]; then
-        for f in "${MODIFIED_FILES[@]}"; do
-            if [ -f "$APPLIED_DIR/$f" ] && [ -f "$f" ] && ! cmp -s "$f" "$APPLIED_DIR/$f"; then
-                echo "❌ Refusing to revert because '$f' has changed since local SDK was activated."
-                echo "   Commit or stash those edits first, or run './use-local-sdk.sh --force-revert' to discard them."
-                exit 1
-            fi
-        done
-    fi
-
-    for f in "${MODIFIED_FILES[@]}"; do
-        if [ -f "$BACKUP_DIR/$f" ]; then
-            mkdir -p "$(dirname "$f")"
-            cp "$BACKUP_DIR/$f" "$f"
-        fi
-    done
-
-    rm -rf "$STATE_DIR"
-    rm -rf ~/.nuget/packages/github.copilot.sdk/$LOCAL_VERSION
-    echo "✅ Reverted to NuGet SDK. Run 'dotnet restore' to re-resolve."
-    exit 0
-fi
-
-# Validate SDK path
-if [ ! -d "$SDK_DIR/dotnet/src" ]; then
-    echo "❌ Copilot SDK not found at: $SDK_DIR"
-    echo ""
-    echo "Clone it first:"
+if [ ! -f "$SDK_PROJECT" ]; then
+    echo "Copilot SDK project not found at:"
+    echo "  $SDK_PROJECT"
+    echo
+    echo "Clone it first, for example:"
     echo "  git clone https://github.com/PureWeen/copilot-sdk.git $SDK_DIR"
     echo "  cd $SDK_DIR && git checkout upstream_validation"
-    echo ""
-    echo "Or specify a custom path:"
+    echo
+    echo "Or pass a custom path:"
     echo "  ./use-local-sdk.sh /path/to/copilot-sdk"
-    echo "  COPILOT_SDK_PATH=/path/to/sdk ./use-local-sdk.sh"
     exit 1
 fi
 
-echo "📦 Building local Copilot SDK..."
-echo "   Source: $SDK_DIR (branch: $(cd "$SDK_DIR" && git branch --show-current 2>/dev/null || echo 'detached'))"
-cd "$SDK_DIR/dotnet"
-rm -rf nupkg
-dotnet pack src/GitHub.Copilot.SDK.csproj -c Debug -o ./nupkg -p:Version=$LOCAL_VERSION --nologo
-
-if [ ! -f "$NUPKG_DIR/GitHub.Copilot.SDK.$LOCAL_VERSION.nupkg" ]; then
-    echo "❌ Pack failed — nupkg not found"
-    exit 1
-fi
-
-echo "🔧 Updating PolyPilot references..."
 cd "$SCRIPT_DIR"
 
-rm -rf "$STATE_DIR"
-mkdir -p "$BACKUP_DIR" "$APPLIED_DIR"
-for f in "${MODIFIED_FILES[@]}"; do
-    if [ -f "$f" ]; then
-        copy_to_state_dir "$f" "$BACKUP_DIR"
-    fi
-done
+cat > "$OVERRIDE_FILE" <<EOF
+<Project>
+  <PropertyGroup>
+    <!-- Local-only override generated by use-local-sdk.sh. This file is gitignored. -->
+    <CopilotSdkProjectPath>$SDK_PROJECT</CopilotSdkProjectPath>
+  </PropertyGroup>
+</Project>
+EOF
 
-ESCAPED_NUPKG_DIR="$(escape_sed_replacement "$NUPKG_DIR")"
+dotnet restore PolyPilot.slnx --force --nologo
 
-# Update nuget.config — add local source if not present
-if ! grep -q "local-sdk" nuget.config; then
-    sedi '/<clear \/>/a\
-    <add key="local-sdk" value="'"$NUPKG_DIR"'" />' nuget.config
-    sedi '/<packageSourceMapping>/a\
-    <packageSource key="local-sdk">\
-      <package pattern="GitHub.Copilot.SDK" />\
-    </packageSource>' nuget.config
-else
-    # Update the path in case SDK location changed
-    sedi 's|key="local-sdk" value="[^"]*"|key="local-sdk" value="'"$ESCAPED_NUPKG_DIR"'"|' nuget.config
-fi
-
-# Update all csproj files
-for f in "${MODIFIED_FILES[@]}"; do
-    if [ -f "$f" ] && [ "$f" != "nuget.config" ]; then
-        sedi 's/GitHub.Copilot.SDK" Version="[^"]*"/GitHub.Copilot.SDK" Version="'"$LOCAL_VERSION"'"/g' "$f"
-    fi
-done
-
-# Save the exact script-generated state so --revert can detect later user edits safely.
-for f in "${MODIFIED_FILES[@]}"; do
-    if [ -f "$f" ]; then
-        copy_to_state_dir "$f" "$APPLIED_DIR"
-    fi
-done
-
-# Mark modified files as assume-unchanged so they don't appear in git status
-# and can't be accidentally committed with machine-specific paths
-for f in "${MODIFIED_FILES[@]}"; do
-    git update-index --assume-unchanged "$f" 2>/dev/null || true
-done
-
-# Clear cached local package so dotnet picks up the fresh build
-rm -rf ~/.nuget/packages/github.copilot.sdk/$LOCAL_VERSION
-
-echo "🔄 Restoring..."
-dotnet restore PolyPilot/PolyPilot.csproj --force --nologo
-
-echo ""
-echo "✅ PolyPilot now uses local Copilot SDK ($LOCAL_VERSION)"
-echo "   SDK source: $SDK_DIR"
-echo "   To rebuild after SDK changes: ./use-local-sdk.sh $([ "$SDK_DIR" != "$SCRIPT_DIR/../copilot-sdk" ] && echo "$SDK_DIR")"
-echo "   To revert to NuGet:           ./use-local-sdk.sh --revert"
-echo "   To discard local edits too:   ./use-local-sdk.sh --force-revert"
-echo ""
-echo "⚠️  Modified files are hidden from git status (--assume-unchanged)."
-echo "   Do NOT commit while local SDK is active. Use --revert first."
+echo
+echo "PolyPilot is now configured to build GitHub.Copilot.SDK from source:"
+echo "  $SDK_PROJECT"
+echo
+echo "This only affects compile-time references."
+echo "Runtime CLI selection still comes from PolyPilot settings."
+echo
+echo "To switch back to the package reference later:"
+echo "  ./use-local-sdk.sh --revert"


### PR DESCRIPTION
## What

Adds a zero-config way to build PolyPilot against a local copilot-sdk checkout from source, using a gitignored `Directory.Build.props.local` override instead of rewriting tracked files.

## How it works

1. `Directory.Build.props` imports `Directory.Build.props.local` if it exists
2. `Directory.Build.targets` checks for `CopilotSdkProjectPath` — if set, it removes the `GitHub.Copilot.SDK` package reference and adds a `ProjectReference` to the local SDK project instead
3. `use-local-sdk.sh` writes/removes that local override file
4. `Directory.Build.props.local` is gitignored — no tracked files are modified

## Usage

```bash
# Activate local SDK (defaults to ../copilot-sdk)
./use-local-sdk.sh

# Or with a custom path
./use-local-sdk.sh /path/to/copilot-sdk

# Revert to NuGet package
./use-local-sdk.sh --revert
```

This only affects the **compile-time SDK reference**. Runtime CLI selection (Global vs Built-in) still comes from PolyPilot settings.

## What changed from the original approach

The original version used `sed` to rewrite tracked `nuget.config` and `.csproj` files, packed a local nupkg, and used `--assume-unchanged` to hide the changes. That was fragile and platform-specific.

The new version:
- writes a single gitignored file (`Directory.Build.props.local`)
- uses MSBuild's native `ProjectReference` swap via `Directory.Build.targets`
- does not modify any tracked files
- does not pack a local nupkg — builds the SDK from source alongside PolyPilot
