### PR TITLE
fix: skip provider sessions during SDK reconnect

### DIFF
--- a/PolyPilot.Tests/ConnectionRecoveryTests.cs
+++ b/PolyPilot.Tests/ConnectionRecoveryTests.cs
@@ -280,6 +280,10 @@ public class ConnectionRecoveryTests
         Assert.True(skipIndex > loopIndex,
             "Sibling reconnect loop must skip provider/virtual sessions before attempting ResumeSessionAsync");
 
+        var forceCompleteIndex = source.IndexOf("ForceCompleteProcessingAsync(kvp.Key", loopIndex, StringComparison.Ordinal);
+        Assert.True(forceCompleteIndex > skipIndex,
+            "Provider-session skip must appear before ForceCompleteProcessingAsync in the sibling reconnect path");
+
         var resumeIndex = source.IndexOf("ResumeSessionAsync(", loopIndex, StringComparison.Ordinal);
         Assert.True(resumeIndex > skipIndex,
             "Provider-session skip must appear before ResumeSessionAsync in the sibling reconnect path");

--- a/PolyPilot.Tests/ConnectionRecoveryTests.cs
+++ b/PolyPilot.Tests/ConnectionRecoveryTests.cs
@@ -264,6 +264,27 @@ public class ConnectionRecoveryTests
             "client.CreateSessionAsync (Session not found fallback) must be after client = _client refresh");
     }
 
+    [Fact]
+    public void SendPromptAsync_SiblingReconnect_SkipsProviderAndVirtualSessions()
+    {
+        // STRUCTURAL REGRESSION GUARD: when the shared SDK client is recreated after a
+        // JSON-RPC transport loss, the sibling re-resume loop must skip provider sessions.
+        // Their synthetic SessionId values are for persistence only and are invalid for
+        // session.resume, which otherwise causes Papilot sessions to break after reconnect.
+        var source = File.ReadAllText(Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.cs"));
+
+        var loopIndex = source.IndexOf("foreach (var kvp in _sessions)", StringComparison.Ordinal);
+        Assert.True(loopIndex > 0, "Could not find sibling reconnect loop");
+
+        var skipIndex = source.IndexOf("if (otherState.Session == null || IsProviderSession(kvp.Key))", loopIndex, StringComparison.Ordinal);
+        Assert.True(skipIndex > loopIndex,
+            "Sibling reconnect loop must skip provider/virtual sessions before attempting ResumeSessionAsync");
+
+        var resumeIndex = source.IndexOf("ResumeSessionAsync(", loopIndex, StringComparison.Ordinal);
+        Assert.True(resumeIndex > skipIndex,
+            "Provider-session skip must appear before ResumeSessionAsync in the sibling reconnect path");
+    }
+
     // ===== Regression: Fresh session after "Session not found" must include MCP servers & skills =====
     // When the JSON-RPC connection is lost and the server-side session has expired,
     // SendPromptAsync falls back to creating a fresh session via CreateSessionAsync.

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -3637,6 +3637,15 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
                                             if (kvp.Key == sessionName) continue;
                                             var otherState = kvp.Value;
                                             if (string.IsNullOrEmpty(otherState.Info.SessionId)) continue;
+                                            // Provider/virtual sessions are not backed by the SDK client that
+                                            // was just recreated. Their SessionId values are persistence keys,
+                                            // not CLI-resumable session IDs, so trying to ResumeSessionAsync
+                                            // them produces invalid-session errors and can destabilize recovery.
+                                            if (otherState.Session == null || IsProviderSession(kvp.Key))
+                                            {
+                                                Debug($"[RECONNECT] Skipping non-SDK sibling '{kvp.Key}' during client recreation");
+                                                continue;
+                                            }
                                             // INV-O14: IsProcessing siblings have dead event streams —
                                             // their CopilotSession was tied to the old client which was
                                             // just disposed. Force-abort so the orchestrator retries


### PR DESCRIPTION
## Summary
- skip provider and other virtual sessions when recreating the shared Copilot SDK client after a JSON-RPC disconnect
- avoid invalid `session.resume` calls against synthetic provider session IDs like `provider:papilot:leader`
- add a regression guard covering the sibling reconnect path

## Why
When the Copilot CLI transport dropped, PolyPilot tried to re-resume Papilot provider sessions using their persistence-only IDs. Those are not real CLI session IDs, so reconnect recovery could cascade into more errors and leave provider chats looking broken.

## Testing
- /opt/homebrew/bin/dotnet test PolyPilot.Tests/PolyPilot.Tests.csproj --no-restore --filter "ConnectionRecoveryTests"