### PR TITLE
fix: fail fast when bundled copilot is missing

### DIFF
--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -292,7 +292,8 @@ jobs:
               --options runtime --timestamp \
               "$COPILOT_BIN"
           else
-            echo "Warning: copilot binary not found at $COPILOT_BIN"
+            echo "::error::Bundled copilot binary not found at $COPILOT_BIN"
+            exit 1
           fi
 
           # Re-sign all dylibs (inside-out)


### PR DESCRIPTION
## What

Fail the Mac Catalyst release workflow immediately if the bundled `copilot` binary is missing from the app bundle, instead of only warning and continuing to package a broken artifact.

## Why

This addresses the leftover actionable review feedback from #556:

- stops CI from wasting time packaging/uploading an invalid build
- surfaces the real error early and explicitly
- avoids a misleading late `codesign` failure (`No such file or directory`)

## Testing

- validated the workflow YAML parses cleanly
- verified the diff is limited to the fail-fast guard in `.github/workflows/release-apps.yml`

Related context: #556
