### PR TITLE
fix: preserve stale shell fingerprint across CompleteResponse

### DIFF
--- a/PolyPilot.Tests/SessionStabilityTests.cs
+++ b/PolyPilot.Tests/SessionStabilityTests.cs
@@ -139,7 +139,7 @@ public class SessionStabilityTests
     {
         // ForceCompleteProcessingAsync must delegate to ClearProcessingState rather than
         // manually clearing fields. ClearProcessingState calls ClearDeferredIdleTracking
-        // internally (without preserveCarryOver, which is only needed in SendPromptAsync).
+        // with preserveCarryOver: true so stale shell fingerprints survive across turns.
         var source = File.ReadAllText(TestPaths.OrganizationCs);
         var method = ExtractMethod(source, "Task ForceCompleteProcessingAsync");
 

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -797,7 +797,7 @@ public partial class CopilotService : IAsyncDisposable
         Interlocked.Exchange(ref state.SendingFlag, 0);
         Interlocked.Exchange(ref state.ActiveToolCallCount, 0);
         state.HasUsedToolsThisTurn = false;
-        ClearDeferredIdleTracking(state);
+        ClearDeferredIdleTracking(state, preserveCarryOver: true);
         Interlocked.Exchange(ref state.SuccessfulToolCountThisTurn, 0);
         Interlocked.Exchange(ref state.ToolHealthStaleChecks, 0);
         Interlocked.Exchange(ref state.EventCountThisTurn, 0);


### PR DESCRIPTION
## What

One-line fix: `ClearProcessingState` now uses `preserveCarryOver: true` when clearing deferred idle tracking, matching what `SendPromptAsync` already does.

## Why

When the CLI leaks stale shell entries in `backgroundTasks` across turns (issue #573), the carryover detection (`ShouldIgnoreCarryOverShellOnlyTasks`) should recognize them as old and skip the IDLE-DEFER. But `ClearProcessingState` was wiping the fingerprint and firstSeenTicks on every turn completion, so the next turn saw the same stale shells as brand-new and deferred for ~10 minutes every time.

## The bug path

1. Turn completes → `CompleteResponse` → `ClearProcessingState` → wipes `DeferredBackgroundTaskFingerprint` and `FirstSeenTicks`
2. User sends new message → `SendPromptAsync` calls `ClearDeferredIdleTracking(preserveCarryOver: true)` — but the data is already gone
3. `session.idle` arrives with `shells=2` (stale from CLI)
4. `RefreshDeferredBackgroundTaskTracking` sees `previousTicks=0`, sets `firstSeenTicks = now`
5. `ShouldIgnoreCarryOverShellOnlyTasks` checks `firstSeenTicks < processingStartedAt` — **false** (both are ~now)
6. IDLE-DEFER kicks in, watchdog eventually force-completes after ~10 min

## The fix

`preserveCarryOver: true` in `ClearProcessingState` keeps the shell fingerprint and age across the complete→send boundary, so step 5 correctly detects the shells as carried over and skips the defer.

## Testing

- 3323/3323 tests pass
- Specifically verified `BackgroundTasksIdleTests`, `ProcessingWatchdogTests`, and `ChatExperienceSafetyTests` (254 targeted tests)
