### PR TITLE
fix: remove broad home-directory read-only entitlement

### DIFF
--- a/PolyPilot/Platforms/MacCatalyst/Entitlements.AppStore.plist
+++ b/PolyPilot/Platforms/MacCatalyst/Entitlements.AppStore.plist
@@ -20,14 +20,6 @@
         <key>com.apple.security.files.user-selected.read-write</key>
         <true/>
 
-        <!-- File access: read-only access to the user's home directory.
-             Required for reading ~/.copilot/ (session state), git repos,
-             and spawning the copilot CLI from its bundled location. -->
-        <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
-        <array>
-            <string>/</string>
-        </array>
-
         <!-- File access: read-write to app-specific data directories.
              ~/.polypilot/ stores settings, organization, active-sessions.
              ~/.copilot/ stores SDK session state (events.jsonl). -->


### PR DESCRIPTION
Apple review rejected the read-only temporary-exception for '/' (entire home directory). Removed it. The app still has user-selected.read-write for picker-opened files and specific read-write access to ~/.polypilot/ and ~/.copilot/.