### PR TITLE
Fix context menus rendering behind floating sidebar toolbar

### DIFF
--- a/PolyPilot/Components/Layout/SessionListItem.razor.css
+++ b/PolyPilot/Components/Layout/SessionListItem.razor.css
@@ -811,7 +811,6 @@
     display: inline-flex;
     gap: 0.14rem;
     align-self: auto;
-    z-index: 2;
 }
 
 .session-context-ring {

--- a/PolyPilot/Components/Layout/SessionSidebar.razor
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor
@@ -77,7 +77,7 @@ else if (IsFlyoutPanel)
 }
 else
 {
-    <div class="sidebar-content desktop-sidebar @(IsDesktopRailMode ? "desktop-rail-mode" : "desktop-expanded-mode") @(IsSupportPanelOpen ? "support-open" : "")">
+    <div class="sidebar-content desktop-sidebar @(IsDesktopRailMode ? "desktop-rail-mode" : "desktop-expanded-mode") @(IsSupportPanelOpen ? "support-open" : "") @(openMenuSession != null || openGroupMenuId != null ? "has-open-menu" : "")">
         <div class="sidebar-header desktop-shell">
             <div class="sidebar-header-row">
                 <a href="/" class="header-logo-link header-brand @(currentPage == "/" || currentPage == "/dashboard" ? "active" : "")"

--- a/PolyPilot/Components/Layout/SessionSidebar.razor.css
+++ b/PolyPilot/Components/Layout/SessionSidebar.razor.css
@@ -2623,6 +2623,11 @@
     transform: translateY(0);
 }
 
+.sidebar-header:has(.header-overflow:hover),
+.sidebar-header:has(.header-overflow:focus-within) {
+    z-index: 50;
+}
+
 .header-overflow-panel::before {
     content: "";
     position: absolute;
@@ -4649,6 +4654,13 @@
 
 .sidebar-top-tools {
     z-index: 24;
+}
+
+.has-open-menu ::deep .sidebar-top-tools,
+.has-open-menu ::deep .sidebar-compose-panel,
+.has-open-menu ::deep .sidebar-organize-shell-compact,
+.has-open-menu ::deep .sidebar-support-fab {
+    z-index: auto;
 }
 
 .sidebar-create-popover {


### PR DESCRIPTION
## Problem
Context menus (session right-click, group `⋯` menu, header `⋯` overflow) render **behind** the floating sidebar toolbar buttons (New, Manual sort, refresh, filter chips).

## Root Cause
Multiple positioned elements with explicit `z-index` values create **stacking contexts** that trap descendant `position: fixed` menus — even though the menus have `z-index: 10000`, they can't escape a parent stacking context with a lower z-index.

## Fix
- **Session/group context menus:** Add `has-open-menu` CSS class to `sidebar-content` when any menu is open. Collapse stacking contexts on toolbar elements (`sidebar-top-tools`, `sidebar-compose-panel`, `sidebar-organize-shell-compact`, `sidebar-support-fab`) to `z-index: auto` — buttons stay visible but the menu paints on top.
- **Header overflow menu:** Use `:has()` to bump `.sidebar-header` from z-index 3 → 50 when the overflow is hovered/focused.
- **Cleanup:** Remove unnecessary `z-index: 2` from `.session-actions`.