### PR TITLE
fix: route orchestrator messages through dispatch pipeline even with image attachments

### DIFF
--- a/PolyPilot.Tests/MultiAgentRegressionTests.cs
+++ b/PolyPilot.Tests/MultiAgentRegressionTests.cs
@@ -2942,8 +2942,8 @@ public class MultiAgentRegressionTests
         // When PolyPilot restarts mid-reflect-loop, the persisted ReflectionState
         // has IsActive=true. After resume completes (MonitorAndSynthesizeAsync),
         // the code must reset IsActive=false so StartGroupReflection can create
-        // fresh state on the next user prompt. This test verifies the model-level
-        // behavior: an active ReflectionState can be detected and reset.
+        // fresh state on the next user prompt. The StartedAt guard ensures we only
+        // reset the stale cycle, not a fresh one created by the user.
         var group = new SessionGroup
         {
             Id = Guid.NewGuid().ToString(),
@@ -2958,12 +2958,16 @@ public class MultiAgentRegressionTests
         Assert.True(group.ReflectionState.IsActive);
         Assert.Null(group.ReflectionState.CompletedAt);
 
+        // Capture StartedAt as the production code does (from PendingOrchestration)
+        var staleStartedAt = group.ReflectionState.StartedAt;
+
         // Simulate what ResumeOrchestrationIfPendingAsync does after resume completes:
-        // detect stale IsActive=true and reset it
-        if (group.ReflectionState is { IsActive: true })
+        // detect stale IsActive=true and reset it (with StartedAt guard)
+        if (group.ReflectionState is { IsActive: true } rs
+            && (staleStartedAt == default || rs.StartedAt <= staleStartedAt))
         {
-            group.ReflectionState.IsActive = false;
-            group.ReflectionState.CompletedAt = DateTime.Now;
+            rs.IsActive = false;
+            rs.CompletedAt = DateTime.Now;
         }
 
         Assert.False(group.ReflectionState.IsActive);
@@ -2990,17 +2994,56 @@ public class MultiAgentRegressionTests
         group.ReflectionState.GoalMet = true;
         var originalCompleted = DateTime.Now.AddMinutes(-10);
         group.ReflectionState.CompletedAt = originalCompleted;
+        var staleStartedAt = group.ReflectionState.StartedAt;
 
         // Simulate resume check — should NOT match because IsActive is false
-        if (group.ReflectionState is { IsActive: true })
+        if (group.ReflectionState is { IsActive: true } rs
+            && (staleStartedAt == default || rs.StartedAt <= staleStartedAt))
         {
-            group.ReflectionState.IsActive = false;
-            group.ReflectionState.CompletedAt = DateTime.Now;
+            rs.IsActive = false;
+            rs.CompletedAt = DateTime.Now;
         }
 
         // CompletedAt should remain the original value
         Assert.Equal(originalCompleted, group.ReflectionState.CompletedAt);
         Assert.True(group.ReflectionState.GoalMet);
+    }
+
+    [Fact]
+    public void ReflectionState_FreshCycleNotResetByStaleResume()
+    {
+        // Sequential TOCTOU guard: if the user sends a new prompt (creating a fresh
+        // ReflectionState) before the queued InvokeOnUI callback fires, the callback
+        // must NOT reset the fresh cycle. The StartedAt comparison prevents this.
+        var group = new SessionGroup
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "TestOrchestrator",
+            IsMultiAgent = true,
+            OrchestratorMode = MultiAgentMode.OrchestratorReflect,
+            ReflectionState = ReflectionCycle.Create("Original goal", maxIterations: 5)
+        };
+
+        // Capture stale StartedAt (simulates PendingOrchestration.StartedAt)
+        var staleStartedAt = DateTime.Now.AddMinutes(-5);
+
+        // Simulate user sending a new prompt → StartGroupReflection creates fresh state
+        group.ReflectionState = ReflectionCycle.Create("New goal", maxIterations: 3);
+        Assert.True(group.ReflectionState.IsActive);
+        Assert.True(group.ReflectionState.StartedAt > staleStartedAt);
+
+        // Simulate the queued InvokeOnUI callback firing AFTER the fresh cycle was created
+        if (group.ReflectionState is { IsActive: true } rs
+            && (staleStartedAt == default || rs.StartedAt <= staleStartedAt))
+        {
+            rs.IsActive = false;
+            rs.CompletedAt = DateTime.Now;
+        }
+
+        // Fresh cycle should NOT have been reset
+        Assert.True(group.ReflectionState.IsActive);
+        Assert.Null(group.ReflectionState.CompletedAt);
+        Assert.Equal("New goal", group.ReflectionState.Goal);
     }
 
     #endregion

--- a/PolyPilot.Tests/MultiAgentRegressionTests.cs
+++ b/PolyPilot.Tests/MultiAgentRegressionTests.cs
@@ -2933,4 +2933,75 @@ public class MultiAgentRegressionTests
     }
 
     #endregion
+
+    #region ReflectionState Reset After Resume (PR #590)
+
+    [Fact]
+    public void ReflectionState_StaleActiveState_CanBeResetAfterResume()
+    {
+        // When PolyPilot restarts mid-reflect-loop, the persisted ReflectionState
+        // has IsActive=true. After resume completes (MonitorAndSynthesizeAsync),
+        // the code must reset IsActive=false so StartGroupReflection can create
+        // fresh state on the next user prompt. This test verifies the model-level
+        // behavior: an active ReflectionState can be detected and reset.
+        var group = new SessionGroup
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "TestOrchestrator",
+            IsMultiAgent = true,
+            OrchestratorMode = MultiAgentMode.OrchestratorReflect,
+            ReflectionState = ReflectionCycle.Create("Fix all bugs", maxIterations: 10)
+        };
+
+        // Simulate mid-loop state (iteration 3, still active)
+        group.ReflectionState.CurrentIteration = 3;
+        Assert.True(group.ReflectionState.IsActive);
+        Assert.Null(group.ReflectionState.CompletedAt);
+
+        // Simulate what ResumeOrchestrationIfPendingAsync does after resume completes:
+        // detect stale IsActive=true and reset it
+        if (group.ReflectionState is { IsActive: true })
+        {
+            group.ReflectionState.IsActive = false;
+            group.ReflectionState.CompletedAt = DateTime.Now;
+        }
+
+        Assert.False(group.ReflectionState.IsActive);
+        Assert.NotNull(group.ReflectionState.CompletedAt);
+        // Iteration count preserved (not reset — that's RetryOrchestration's job)
+        Assert.Equal(3, group.ReflectionState.CurrentIteration);
+    }
+
+    [Fact]
+    public void ReflectionState_AlreadyInactive_NotModifiedOnResume()
+    {
+        // If ReflectionState is already inactive (completed normally before restart),
+        // the resume path should not touch it.
+        var group = new SessionGroup
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "TestOrchestrator",
+            IsMultiAgent = true,
+            OrchestratorMode = MultiAgentMode.OrchestratorReflect,
+            ReflectionState = ReflectionCycle.Create("Fix all bugs", maxIterations: 5)
+        };
+
+        group.ReflectionState.IsActive = false;
+        group.ReflectionState.GoalMet = true;
+        var originalCompleted = DateTime.Now.AddMinutes(-10);
+        group.ReflectionState.CompletedAt = originalCompleted;
+
+        // Simulate resume check — should NOT match because IsActive is false
+        if (group.ReflectionState is { IsActive: true })
+        {
+            group.ReflectionState.IsActive = false;
+            group.ReflectionState.CompletedAt = DateTime.Now;
+        }
+
+        // CompletedAt should remain the original value
+        Assert.Equal(originalCompleted, group.ReflectionState.CompletedAt);
+        Assert.True(group.ReflectionState.GoalMet);
+    }
+
+    #endregion
 }

--- a/PolyPilot.Tests/MultiAgentRegressionTests.cs
+++ b/PolyPilot.Tests/MultiAgentRegressionTests.cs
@@ -3015,6 +3015,8 @@ public class MultiAgentRegressionTests
         // Sequential TOCTOU guard: if the user sends a new prompt (creating a fresh
         // ReflectionState) before the queued InvokeOnUI callback fires, the callback
         // must NOT reset the fresh cycle. The StartedAt comparison prevents this.
+        // Uses DateTime.UtcNow to match PendingOrchestration.StartedAt (UTC clock),
+        // then converts to local to match ReflectionCycle.StartedAt (local clock).
         var group = new SessionGroup
         {
             Id = Guid.NewGuid().ToString(),
@@ -3024,8 +3026,10 @@ public class MultiAgentRegressionTests
             ReflectionState = ReflectionCycle.Create("Original goal", maxIterations: 5)
         };
 
-        // Capture stale StartedAt (simulates PendingOrchestration.StartedAt)
-        var staleStartedAt = DateTime.Now.AddMinutes(-5);
+        // Capture stale StartedAt as UTC (simulates PendingOrchestration.StartedAt)
+        // then normalize to local time (as the production code does)
+        var pendingStartedAtUtc = DateTime.UtcNow.AddMinutes(-5);
+        var staleStartedAt = pendingStartedAtUtc.ToLocalTime();
 
         // Simulate user sending a new prompt → StartGroupReflection creates fresh state
         group.ReflectionState = ReflectionCycle.Create("New goal", maxIterations: 3);

--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -1932,19 +1932,21 @@
                     if (imgSession != null)
                     {
                         imgSession.History.Add(ChatMessage.SystemMessage(
-                            "⚠️ Images stripped for orchestration — images are not forwarded to workers. The text prompt is dispatched normally."));
+                            "⚠️ Images dropped — orchestration dispatch does not support image attachments. Only the text prompt is dispatched to the orchestrator and workers."));
                         imgSession.MessageCount = imgSession.History.Count;
                     }
                 }
-                AutoStartReflectionIfNeeded(group!.Id, finalPrompt);
-                _ = CopilotService.SendToMultiAgentGroupAsync(group!.Id, finalPrompt).ContinueWith(t =>
+                var groupId = group!.Id;
+                var groupName = group.Name;
+                AutoStartReflectionIfNeeded(groupId, finalPrompt);
+                _ = CopilotService.SendToMultiAgentGroupAsync(groupId, finalPrompt).ContinueWith(t =>
                 {
                     if (t.IsFaulted)
                     {
                         var msg = t.Exception?.InnerException?.Message ?? t.Exception?.Message ?? "unknown";
                         InvokeAsync(() =>
                         {
-                            CopilotService.LogDispatchError($"[DISPATCH] Error sending to multi-agent group '{group!.Name}': {msg}");
+                            CopilotService.LogDispatchError($"[DISPATCH] Error sending to multi-agent group '{groupName}': {msg}");
                             var s = sessions.FirstOrDefault(s => s.Name == sessionName);
                             if (s != null)
                             {

--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -1935,6 +1935,10 @@
                             "⚠️ Images dropped — orchestration dispatch does not support image attachments. Only the text prompt is dispatched to the orchestrator and workers."));
                         imgSession.MessageCount = imgSession.History.Count;
                     }
+                    foreach (var p in imagePaths)
+                    {
+                        try { File.Delete(p); } catch { }
+                    }
                 }
                 var groupId = group!.Id;
                 var groupName = group.Name;

--- a/PolyPilot/Components/Pages/Dashboard.razor
+++ b/PolyPilot/Components/Pages/Dashboard.razor
@@ -1919,8 +1919,23 @@
             // Diagnostic: log every send attempt so we can trace routing failures
             CopilotService.LogDispatchRoute(sessionName, sessionMeta != null, group?.Name, group?.IsMultiAgent, group?.OrchestratorMode, orchSession, isOrchestrator);
 
-            if (isOrchestrator && (imagePaths == null || imagePaths.Count == 0))
+            if (isOrchestrator)
             {
+                // Always route orchestrator messages through the dispatch pipeline,
+                // even when images are attached. Images are stripped (the pipeline
+                // doesn't forward them to workers) but the prompt still gets parsed
+                // for @worker blocks. Without this, image-bearing messages bypass
+                // dispatch entirely and @worker blocks in the response go nowhere.
+                if (imagePaths is { Count: > 0 })
+                {
+                    var imgSession = sessions.FirstOrDefault(s => s.Name == sessionName);
+                    if (imgSession != null)
+                    {
+                        imgSession.History.Add(ChatMessage.SystemMessage(
+                            "⚠️ Images stripped for orchestration — images are not forwarded to workers. The text prompt is dispatched normally."));
+                        imgSession.MessageCount = imgSession.History.Count;
+                    }
+                }
                 AutoStartReflectionIfNeeded(group!.Id, finalPrompt);
                 _ = CopilotService.SendToMultiAgentGroupAsync(group!.Id, finalPrompt).ContinueWith(t =>
                 {
@@ -1929,24 +1944,20 @@
                         var msg = t.Exception?.InnerException?.Message ?? t.Exception?.Message ?? "unknown";
                         InvokeAsync(() =>
                         {
-                            Console.WriteLine($"[DISPATCH] Error sending to multi-agent group: {msg}");
+                            CopilotService.LogDispatchError($"[DISPATCH] Error sending to multi-agent group '{group!.Name}': {msg}");
+                            var s = sessions.FirstOrDefault(s => s.Name == sessionName);
+                            if (s != null)
+                            {
+                                s.History.Add(ChatMessage.ErrorMessage($"Dispatch failed: {msg}"));
+                                s.MessageCount = s.History.Count;
+                            }
+                            _ = SafeRefreshAsync();
                         });
                     }
                 });
             }
             else
             {
-            // If this is an orchestrator but images are present, warn the user
-            if (isOrchestrator && imagePaths is { Count: > 0 })
-            {
-                var imgSession = sessions.FirstOrDefault(s => s.Name == sessionName);
-                if (imgSession != null)
-                {
-                    imgSession.History.Add(ChatMessage.SystemMessage(
-                        "⚠️ Images sent directly — orchestration routing does not support images yet."));
-                    imgSession.MessageCount = imgSession.History.Count;
-                }
-            }
             _ = CopilotService.SendPromptAsync(sessionName, finalPrompt, imagePaths, agentMode: agentMode).ContinueWith(t =>
             {
                 if (t.IsFaulted)

--- a/PolyPilot/Services/CopilotService.Organization.cs
+++ b/PolyPilot/Services/CopilotService.Organization.cs
@@ -3332,20 +3332,24 @@ public partial class CopilotService
 
         ClearPendingOrchestration();
 
-        // Reset the stale ReflectionState so StartGroupReflection can create
-        // fresh state on the next user prompt. Without this, the old IsActive=true
-        // from the killed reflect loop persists across restarts and
+        // Reset the stale ReflectionState on the UI thread so StartGroupReflection
+        // can create fresh state on the next user prompt. Without this, the old
+        // IsActive=true from the killed reflect loop persists across restarts and
         // StartGroupReflection returns early without resetting iteration counters.
-        var resumeGroup = Organization.Groups.FirstOrDefault(g => g.Id == pending.GroupId);
-        if (resumeGroup?.ReflectionState is { IsActive: true })
+        // Must run on UI thread: Organization.Groups is a plain List<T> (not thread-safe).
+        var pendingGroupId = pending.GroupId;
+        InvokeOnUI(() =>
         {
-            resumeGroup.ReflectionState.IsActive = false;
-            resumeGroup.ReflectionState.CompletedAt = DateTime.Now;
-            Debug($"[DISPATCH] Resume cleared stale ReflectionState for group '{resumeGroup.Name}' (was iteration {resumeGroup.ReflectionState.CurrentIteration})");
-            SaveOrganization();
-        }
-
-        InvokeOnUI(() => OnOrchestratorPhaseChanged?.Invoke(pending.GroupId, OrchestratorPhase.Complete, null));
+            var resumeGroup = Organization.Groups.FirstOrDefault(g => g.Id == pendingGroupId);
+            if (resumeGroup?.ReflectionState is { IsActive: true })
+            {
+                resumeGroup.ReflectionState.IsActive = false;
+                resumeGroup.ReflectionState.CompletedAt = DateTime.Now;
+                Debug($"[DISPATCH] Resume cleared stale ReflectionState for group '{resumeGroup.Name}' (was iteration {resumeGroup.ReflectionState.CurrentIteration})");
+                SaveOrganization();
+            }
+            OnOrchestratorPhaseChanged?.Invoke(pendingGroupId, OrchestratorPhase.Complete, null);
+        });
     }
 
     #endregion

--- a/PolyPilot/Services/CopilotService.Organization.cs
+++ b/PolyPilot/Services/CopilotService.Organization.cs
@@ -1647,6 +1647,16 @@ public partial class CopilotService
     }
 
     /// <summary>
+    /// Log dispatch errors to the diagnostics file (not just Console.WriteLine).
+    /// Called from Dashboard.razor's ContinueWith error handler so dispatch failures
+    /// are visible in event-diagnostics.log for post-mortem analysis.
+    /// </summary>
+    public void LogDispatchError(string message)
+    {
+        Debug(message);
+    }
+
+    /// <summary>
     /// Returns the group ID if the given session is an orchestrator in an active multi-agent group.
     /// Used by the message queue drain to route dequeued messages through the dispatch pipeline.
     /// </summary>
@@ -3321,6 +3331,20 @@ public partial class CopilotService
         }
 
         ClearPendingOrchestration();
+
+        // Reset the stale ReflectionState so StartGroupReflection can create
+        // fresh state on the next user prompt. Without this, the old IsActive=true
+        // from the killed reflect loop persists across restarts and
+        // StartGroupReflection returns early without resetting iteration counters.
+        var resumeGroup = Organization.Groups.FirstOrDefault(g => g.Id == pending.GroupId);
+        if (resumeGroup?.ReflectionState is { IsActive: true })
+        {
+            resumeGroup.ReflectionState.IsActive = false;
+            resumeGroup.ReflectionState.CompletedAt = DateTime.Now;
+            Debug($"[DISPATCH] Resume cleared stale ReflectionState for group '{resumeGroup.Name}' (was iteration {resumeGroup.ReflectionState.CurrentIteration})");
+            SaveOrganization();
+        }
+
         InvokeOnUI(() => OnOrchestratorPhaseChanged?.Invoke(pending.GroupId, OrchestratorPhase.Complete, null));
     }
 

--- a/PolyPilot/Services/CopilotService.Organization.cs
+++ b/PolyPilot/Services/CopilotService.Organization.cs
@@ -3341,7 +3341,9 @@ public partial class CopilotService
         // prompt between ClearPendingOrchestration() and the InvokeOnUI callback,
         // StartGroupReflection creates a fresh cycle with a different StartedAt.
         var pendingGroupId = pending.GroupId;
-        var staleStartedAt = pending.StartedAt;
+        var staleStartedAt = pending.StartedAt.Kind == DateTimeKind.Utc
+            ? pending.StartedAt.ToLocalTime()
+            : pending.StartedAt;
         InvokeOnUI(() =>
         {
             var resumeGroup = Organization.Groups.FirstOrDefault(g => g.Id == pendingGroupId);

--- a/PolyPilot/Services/CopilotService.Organization.cs
+++ b/PolyPilot/Services/CopilotService.Organization.cs
@@ -3337,15 +3337,20 @@ public partial class CopilotService
         // IsActive=true from the killed reflect loop persists across restarts and
         // StartGroupReflection returns early without resetting iteration counters.
         // Must run on UI thread: Organization.Groups is a plain List<T> (not thread-safe).
+        // Capture StartedAt to guard against sequential TOCTOU: if the user sends a new
+        // prompt between ClearPendingOrchestration() and the InvokeOnUI callback,
+        // StartGroupReflection creates a fresh cycle with a different StartedAt.
         var pendingGroupId = pending.GroupId;
+        var staleStartedAt = pending.StartedAt;
         InvokeOnUI(() =>
         {
             var resumeGroup = Organization.Groups.FirstOrDefault(g => g.Id == pendingGroupId);
-            if (resumeGroup?.ReflectionState is { IsActive: true })
+            if (resumeGroup?.ReflectionState is { IsActive: true } rs
+                && (staleStartedAt == default || rs.StartedAt == null || rs.StartedAt <= staleStartedAt))
             {
-                resumeGroup.ReflectionState.IsActive = false;
-                resumeGroup.ReflectionState.CompletedAt = DateTime.Now;
-                Debug($"[DISPATCH] Resume cleared stale ReflectionState for group '{resumeGroup.Name}' (was iteration {resumeGroup.ReflectionState.CurrentIteration})");
+                rs.IsActive = false;
+                rs.CompletedAt = DateTime.Now;
+                Debug($"[DISPATCH] Resume cleared stale ReflectionState for group '{resumeGroup.Name}' (was iteration {rs.CurrentIteration})");
                 SaveOrganization();
             }
             OnOrchestratorPhaseChanged?.Invoke(pendingGroupId, OrchestratorPhase.Complete, null);

--- a/PolyPilot/Services/CopilotService.Organization.cs
+++ b/PolyPilot/Services/CopilotService.Organization.cs
@@ -3007,6 +3007,33 @@ public partial class CopilotService
     internal static void ClearPendingOrchestrationForTest() => ClearPendingOrchestration();
 
     /// <summary>
+    /// Clear pending orchestration file AND reset any stale ReflectionState on the UI thread.
+    /// All early-exit and completion paths in the resume flow must call this instead of bare
+    /// ClearPendingOrchestration() to avoid leaving ReflectionState.IsActive=true persisted.
+    /// </summary>
+    private void ClearPendingOrchestrationAndResetState(PendingOrchestration pending)
+    {
+        ClearPendingOrchestration();
+        var pendingGroupId = pending.GroupId;
+        var staleStartedAt = pending.StartedAt.Kind == DateTimeKind.Utc
+            ? pending.StartedAt.ToLocalTime()
+            : pending.StartedAt;
+        InvokeOnUI(() =>
+        {
+            var resumeGroup = Organization.Groups.FirstOrDefault(g => g.Id == pendingGroupId);
+            if (resumeGroup?.ReflectionState is { IsActive: true } rs
+                && (staleStartedAt == default || rs.StartedAt == null || rs.StartedAt <= staleStartedAt))
+            {
+                rs.IsActive = false;
+                rs.CompletedAt = DateTime.Now;
+                Debug($"[DISPATCH] Resume cleared stale ReflectionState for group '{resumeGroup.Name}' (was iteration {rs.CurrentIteration})");
+                SaveOrganization();
+            }
+            OnOrchestratorPhaseChanged?.Invoke(pendingGroupId, OrchestratorPhase.Complete, null);
+        });
+    }
+
+    /// <summary>
     /// After session restore, check for a pending orchestration dispatch that was interrupted
     /// by an app relaunch. If found, monitor workers and auto-synthesize when all complete.
     /// </summary>
@@ -3019,7 +3046,7 @@ public partial class CopilotService
         if (group == null)
         {
             Debug($"[DISPATCH] Pending orchestration group '{pending.GroupId}' no longer exists — clearing");
-            ClearPendingOrchestration();
+            ClearPendingOrchestrationAndResetState(pending);
             return;
         }
 
@@ -3027,7 +3054,7 @@ public partial class CopilotService
         if (!_sessions.ContainsKey(pending.OrchestratorName))
         {
             Debug($"[DISPATCH] Pending orchestration orchestrator '{pending.OrchestratorName}' not found — clearing");
-            ClearPendingOrchestration();
+            ClearPendingOrchestrationAndResetState(pending);
             return;
         }
 
@@ -3051,8 +3078,7 @@ public partial class CopilotService
                 Debug($"[DISPATCH] Resume orchestration failed: {ex.Message}");
                 AddOrchestratorSystemMessage(pending.OrchestratorName,
                     $"⚠️ Failed to resume orchestration: {ex.Message}");
-                ClearPendingOrchestration();
-                InvokeOnUI(() => OnOrchestratorPhaseChanged?.Invoke(pending.GroupId, OrchestratorPhase.Complete, null));
+                ClearPendingOrchestrationAndResetState(pending);
             }
         });
     }
@@ -3086,8 +3112,7 @@ public partial class CopilotService
 
         if (ct.IsCancellationRequested)
         {
-            ClearPendingOrchestration();
-            InvokeOnUI(() => OnOrchestratorPhaseChanged?.Invoke(pending.GroupId, OrchestratorPhase.Complete, null));
+            ClearPendingOrchestrationAndResetState(pending);
             return;
         }
 
@@ -3241,8 +3266,7 @@ public partial class CopilotService
         {
             AddOrchestratorSystemMessage(pending.OrchestratorName,
                 "⚠️ No worker responses available after restart — orchestration aborted.");
-            ClearPendingOrchestration();
-            InvokeOnUI(() => OnOrchestratorPhaseChanged?.Invoke(pending.GroupId, OrchestratorPhase.Complete, null));
+            ClearPendingOrchestrationAndResetState(pending);
             return;
         }
 
@@ -3330,33 +3354,7 @@ public partial class CopilotService
                 $"⚠️ Failed to send synthesis: {ex.Message}");
         }
 
-        ClearPendingOrchestration();
-
-        // Reset the stale ReflectionState on the UI thread so StartGroupReflection
-        // can create fresh state on the next user prompt. Without this, the old
-        // IsActive=true from the killed reflect loop persists across restarts and
-        // StartGroupReflection returns early without resetting iteration counters.
-        // Must run on UI thread: Organization.Groups is a plain List<T> (not thread-safe).
-        // Capture StartedAt to guard against sequential TOCTOU: if the user sends a new
-        // prompt between ClearPendingOrchestration() and the InvokeOnUI callback,
-        // StartGroupReflection creates a fresh cycle with a different StartedAt.
-        var pendingGroupId = pending.GroupId;
-        var staleStartedAt = pending.StartedAt.Kind == DateTimeKind.Utc
-            ? pending.StartedAt.ToLocalTime()
-            : pending.StartedAt;
-        InvokeOnUI(() =>
-        {
-            var resumeGroup = Organization.Groups.FirstOrDefault(g => g.Id == pendingGroupId);
-            if (resumeGroup?.ReflectionState is { IsActive: true } rs
-                && (staleStartedAt == default || rs.StartedAt == null || rs.StartedAt <= staleStartedAt))
-            {
-                rs.IsActive = false;
-                rs.CompletedAt = DateTime.Now;
-                Debug($"[DISPATCH] Resume cleared stale ReflectionState for group '{resumeGroup.Name}' (was iteration {rs.CurrentIteration})");
-                SaveOrganization();
-            }
-            OnOrchestratorPhaseChanged?.Invoke(pendingGroupId, OrchestratorPhase.Complete, null);
-        });
+        ClearPendingOrchestrationAndResetState(pending);
     }
 
     #endregion


### PR DESCRIPTION
## Problem

When a user sends a message to an orchestrator session that includes image attachments, the dispatch pipeline was completely bypassed. The message went directly to the orchestrator's SDK session via SendPromptAsync, and the orchestrator's response (containing @worker blocks) was never parsed or dispatched to workers.

### Root Cause

Dashboard.razor line ~1922 had a guard that checked for empty imagePaths before routing through the dispatch pipeline. With images present, the code fell through to the direct send path, skipping SendToMultiAgentGroupAsync entirely.

## Changes

### Dashboard.razor
- Orchestrator messages always route through dispatch regardless of image attachments
- Images are stripped with a user-visible warning (SDK doesn't support image forwarding to workers)

### CopilotService.Organization.cs
- Added LogDispatchError method for persistent dispatch error logging
- Fixed ResumeOrchestrationIfPendingAsync to reset stale ReflectionState after resume completion

## Testing
All 3433 tests pass (12 pre-existing ExternalSessionScannerTests failures due to missing node).
