### PR TITLE
Strengthen no-test-message rule in review workflow

### DIFF
--- a/.github/agents/expert-reviewer.agent.md
+++ b/.github/agents/expert-reviewer.agent.md
@@ -388,7 +388,7 @@ Use this to prioritize dimensions based on changed files.
 
 > **Tool availability note**: Steps 5–7 reference gh-aw safe-output tools (`create_pull_request_review_comment`, `submit_pull_request_review`, `add_comment`). When running outside an agentic workflow (e.g. locally in VS Code), these tools are unavailable — use the closest GitHub MCP or CLI equivalents instead (e.g. `gh api` to create PR review comments, `gh pr review` to submit a review, `gh pr comment` to post general comments).
 
-> **🚨 Do NOT emit test or probe messages.** Never call `create_pull_request_review_comment` with placeholder text like "test inline comment" to verify the tool works. Every call posts a real comment on the PR. Call the tool only with final, production-quality review content.
+> **🚨 Do NOT emit test, probe, or placeholder messages.** Never call `create_pull_request_review_comment` or any safe-output tool with placeholder text like "test", "test inline comment", "hello", or any non-review content. Every safe-output call posts a real, permanent comment on the PR. There is no "dry run" — the tool is live. Call it only with final, production-quality review content. This rule applies to you AND to any sub-agents you invoke.
 
 5. **Validate line numbers before posting.** The `line` parameter in `create_pull_request_review_comment` must be a line number that appears **within a diff hunk** (`@@` block) of the PR diff. GitHub rejects comments on lines outside the diff with "Line could not be resolved", which causes the entire review submission to fail (all inline comments are lost).
 

--- a/.github/workflows/review.agent.md
+++ b/.github/workflows/review.agent.md
@@ -39,8 +39,10 @@ Review pull request #${{ github.event.pull_request.number || github.event.issue.
 
 ## Instructions
 
+> **🚨 No test messages.** Never call any safe-output tool (`create_pull_request_review_comment`, `submit_pull_request_review`, `add_comment`) with placeholder or test content like "test", "hello", or "test inline comment". Every call posts permanently on the PR. This applies to you and all sub-agents.
+
 1. Fetch the full diff for the pull request.
-2. Call the `expert-reviewer` agent. Make sure to call it as subagent (`task` tool, `agent_type: "general-purpose"`, `model: "claude-opus-4.6"`). And make sure to follow the guidance on subagent calls from within the `expert-reviewer` agent. We expect 2+ levels of agents to be called.
+2. Call the `expert-reviewer` agent. Make sure to call it as subagent (`task` tool, `agent_type: "general-purpose"`, `model: "claude-opus-4.6"`). Pass along the "no test messages" rule explicitly in your sub-agent prompt. We expect 2+ levels of agents to be called.
 3. Do **not** post comments or reviews yourself, except for the fallback in step 4 if the subagent posts nothing. The subagent will post its own comments using the available safe-output tools:
    - **Inline review comments** on specific diff lines via `create_pull_request_review_comment`
    - **Design-level concerns** (not tied to a line) via `add_comment`


### PR DESCRIPTION
The second review run on PR #527 was successful (all comments posted, review submitted) but still leaked one 'test' probe message from a sub-agent. This strengthens the prohibition at both levels.