### PR TITLE
Move multi-model dispatch to outer agent, per-dimension in expert-reviewer

### DIFF
--- a/.github/agents/expert-reviewer.agent.md
+++ b/.github/agents/expert-reviewer.agent.md
@@ -311,106 +311,68 @@ Use this to prioritize dimensions based on changed files.
 
 ## Review Execution
 
-> **🚨 MANDATORY: You MUST follow this execution plan step by step.** Do not skip steps. Do not combine steps. Do not do a "single-pass review" instead. The multi-model dispatch in Step 2 is NOT optional — it is the core of this review process. If you skip it, the review is invalid.
-
 > **🚨 No test messages.** Never call any safe-output tool with placeholder text like "test", "hello", or probe content. Every call posts permanently on the PR. This applies to you AND all sub-agents.
+
+You are a single-model expert reviewer. Apply the 12 review dimensions systematically. Return your findings as structured text — the orchestrator will handle consensus and posting.
 
 ### Step 1: Gather Context
 
-Run these commands (or equivalent) to collect the PR context:
-
+If not already provided in your prompt, run:
 ```
-gh pr view <number>                           # description, labels, linked issues
-gh pr diff <number>                           # full diff
-gh pr checks <number>                         # CI status
-gh pr view <number> --json reviews,comments   # existing review comments
-```
-
-Save the full diff text — you will pass it to each sub-agent in Step 2.
-
-### Step 2: Multi-Model Review (MANDATORY — do NOT skip)
-
-> **This step is the most important part of the entire review.** You MUST dispatch exactly 3 parallel sub-agents using the `task` tool. Each sub-agent reviews the PR independently with a different model for diverse perspectives. A single-pass review by one model is NOT acceptable.
-
-Dispatch **3 parallel sub-agents** via the `task` tool, each with `agent_type: "general-purpose"`:
-
-| Sub-agent | Model | Strength |
-|-----------|-------|----------|
-| Reviewer 1 | `claude-opus-4.6` | Deep reasoning, architecture, subtle logic bugs |
-| Reviewer 2 | `claude-sonnet-4.6` | Fast pattern matching, common bug classes, security |
-| Reviewer 3 | `gpt-5.3-codex` | Alternative perspective, edge cases |
-
-**Each sub-agent receives the same prompt** containing:
-1. The full PR diff (from Step 1)
-2. The PR description
-3. The complete Review Dimensions section from this document (all 12 dimensions)
-4. The Folder Hotspot Mapping
-5. These instructions:
-
-```
-You are an expert PolyPilot code reviewer. Review this PR diff for: regressions, security issues,
-bugs, data loss, race conditions, and code quality. Do NOT comment on style or formatting.
-
-Apply the review dimensions below, weighted by which files changed (see Folder Hotspot Mapping).
-
-For each finding, include:
-- File path and line number (must be within a @@ diff hunk — mark "outside diff" if not)
-- Severity: 🔴 CRITICAL, 🟡 MODERATE, 🟢 MINOR
-- What's wrong and why it matters
-- A concrete failing scenario (specific input, thread interleaving, or call sequence)
-
-If a dimension is clean, do not mention it. Only report actual findings.
-
-[paste all 12 Review Dimensions here]
-[paste Folder Hotspot Mapping here]
+gh pr diff <number>
+gh pr view <number> --json title,body
+gh pr checks <number>
+gh pr view <number> --json reviews,comments
 ```
 
-**Launch all 3 in parallel** (use `mode: "background"` or make all 3 `task` calls in a single response). Wait for all 3 to complete before proceeding.
+### Step 2: Classify and Map
 
-If a model is unavailable, proceed with the remaining models. If only 1 model ran, include all its findings with a ⚠️ LOW CONFIDENCE disclaimer.
+1. Map changed files to the [Folder Hotspot Mapping](#folder-hotspot-mapping).
+2. Identify which dimensions are relevant based on which files changed.
+3. For dimensions 1 (IsProcessing) and 10 (Watchdog), read the actual source files from the repo to get current field lists and timeout constants:
+   - `PolyPilot/Services/CopilotService.cs` — find `ClearProcessingState()` for the authoritative field list
+   - `PolyPilot/Services/CopilotService.Events.cs` — find `Watchdog` constants for timeout values
 
-### Step 3: Adversarial Consensus
+### Step 3: Per-Dimension Review
 
-After collecting all 3 sub-agent reviews, apply consensus:
+Launch **one sub-agent per relevant dimension** (`task` tool, `agent_type: "general-purpose"`, `model: "claude-sonnet-4.6"`). Each agent evaluates exactly one dimension against the full PR diff. Run in **parallel batches of 4**.
 
-1. **All 3 agree** on a finding → include it immediately
-2. **2/3 agree** → include it with the median severity
-3. **Only 1/3 flagged** a finding → share that finding with the other 2 models (dispatch 2 follow-up sub-agents via `task` tool) asking: "Reviewer X found this issue: [finding]. Do you agree or disagree? Explain why."
-   - If after the adversarial round, 2+ agree → include it
-   - If still only 1 → discard (note in informational section)
+Each sub-agent receives: the PR diff, PR description, the single dimension's rules and checklist, and the folder context.
 
-### Step 4: Validate Line Numbers
+Include verbatim in every sub-agent prompt:
 
-Before posting any inline comment, validate that the `line` parameter falls within a `@@` diff hunk:
-- Parse `@@ -old,len +new,len @@` — the comment's `line` must be within `[new, new+len)` for that file
-- **Lines outside any hunk will cause the ENTIRE review submission to fail** with "Line could not be resolved"
-- For findings on lines outside the diff → post via `add_comment` as a design-level concern
+> You evaluate **one dimension only**: $DimensionName.
+>
+> Report `$DimensionName — LGTM` when the dimension is genuinely clean.
+>
+> Report an ISSUE only when you can construct a **concrete failing scenario**: a specific thread interleaving, a specific null input, a specific call sequence that triggers the bug. No hypotheticals.
+>
+> Read the **PR diff**, not main — new files and methods only exist in the PR branch.
+>
+> **Line numbers**: Include the diff line number (new file side). Only reference lines within a `@@` diff hunk. Mark "outside diff" if not in a hunk.
+>
+> **Thread Safety**: identify every thread that reads/writes shared state. Map the timeline.
+> **IsProcessing**: verify `ClearProcessingState()` is called (atomically clears ~22 fields/operations).
+> **Correctness**: construct the exact input that fails.
+>
+> ```
+> $DimensionName — LGTM
+> ```
+> ```
+> $DimensionName — ISSUE
+> SEVERITY: BLOCKING | MAJOR | MODERATE | NIT
+> FILE: path/to/file.cs
+> LINES: 100-120 (must be within a @@ diff hunk; mark "outside diff" if not)
+> SCENARIO: <concrete trigger>
+> FINDING: <what breaks>
+> RECOMMENDATION: <fix>
+> ```
 
-### Step 5: Post Results
+### Step 4: Compile Results
 
-Post the review using safe-output tools:
+Collect all dimension sub-agent results. For each finding:
+- Include file path, line number, severity, scenario, and recommendation
+- Note which dimension flagged it
+- Mark findings on lines outside diff hunks as "outside diff — use add_comment"
 
-1. **Inline comments** — Use `create_pull_request_review_comment` for findings tied to specific diff lines. Format:
-   ```markdown
-   **[🔴 CRITICAL / 🟡 MODERATE / 🟢 MINOR] Category**
-
-   Description of the issue.
-
-   **Flagged by:** X/3 reviewers
-   **Scenario:** Concrete trigger
-   **Recommendation:** Fix suggestion
-   ```
-
-2. **Design-level concerns** — Use `add_comment` for findings not tied to a specific diff line (one comment, multiple bullets). Also use for findings where the code is outside the diff hunks.
-
-3. **Final verdict** — Use `submit_pull_request_review` with:
-   - Findings ranked by severity
-   - CI status: ✅ passing, ❌ failing (PR-specific), ⚠️ failing (pre-existing)
-   - Note if prior review comments were addressed
-   - Test coverage assessment: new code paths lacking tests?
-   - **Never mention specific model names** — refer to "Reviewer 1/2/3" or "X/3 reviewers"
-   - Recommended action: ✅ Approve, ⚠️ Request changes, or 🔴 Do not merge
-   - `event: "REQUEST_CHANGES"` if any CRITICAL/MODERATE issues; `event: "COMMENT"` otherwise
-   - **Never use APPROVE** — the agent must not count as a PR approval
-
-   All inline comments from step 5.1 are automatically bundled into this review submission.
+Return your complete findings as structured text. The orchestrator will handle consensus across models and posting to the PR.

--- a/.github/workflows/review.agent.lock.yml
+++ b/.github/workflows/review.agent.lock.yml
@@ -167,7 +167,6 @@ jobs:
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ env.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_EXPR_93C755A4: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -238,7 +237,6 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_EXPR_93C755A4: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -249,7 +247,6 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_EXPR_93C755A4: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -272,7 +269,6 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
-                GH_AW_EXPR_93C755A4: process.env.GH_AW_EXPR_93C755A4,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,

--- a/.github/workflows/review.agent.md
+++ b/.github/workflows/review.agent.md
@@ -38,20 +38,4 @@ imports:
 timeout-minutes: 90
 ---
 
-# Expert Code Review
-
-Review pull request #${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }} using the `expert-reviewer` agent defined at `.github/agents/expert-reviewer.agent.md`.
-
-## Instructions
-
-> **🚨 No test messages.** Never call any safe-output tool (`create_pull_request_review_comment`, `submit_pull_request_review`, `add_comment`) with placeholder or test content like "test", "hello", or "test inline comment". Every call posts permanently on the PR. This applies to you and all sub-agents.
-
-1. Fetch the full diff for the pull request.
-2. Call the `expert-reviewer` agent. Make sure to call it as subagent (`task` tool, `agent_type: "general-purpose"`, `model: "claude-opus-4.6"`). Pass along the "no test messages" rule explicitly in your sub-agent prompt. We expect 2+ levels of agents to be called.
-3. Do **not** post comments or reviews yourself, except for the fallback in step 4 if the subagent posts nothing. The subagent will post its own comments using the available safe-output tools:
-   - **Inline review comments** on specific diff lines via `create_pull_request_review_comment`
-   - **Design-level concerns** (not tied to a line) via `add_comment`
-   - **Final review verdict** (COMMENT or REQUEST_CHANGES) via `submit_pull_request_review`
-   - **Never use APPROVE** — the agent must not count as a PR approval. Use COMMENT for clean reviews.
-4. If the subagent does not post anything (e.g. no issues found), this is the only exception to step 3: post a brief fallback review using `submit_pull_request_review` with event `COMMENT` (not `APPROVE`). Do not use `add_comment` for this fallback.
-5. If the subagent posts inline comments but does **not** submit the final review verdict (e.g. due to a timeout or error), detect this by checking whether `submit_pull_request_review` was called. If not, submit a fallback review with event `COMMENT` summarizing that the review was partial and inline comments were posted.
+<!-- Orchestration instructions are in shared/review-shared.md -->

--- a/.github/workflows/shared/review-shared.md
+++ b/.github/workflows/shared/review-shared.md
@@ -25,4 +25,73 @@ safe-outputs:
     max: 5
 ---
 
-<!-- Body provided by shared/review-shared.md -->
+# Expert Code Review
+
+Review pull request #${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }} using the `expert-reviewer` agent defined at `.github/agents/expert-reviewer.agent.md`.
+
+> **🚨 No test messages.** Never call any safe-output tool with placeholder or test content. Every call posts permanently on the PR. This applies to you and all sub-agents.
+
+## Instructions
+
+You are the orchestrator. Your job is to dispatch **3 parallel expert-reviewer sub-agents** with different models, collect their results, synthesize a consensus, and post the final review. Follow these steps exactly.
+
+### Step 1: Gather Context
+
+Fetch the PR diff and save it — you will pass it to each sub-agent:
+
+```
+gh pr diff <number>
+gh pr view <number> --json title,body
+gh pr checks <number>
+```
+
+### Step 2: Dispatch 3 Parallel Expert Reviewers
+
+Launch **exactly 3 sub-agents in parallel** using the `task` tool. Each calls the `expert-reviewer` agent with a different model. All 3 must be launched — do not skip any.
+
+```
+task(agent_type: "general-purpose", model: "claude-opus-4.6", mode: "background",
+     description: "Reviewer 1: deep reasoning review",
+     prompt: "<full diff + PR description + instruction to follow .github/agents/expert-reviewer.agent.md>")
+
+task(agent_type: "general-purpose", model: "claude-sonnet-4.6", mode: "background",
+     description: "Reviewer 2: pattern matching review",
+     prompt: "<same diff + same PR description + same instruction>")
+
+task(agent_type: "general-purpose", model: "gpt-5.3-codex", mode: "background",
+     description: "Reviewer 3: alternative perspective review",
+     prompt: "<same diff + same PR description + same instruction>")
+```
+
+Each sub-agent prompt must include:
+- The full PR diff
+- The PR description
+- This instruction: "You are an expert PolyPilot code reviewer. Read and follow `.github/agents/expert-reviewer.agent.md` in this repo. Apply all review dimensions from that file. Return your findings as a structured list with severity, file, line, scenario, finding, and recommendation for each issue. Do NOT call any safe-output tools — just return your findings as text. Do NOT emit test messages."
+
+**Wait for all 3 to complete before proceeding.**
+
+### Step 3: Adversarial Consensus
+
+Collect findings from all 3 sub-agents and apply consensus:
+
+1. **3/3 agree** on a finding → include immediately
+2. **2/3 agree** → include with median severity
+3. **Only 1/3 flagged** → dispatch 2 follow-up sub-agents (the other 2 models) asking: "Reviewer X found this issue: [finding]. Do you agree or disagree? Explain why."
+   - If 2+ now agree → include
+   - If still 1/3 → discard (note as "discarded — single reviewer only")
+
+### Step 4: Validate Line Numbers
+
+Before posting inline comments, verify each `line` falls within a `@@` diff hunk for that file. Parse `@@ -old,len +new,len @@` — the line must be in `[new, new+len)`. Lines outside any hunk will cause the entire review to fail with "Line could not be resolved". For findings outside the diff, use `add_comment` instead.
+
+### Step 5: Post Results
+
+1. **Inline comments** — `create_pull_request_review_comment` for findings on diff lines. Include "Flagged by: X/3 reviewers" in each.
+2. **Design-level comment** — `add_comment` for findings outside the diff (one comment, multiple bullets).
+3. **Final verdict** — `submit_pull_request_review` with:
+   - Summary of all findings ranked by severity
+   - Methodology note: "3 independent reviewers with adversarial consensus"
+   - CI status, test coverage assessment, prior review status
+   - Never mention specific model names — use "Reviewer 1/2/3"
+   - `event: "REQUEST_CHANGES"` if any 🔴 CRITICAL or 🟡 MODERATE; `event: "COMMENT"` otherwise
+   - **Never use APPROVE**


### PR DESCRIPTION
Restructures the review architecture to ensure multi-model review always happens:

**Before:** Outer agent → single expert-reviewer → expert-reviewer told to dispatch 3 models (inconsistently followed)

**After:** Outer agent dispatches 3 expert-reviewers with different models → each does per-dimension analysis → outer agent runs consensus → posts results

Modeled after dotnet/msbuild's proven pattern where orchestration is in the workflow body.