### PR TITLE
fix: TurnEnd fallback checks events.jsonl freshness before completing

### DIFF
--- a/.claude/skills/processing-state-safety/SKILL.md
+++ b/.claude/skills/processing-state-safety/SKILL.md
@@ -192,7 +192,7 @@ When `ReconcileOrganization` hasn't run yet (during `IsRestoring` window),
 during this window must call `ReconcileOrganization(allowPruning: false)` first.
 This additive mode safely adds missing entries without pruning loading sessions.
 
-### INV-10: TurnEnd fallback must not be permanently suppressed (PR #332)
+### INV-10: TurnEnd fallback must not be permanently suppressed (PR #332, #619)
 The `AssistantTurnEndEvent` 4s fallback → `CompleteResponse` guards against
 premature firing during multi-tool sessions. **Do NOT** use `HasUsedToolsThisTurn`
 to skip this fallback entirely — that permanently disables recovery for all
@@ -206,7 +206,20 @@ event is dropped (SDK bug #299), the session sticks for 600s.
 `AssistantTurnStartEvent` is the correct mechanism to prevent premature firing
 when the LLM does multi-round tool use.
 
-### INV-11: Watchdog must distinguish active tools from lost events (PR #332)
+**Live-event-stream gap (PR #619)**: `ToolExecutionStartEvent` may not be
+delivered via the live SDK event stream even though the CLI is actively executing
+a tool (the event only appears in `events.jsonl`). This causes `ActiveToolCallCount`
+to stay at 0 during tool execution. After the 30s extended wait, two additional
+guards prevent premature completion:
+1. **events.jsonl freshness** (`TurnEndFallbackFreshnessSeconds = 30`): If the
+   file was written after the wait started AND recently, defer with a 15s recheck
+   (`TurnEndFallbackRecheckMs`), then defer to the watchdog if still fresh.
+2. **Last-event-type check**: `GetLastEventType()` reads the last line of
+   `events.jsonl`. If it's `tool.execution_start` (no matching
+   `tool.execution_complete`), a tool IS running — defer to watchdog regardless
+   of file age. This handles long-running tools (e.g., `read_bash delay:600`).
+
+### INV-11: Watchdog must distinguish active tools from lost events (PR #332, #619)
 Blindly waiting the full 600s tool timeout when `ActiveToolCallCount == 0`
 (tools finished) is wrong — the SDK may have silently dropped the terminal event
 (`SessionIdleEvent`). The watchdog timeout path must use a 3-way branch:
@@ -215,6 +228,11 @@ Blindly waiting the full 600s tool timeout when `ActiveToolCallCount == 0`
   (TCP port check). If alive → reset `LastEventAtTicks` and continue. If dead → fall through to kill.
 - **Case B** (`!hasActiveTool && HasUsedToolsThisTurn && !exceededMaxTime`): Call
   `CompleteResponse` cleanly (no error message) then `break`. Lost terminal event scenario.
+  **Pre-check (PR #619)**: Before running Case B logic, check `GetLastEventType()` on
+  `events.jsonl`. If the last event is `tool.execution_start`, a tool IS running even
+  though `ActiveToolCallCount == 0` (live event not delivered). Reset `LastEventAtTicks`
+  and `continue` — same as Case A server-alive behavior. This allows tools of any
+  duration to complete without premature session completion.
 - **Case C** (default): Kill with "⚠️ Session appears stuck" error message. Max time
   exceeded, server dead, or something genuinely wrong.
 

--- a/.claude/skills/processing-state-safety/SKILL.md
+++ b/.claude/skills/processing-state-safety/SKILL.md
@@ -414,7 +414,7 @@ When a session shows "Thinking..." indefinitely:
 ## Regression History
 
 10 PRs of fix/regression cycles: #141 → #147 → #148 → #153 → #158 → #163 → #164 → #276 → #284 → #332.
-Additional safety PRs: #373 (orphaned state guards), #375 (premature idle re-arm), #399 (IDLE-DEFER for background tasks), #472 (poll-then-resume + IDLE-DEFER-REARM + model selection).
+Additional safety PRs: #373 (orphaned state guards), #375 (premature idle re-arm), #399 (IDLE-DEFER for background tasks), #472 (poll-then-resume + IDLE-DEFER-REARM + model selection), #612 (CompleteResponse generation increment), #619 (TurnEnd fallback events.jsonl freshness + last-event-type guard).
 See `references/regression-history.md` for the full timeline with root causes.
 
 ---

--- a/.claude/skills/processing-state-safety/SKILL.md
+++ b/.claude/skills/processing-state-safety/SKILL.md
@@ -229,10 +229,11 @@ Blindly waiting the full 600s tool timeout when `ActiveToolCallCount == 0`
 - **Case B** (`!hasActiveTool && HasUsedToolsThisTurn && !exceededMaxTime`): Call
   `CompleteResponse` cleanly (no error message) then `break`. Lost terminal event scenario.
   **Pre-check (PR #619)**: Before running Case B logic, check `GetLastEventType()` on
-  `events.jsonl`. If the last event is `tool.execution_start`, a tool IS running even
-  though `ActiveToolCallCount == 0` (live event not delivered). Reset `LastEventAtTicks`
-  and `continue` — same as Case A server-alive behavior. This allows tools of any
-  duration to complete without premature session completion.
+  `events.jsonl`. If the last event is `tool.execution_start` AND the server is alive,
+  a tool IS running even though `ActiveToolCallCount == 0` (live event not delivered).
+  Reset `LastEventAtTicks` and `continue` — similar to Case A server-alive behavior
+  (bounded by `exceededMaxTime` at 60 min). If the server is dead, skip the pre-check
+  and let normal Case B recovery handle it (~30s).
 - **Case C** (default): Kill with "⚠️ Session appears stuck" error message. Max time
   exceeded, server dead, or something genuinely wrong.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -308,6 +308,10 @@ The processing watchdog (`RunProcessingWatchdogAsync` in `CopilotService.Events.
   - The session was resumed mid-turn after app restart (`IsResumed`)
   - Tools have been used this turn (`HasUsedToolsThisTurn`) — even between tool rounds when the model is thinking
 
+**Live-event-stream gap (PR #619)**: `ToolExecutionStartEvent` may not be delivered via the live SDK event stream even though the CLI is actively executing a tool (the event only appears in `events.jsonl`). This causes `ActiveToolCallCount` to remain 0 during tool execution. Two mechanisms compensate:
+1. **TurnEnd fallback**: After the 34s extended wait, checks `GetLastEventType()` on `events.jsonl`. If the last event is `tool.execution_start`, defers to the watchdog instead of completing prematurely. Also checks `events.jsonl` freshness (`TurnEndFallbackFreshnessSeconds = 30`) with a 15s recheck (`TurnEndFallbackRecheckMs`).
+2. **Watchdog Case B pre-check**: Before running Case B completion logic, checks `GetLastEventType()`. If `tool.execution_start`, resets the inactivity timer and continues — same as Case A server-alive behavior. This allows tools of any duration to complete.
+
 For multi-agent sessions, Case B also checks **file-size-growth**: if events.jsonl hasn't grown for `WatchdogCaseBMaxStaleChecks` (2) consecutive deferrals, the session is force-completed — the connection is dead. This catches `ConnectionLostException` scenarios where mtime stays fresh but no new data arrives, reducing detection from 30+ min to ~360s (3 cycles: 1 baseline + 2 stale checks). The 1800s freshness window is preserved.
 
 Note: `session.idle` is an ephemeral event (`ephemeral: true` in the SDK schema) — it is delivered over the live event stream but intentionally NOT written to `events.jsonl`. When `session.idle` includes active `backgroundTasks` (sub-agents, shells), the IDLE-DEFER logic defers completion until a subsequent idle arrives with empty/null backgroundTasks. In rare cases where `IsProcessing` was already cleared (by watchdog timeout or reconnect) before the deferred idle arrives, the session may appear stuck until the watchdog fires again — see issue #403.
@@ -330,6 +334,8 @@ The event diagnostics log (`~/.polypilot/event-diagnostics.log`) uses these tags
 - `[BRIDGE-COMPLETE]` — bridge OnTurnEnd cleared IsProcessing
 - `[INTERRUPTED]` — app restart detected interrupted turn (watchdog timeout after resume)
 - `[WATCHDOG]` — watchdog clearing IsResumed or timing out a stuck session
+- `[IDLE-FALLBACK]` — TurnEnd fallback timer fired, skipped (tools active/fresh events), or deferred to watchdog
+- `[TOOL-HEALTH]` — tool health check (events flowing, server liveness, stale detection)
 
 Every code path that sets `IsProcessing = false` MUST have a diagnostic log entry. This is critical for debugging stuck-session issues.
 

--- a/PolyPilot.Tests/TurnEndFallbackTests.cs
+++ b/PolyPilot.Tests/TurnEndFallbackTests.cs
@@ -251,4 +251,117 @@ public class TurnEndFallbackTests
         await fallbackTask;
         Assert.True(await completion.Task, "Fallback must fire when no TurnStart or SessionIdle arrives");
     }
+
+    // ===== Events.jsonl freshness guard constants =====
+
+    [Fact]
+    public void TurnEndFallbackFreshnessSeconds_IsReasonable()
+    {
+        // Must be tight enough to avoid false positives from prior-turn writes
+        // but wide enough to catch genuinely active tools.
+        Assert.InRange(CopilotService.TurnEndFallbackFreshnessSeconds, 5, 60);
+    }
+
+    [Fact]
+    public void TurnEndFallbackRecheckMs_IsReasonable()
+    {
+        // Must be shorter than the watchdog check interval (15s) to provide
+        // faster recovery than deferring entirely to the watchdog.
+        Assert.InRange(CopilotService.TurnEndFallbackRecheckMs, 5_000, 30_000);
+        Assert.True(CopilotService.TurnEndFallbackRecheckMs <=
+            CopilotService.WatchdogCheckIntervalSeconds * 1000,
+            "Recheck delay should be at most one watchdog interval");
+    }
+
+    [Fact]
+    public void TurnEndFallbackFreshnessSeconds_IsSeparateFromWatchdog()
+    {
+        // The TurnEnd fallback freshness threshold must NOT be the same constant
+        // as the watchdog's Case B freshness (300s). They serve different purposes:
+        // the fallback needs a tight window, the watchdog needs a wide one.
+        Assert.NotEqual(
+            CopilotService.TurnEndFallbackFreshnessSeconds,
+            CopilotService.WatchdogCaseBFreshnessSeconds);
+        Assert.True(
+            CopilotService.TurnEndFallbackFreshnessSeconds < CopilotService.WatchdogCaseBFreshnessSeconds,
+            "Fallback freshness must be tighter than watchdog Case B freshness");
+    }
+
+    // ===== Events.jsonl freshness guard behavior =====
+
+    [Fact]
+    public void TurnEndFallback_FreshnessGuard_HasTurnStartAnchor()
+    {
+        // The freshness check must use a turn-start anchor to avoid false positives
+        // from prior-turn writes. Verify the code captures freshnessCheckStart before
+        // the delay and uses it in the comparison.
+        var source = File.ReadAllText("../../../../PolyPilot/Services/CopilotService.Events.cs");
+
+        // Must capture timestamp before the extended delay
+        var captureIdx = source.IndexOf("var freshnessCheckStart = DateTime.UtcNow;", StringComparison.Ordinal);
+        var delayIdx = source.IndexOf("await Task.Delay(TurnEndIdleToolFallbackAdditionalMs", StringComparison.Ordinal);
+        Assert.True(captureIdx >= 0, "freshnessCheckStart must be captured");
+        Assert.True(delayIdx >= 0, "Extended delay must exist");
+        Assert.True(captureIdx < delayIdx, "freshnessCheckStart must be captured BEFORE the delay");
+
+        // Must use the anchor in the comparison (not just fileAge)
+        Assert.Contains("lastWrite > freshnessCheckStart", source);
+    }
+
+    [Fact]
+    public void TurnEndFallback_FreshnessGuard_HasRecheckLoop()
+    {
+        // After the first freshness skip, the fallback must recheck rather than
+        // permanently returning (which would leave the session stuck until the watchdog).
+        var source = File.ReadAllText("../../../../PolyPilot/Services/CopilotService.Events.cs");
+        Assert.Contains("TurnEndFallbackRecheckMs", source);
+        Assert.Contains("rescheduling", source); // Debug log mentions rescheduling
+        Assert.Contains("deferring to watchdog", source); // Eventual defer after recheck
+    }
+
+    [Fact]
+    public void TurnEndFallback_FreshnessGuard_HasClockSkewProtection()
+    {
+        // fileAge must use Math.Max(0.0, ...) to prevent negative values from clock skew.
+        var source = File.ReadAllText("../../../../PolyPilot/Services/CopilotService.Events.cs");
+        // The freshness guard uses Math.Max for both initial and recheck age
+        Assert.Contains("Math.Max(0.0, (DateTime.UtcNow - lastWrite).TotalSeconds)", source);
+        Assert.Contains("Math.Max(0.0, (DateTime.UtcNow - File.GetLastWriteTimeUtc(ep)).TotalSeconds)", source);
+    }
+
+    [Fact]
+    public void TurnEndFallback_FreshnessGuard_ChecksLastEventType()
+    {
+        // The fallback must check GetLastEventType for tool.execution_start to handle
+        // long-running tools where events.jsonl was written before the wait started.
+        var source = File.ReadAllText("../../../../PolyPilot/Services/CopilotService.Events.cs");
+        // GetLastEventType is called in the IDLE-FALLBACK context
+        Assert.Contains("var lastEventType = GetLastEventType(ep);", source);
+        Assert.Contains("lastEventType == \"tool.execution_start\"", source);
+        // Must defer to watchdog when tool detected
+        Assert.Contains("tool running without live event", source);
+    }
+
+    [Fact]
+    public void TurnEndFallback_SkipsDemoAndRemoteMode()
+    {
+        // The events.jsonl check must be bypassed in Demo and Remote modes.
+        var source = File.ReadAllText("../../../../PolyPilot/Services/CopilotService.Events.cs");
+        var guardIdx = source.IndexOf("check if the CLI has an in-flight", StringComparison.Ordinal);
+        Assert.True(guardIdx >= 0, "Freshness guard comment must exist");
+        var afterComment = source.Substring(guardIdx, Math.Min(800, source.Length - guardIdx));
+        Assert.Contains("IsDemoMode", afterComment);
+        Assert.Contains("IsRemoteMode", afterComment);
+    }
+
+    [Fact]
+    public void WatchdogCaseB_PreCheck_HasServerLivenessGuard()
+    {
+        // The watchdog Case B pre-check must verify the server is alive.
+        var source = File.ReadAllText("../../../../PolyPilot/Services/CopilotService.Events.cs");
+        var preCheckIdx = source.IndexOf("Case B skipped", StringComparison.Ordinal);
+        Assert.True(preCheckIdx >= 0, "Case B pre-check debug message must exist");
+        var beforeDebug = source.Substring(Math.Max(0, preCheckIdx - 800), 800);
+        Assert.Contains("_serverManager.IsServerRunning", beforeDebug);
+    }
 }

--- a/PolyPilot.Tests/TurnEndFallbackTests.cs
+++ b/PolyPilot.Tests/TurnEndFallbackTests.cs
@@ -364,4 +364,104 @@ public class TurnEndFallbackTests
         var beforeDebug = source.Substring(Math.Max(0, preCheckIdx - 800), 800);
         Assert.Contains("_serverManager.IsServerRunning", beforeDebug);
     }
+
+    // ===== Behavioral tests for GetLastEventType (PR #619 review follow-up) =====
+
+    [Fact]
+    public void GetLastEventType_ReturnsToolExecutionStart_WhenLastEvent()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile,
+                "{\"type\":\"assistant.turn_end\"}\n" +
+                "{\"type\":\"assistant.message\"}\n" +
+                "{\"type\":\"tool.execution_start\",\"data\":{\"name\":\"bash\"}}\n");
+            var result = CopilotService.GetLastEventType(tempFile);
+            Assert.Equal("tool.execution_start", result);
+        }
+        finally { File.Delete(tempFile); }
+    }
+
+    [Fact]
+    public void GetLastEventType_ReturnsSessionIdle_WhenTerminalEvent()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile,
+                "{\"type\":\"assistant.turn_end\"}\n" +
+                "{\"type\":\"session.idle\"}\n");
+            var result = CopilotService.GetLastEventType(tempFile);
+            Assert.Equal("session.idle", result);
+        }
+        finally { File.Delete(tempFile); }
+    }
+
+    [Fact]
+    public void GetLastEventType_ReturnsNull_WhenFileDoesNotExist()
+    {
+        var result = CopilotService.GetLastEventType("/nonexistent/path/events.jsonl");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetLastEventType_ReturnsNull_WhenFileIsEmpty()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "");
+            var result = CopilotService.GetLastEventType(tempFile);
+            Assert.Null(result);
+        }
+        finally { File.Delete(tempFile); }
+    }
+
+    [Fact]
+    public void GetLastEventType_ReturnsNull_WhenInvalidJson()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "not json at all\n");
+            var result = CopilotService.GetLastEventType(tempFile);
+            Assert.Null(result);
+        }
+        finally { File.Delete(tempFile); }
+    }
+
+    [Fact]
+    public void GetLastEventType_IgnoresTrailingBlankLines()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile,
+                "{\"type\":\"tool.execution_complete\"}\n\n\n");
+            var result = CopilotService.GetLastEventType(tempFile);
+            Assert.Equal("tool.execution_complete", result);
+        }
+        finally { File.Delete(tempFile); }
+    }
+
+    [Fact]
+    public void GetLastEventType_ReadsWithFileShareReadWrite()
+    {
+        // Verifies the file can be read while another process is writing
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            using (var writer = new FileStream(tempFile, FileMode.Create, FileAccess.Write, FileShare.ReadWrite))
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes("{\"type\":\"assistant.turn_start\"}\n");
+                writer.Write(bytes);
+                writer.Flush();
+                // Read while writer is still open
+                var result = CopilotService.GetLastEventType(tempFile);
+                Assert.Equal("assistant.turn_start", result);
+            }
+        }
+        finally { File.Delete(tempFile); }
+    }
 }

--- a/PolyPilot/Services/CopilotService.Events.cs
+++ b/PolyPilot/Services/CopilotService.Events.cs
@@ -866,6 +866,7 @@ public partial class CopilotService
                                 // can cancel this fallback before we complete the turn prematurely.
                                 Debug($"[IDLE-FALLBACK] '{sessionName}' tools were used this turn — waiting additional " +
                                       $"{TurnEndIdleToolFallbackAdditionalMs}ms for another round before completing");
+                                var freshnessCheckStart = DateTime.UtcNow;
                                 await Task.Delay(TurnEndIdleToolFallbackAdditionalMs, fallbackToken);
                                 if (fallbackToken.IsCancellationRequested) return;
                                 if (state.IsOrphaned) return;
@@ -877,8 +878,9 @@ public partial class CopilotService
                                 // Final guard: check if the CLI is still writing to events.jsonl.
                                 // ToolExecutionStartEvent may not be delivered via the live event
                                 // stream even though the CLI is actively executing a tool (the event
-                                // only appears in events.jsonl). If events.jsonl was written recently,
-                                // the session is still active — don't complete prematurely.
+                                // only appears in events.jsonl). If events.jsonl was written recently
+                                // AND after the extended wait started, the session is still active.
+                                // Mirrors the watchdog's freshness check (line ~2711).
                                 if (!IsDemoMode && !IsRemoteMode)
                                 {
                                     try
@@ -889,16 +891,34 @@ public partial class CopilotService
                                             var ep = Path.Combine(SessionStatePath, sid, "events.jsonl");
                                             if (File.Exists(ep))
                                             {
-                                                var fileAge = (DateTime.UtcNow - File.GetLastWriteTimeUtc(ep)).TotalSeconds;
-                                                if (fileAge < TurnEndIdleToolFallbackAdditionalMs / 1000.0)
+                                                var lastWrite = File.GetLastWriteTimeUtc(ep);
+                                                var fileAge = Math.Max(0.0, (DateTime.UtcNow - lastWrite).TotalSeconds);
+                                                if (lastWrite > freshnessCheckStart && fileAge < TurnEndFallbackFreshnessSeconds)
                                                 {
-                                                    Debug($"[IDLE-FALLBACK] '{sessionName}' skipped — events.jsonl written {fileAge:F0}s ago, CLI still active");
-                                                    return;
+                                                    Debug($"[IDLE-FALLBACK] '{sessionName}' skipped — events.jsonl written {fileAge:F0}s ago (after wait started), CLI still active — rescheduling");
+                                                    // Reschedule a shorter recheck instead of permanent skip.
+                                                    // This prevents permanent stuck state if the CLI finishes
+                                                    // shortly after this check.
+                                                    await Task.Delay(TurnEndFallbackRecheckMs, fallbackToken);
+                                                    if (fallbackToken.IsCancellationRequested) return;
+                                                    if (state.IsOrphaned) return;
+                                                    if (Volatile.Read(ref state.ActiveToolCallCount) > 0)
+                                                    {
+                                                        Debug($"[IDLE-FALLBACK] '{sessionName}' skipped on recheck — tools became active");
+                                                        return;
+                                                    }
+                                                    // Recheck freshness one more time
+                                                    var recheckAge = Math.Max(0.0, (DateTime.UtcNow - File.GetLastWriteTimeUtc(ep)).TotalSeconds);
+                                                    if (recheckAge < TurnEndFallbackFreshnessSeconds)
+                                                    {
+                                                        Debug($"[IDLE-FALLBACK] '{sessionName}' still fresh on recheck ({recheckAge:F0}s ago) — deferring to watchdog");
+                                                        return;
+                                                    }
                                                 }
                                             }
                                         }
                                     }
-                                    catch { /* filesystem errors → proceed with completion */ }
+                                    catch (Exception ex) { Debug($"[IDLE-FALLBACK] '{sessionName}' freshness check failed: {ex.Message}"); }
                                 }
                             }
                             var totalFallbackDelayMs = toolsUsedThisTurn
@@ -2272,6 +2292,23 @@ public partial class CopilotService
     /// Total wait for tool sessions = TurnEndIdleFallbackMs + TurnEndIdleToolFallbackAdditionalMs = 34s.
     /// </summary>
     internal const int TurnEndIdleToolFallbackAdditionalMs = 30_000;
+
+    /// <summary>
+    /// Seconds threshold for events.jsonl freshness in the TurnEnd fallback.
+    /// If the CLI wrote to events.jsonl within this window AND after the extended wait started,
+    /// the fallback skips completion (the CLI is still active but ToolExecutionStartEvent
+    /// wasn't delivered via the live stream). Separate from WatchdogCaseBFreshnessSeconds
+    /// because the fallback needs a tighter window (30s vs 300s).
+    /// </summary>
+    internal const int TurnEndFallbackFreshnessSeconds = 30;
+
+    /// <summary>
+    /// Milliseconds to wait before rechecking events.jsonl freshness when the first check
+    /// found the CLI was still active. Provides faster recovery than deferring entirely to
+    /// the watchdog (15s check interval). After this recheck, if the file is still fresh,
+    /// the fallback defers to the watchdog for long-running tool safety.
+    /// </summary>
+    internal const int TurnEndFallbackRecheckMs = 15_000;
 
     private static void CancelProcessingWatchdog(SessionState state)
     {

--- a/PolyPilot/Services/CopilotService.Events.cs
+++ b/PolyPilot/Services/CopilotService.Events.cs
@@ -875,12 +875,14 @@ public partial class CopilotService
                                     Debug($"[IDLE-FALLBACK] '{sessionName}' skipped after extended wait — tools became active");
                                     return;
                                 }
-                                // Final guard: check if the CLI is still writing to events.jsonl.
+                                // Final guard: check if the CLI has an in-flight tool execution.
                                 // ToolExecutionStartEvent may not be delivered via the live event
                                 // stream even though the CLI is actively executing a tool (the event
-                                // only appears in events.jsonl). If events.jsonl was written recently
-                                // AND after the extended wait started, the session is still active.
-                                // Mirrors the watchdog's freshness check (line ~2711).
+                                // only appears in events.jsonl). Two checks:
+                                // 1. If events.jsonl was written recently AND after the wait started
+                                // 2. If the last event in events.jsonl IS tool.execution_start
+                                //    (tool is running but we never got the live event)
+                                // Either means the session is still active — don't complete prematurely.
                                 if (!IsDemoMode && !IsRemoteMode)
                                 {
                                     try
@@ -891,14 +893,12 @@ public partial class CopilotService
                                             var ep = Path.Combine(SessionStatePath, sid, "events.jsonl");
                                             if (File.Exists(ep))
                                             {
+                                                // Check 1: events.jsonl freshness (file written during our wait)
                                                 var lastWrite = File.GetLastWriteTimeUtc(ep);
                                                 var fileAge = Math.Max(0.0, (DateTime.UtcNow - lastWrite).TotalSeconds);
                                                 if (lastWrite > freshnessCheckStart && fileAge < TurnEndFallbackFreshnessSeconds)
                                                 {
                                                     Debug($"[IDLE-FALLBACK] '{sessionName}' skipped — events.jsonl written {fileAge:F0}s ago (after wait started), CLI still active — rescheduling");
-                                                    // Reschedule a shorter recheck instead of permanent skip.
-                                                    // This prevents permanent stuck state if the CLI finishes
-                                                    // shortly after this check.
                                                     await Task.Delay(TurnEndFallbackRecheckMs, fallbackToken);
                                                     if (fallbackToken.IsCancellationRequested) return;
                                                     if (state.IsOrphaned) return;
@@ -907,13 +907,24 @@ public partial class CopilotService
                                                         Debug($"[IDLE-FALLBACK] '{sessionName}' skipped on recheck — tools became active");
                                                         return;
                                                     }
-                                                    // Recheck freshness one more time
                                                     var recheckAge = Math.Max(0.0, (DateTime.UtcNow - File.GetLastWriteTimeUtc(ep)).TotalSeconds);
                                                     if (recheckAge < TurnEndFallbackFreshnessSeconds)
                                                     {
                                                         Debug($"[IDLE-FALLBACK] '{sessionName}' still fresh on recheck ({recheckAge:F0}s ago) — deferring to watchdog");
                                                         return;
                                                     }
+                                                }
+
+                                                // Check 2: if the last event is tool.execution_start,
+                                                // a tool is actively running even though ActiveToolCallCount=0
+                                                // (ToolExecutionStartEvent wasn't delivered via live stream).
+                                                // This handles long-running tools (e.g., read_bash delay:600)
+                                                // where events.jsonl was written before our wait started.
+                                                var lastEventType = GetLastEventType(ep);
+                                                if (lastEventType == "tool.execution_start")
+                                                {
+                                                    Debug($"[IDLE-FALLBACK] '{sessionName}' skipped — last event in events.jsonl is tool.execution_start (tool running without live event) — deferring to watchdog");
+                                                    return;
                                                 }
                                             }
                                         }
@@ -2866,6 +2877,31 @@ public partial class CopilotService
                             // confirms the session completed normally, not a server crash.
                             //
                             // BUT: ActiveToolCallCount can drop to 0 between tool rounds (the model
+
+                            // Pre-check: if the last event in events.jsonl is tool.execution_start,
+                            // a tool IS actively running even though ActiveToolCallCount=0
+                            // (ToolExecutionStartEvent wasn't delivered via live stream).
+                            // Treat as Case A instead — defer to next watchdog cycle.
+                            if (!IsDemoMode && !IsRemoteMode)
+                            {
+                                try
+                                {
+                                    var sid = state.Info.SessionId;
+                                    if (!string.IsNullOrEmpty(sid))
+                                    {
+                                        var ep = Path.Combine(SessionStatePath, sid, "events.jsonl");
+                                        var lastEvtType = GetLastEventType(ep);
+                                        if (lastEvtType == "tool.execution_start")
+                                        {
+                                            Debug($"[WATCHDOG] '{sessionName}' Case B skipped — last event is tool.execution_start " +
+                                                  $"(tool running without live event, elapsed={elapsed:F0}s) — deferring");
+                                            Interlocked.Exchange(ref state.LastEventAtTicks, DateTime.UtcNow.Ticks);
+                                            continue;
+                                        }
+                                    }
+                                }
+                                catch { /* filesystem errors → proceed with normal Case B logic */ }
+                            }
                             // is deciding what to do next). If events.jsonl is still being written,
                             // the session is alive — don't complete prematurely.
                             if (!IsDemoMode && !IsRemoteMode && startedAt.HasValue)

--- a/PolyPilot/Services/CopilotService.Events.cs
+++ b/PolyPilot/Services/CopilotService.Events.cs
@@ -2877,12 +2877,15 @@ public partial class CopilotService
                             // confirms the session completed normally, not a server crash.
                             //
                             // BUT: ActiveToolCallCount can drop to 0 between tool rounds (the model
+                            // is deciding what to do next). If events.jsonl is still being written,
+                            // the session is alive — don't complete prematurely.
 
                             // Pre-check: if the last event in events.jsonl is tool.execution_start,
                             // a tool IS actively running even though ActiveToolCallCount=0
                             // (ToolExecutionStartEvent wasn't delivered via live stream).
-                            // Treat as Case A instead — defer to next watchdog cycle.
-                            if (!IsDemoMode && !IsRemoteMode)
+                            // Only defer if the server is alive — if it crashed, the tool can't
+                            // be running and we should fall through to normal Case B recovery.
+                            if (!IsDemoMode && !IsRemoteMode && _serverManager.IsServerRunning)
                             {
                                 try
                                 {
@@ -2894,16 +2897,15 @@ public partial class CopilotService
                                         if (lastEvtType == "tool.execution_start")
                                         {
                                             Debug($"[WATCHDOG] '{sessionName}' Case B skipped — last event is tool.execution_start " +
-                                                  $"(tool running without live event, elapsed={elapsed:F0}s) — deferring");
+                                                  $"(tool running without live event, server alive, elapsed={elapsed:F0}s) — deferring");
                                             Interlocked.Exchange(ref state.LastEventAtTicks, DateTime.UtcNow.Ticks);
                                             continue;
                                         }
                                     }
                                 }
-                                catch { /* filesystem errors → proceed with normal Case B logic */ }
+                                catch (Exception ex) { Debug($"[WATCHDOG] '{sessionName}' Case B pre-check failed: {ex.Message}"); }
                             }
-                            // is deciding what to do next). If events.jsonl is still being written,
-                            // the session is alive — don't complete prematurely.
+
                             if (!IsDemoMode && !IsRemoteMode && startedAt.HasValue)
                             {
                                 // Compare events.jsonl modification time to when this turn started

--- a/PolyPilot/Services/CopilotService.Events.cs
+++ b/PolyPilot/Services/CopilotService.Events.cs
@@ -874,6 +874,32 @@ public partial class CopilotService
                                     Debug($"[IDLE-FALLBACK] '{sessionName}' skipped after extended wait — tools became active");
                                     return;
                                 }
+                                // Final guard: check if the CLI is still writing to events.jsonl.
+                                // ToolExecutionStartEvent may not be delivered via the live event
+                                // stream even though the CLI is actively executing a tool (the event
+                                // only appears in events.jsonl). If events.jsonl was written recently,
+                                // the session is still active — don't complete prematurely.
+                                if (!IsDemoMode && !IsRemoteMode)
+                                {
+                                    try
+                                    {
+                                        var sid = state.Info.SessionId;
+                                        if (!string.IsNullOrEmpty(sid))
+                                        {
+                                            var ep = Path.Combine(SessionStatePath, sid, "events.jsonl");
+                                            if (File.Exists(ep))
+                                            {
+                                                var fileAge = (DateTime.UtcNow - File.GetLastWriteTimeUtc(ep)).TotalSeconds;
+                                                if (fileAge < TurnEndIdleToolFallbackAdditionalMs / 1000.0)
+                                                {
+                                                    Debug($"[IDLE-FALLBACK] '{sessionName}' skipped — events.jsonl written {fileAge:F0}s ago, CLI still active");
+                                                    return;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    catch { /* filesystem errors → proceed with completion */ }
+                                }
                             }
                             var totalFallbackDelayMs = toolsUsedThisTurn
                                 ? TurnEndIdleFallbackMs + TurnEndIdleToolFallbackAdditionalMs


### PR DESCRIPTION
## Problem

The ReliabilityTest session stopped sending messages and appeared stuck. Root cause: the TurnEnd→Idle fallback timer prematurely completed the session while a `read_bash` tool with `delay: 120` was still executing.

**Timeline:**
1. `assistant.turn_end` → starts fallback timer (4s + 30s tool extension = 34s)
2. `assistant.turn_start` → cancels the fallback ✅
3. `assistant.message` + `tool.execution_start` (read_bash delay:120) — **but `ToolExecutionStartEvent` was NOT delivered via the live SDK event stream** (only written to events.jsonl)
4. The next `turn_end` (from the same sub-turn sequence) starts a NEW fallback
5. Fallback checks `ActiveToolCallCount` → 0 (because `TurnStartEvent` reset it at step 2, and step 3's increment never arrived)
6. Fallback fires `CompleteResponse` → `IsProcessing = false`
7. All subsequent `TurnStartEvent`s are rejected as `[EVT-REARM-SKIP]` ("arrived after explicit completion")
8. Session permanently stuck — CLI keeps working but UI shows no activity

## Root Cause

The live SDK event stream and `events.jsonl` are separate channels. `ToolExecutionStartEvent` may appear in `events.jsonl` (written by the CLI) but not be delivered to `HandleSessionEvent` (live stream). The TurnEnd fallback only checks `ActiveToolCallCount` (set by the live stream handler), not whether the CLI is still actively writing.

## Fix

After the extended 30s wait in the TurnEnd fallback, check `events.jsonl` last-write time before completing. If the CLI wrote to it recently (within the 30s window), the session is still active — skip completion. This is the same freshness pattern already used by the watchdog (`useUsedToolsTimeout` upgrade at line 2675-2698).

## Testing

- All 3484 tests pass, 0 failures
- 201 TurnEndFallback + ProcessingWatchdog tests pass