### PR TITLE
chore: update NuGet dependencies

### DIFF
--- a/PolyPilot.Gtk/PolyPilot.Gtk.csproj
+++ b/PolyPilot.Gtk/PolyPilot.Gtk.csproj
@@ -68,8 +68,8 @@
 
   <!-- MauiDevFlow is a dev-time inspection tool — exclude from Release builds. -->
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-    <PackageReference Include="Microsoft.Maui.DevFlow.Agent.Gtk" Version="0.1.0-preview.4.26202.3" />
-    <PackageReference Include="Microsoft.Maui.DevFlow.Blazor.Gtk" Version="0.1.0-preview.4.26202.3" />
+    <PackageReference Include="Microsoft.Maui.DevFlow.Agent.Gtk" Version="0.1.0-preview.5.26217.12" />
+    <PackageReference Include="Microsoft.Maui.DevFlow.Blazor.Gtk" Version="0.1.0-preview.5.26217.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PolyPilot/PolyPilot.csproj
+++ b/PolyPilot/PolyPilot.csproj
@@ -96,8 +96,8 @@
     <!-- MauiDevFlow is a dev-time inspection tool — exclude from Release builds
          to avoid shipping unnecessary assemblies and working around packaging bugs. -->
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-        <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.4.26202.3" />
-        <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="0.1.0-preview.4.26202.3" />
+        <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.5.26217.12" />
+        <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="0.1.0-preview.5.26217.12" />
     </ItemGroup>
 
     <!-- UI Automation for Windows Terminal tab switching (Windows-only) -->

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.maui.cli": {
-      "version": "0.1.0-preview.4.26202.3",
+      "version": "0.1.0-preview.5.26217.12",
       "commands": [
         "maui"
       ],


### PR DESCRIPTION
## NuGet Dependency Updates

### ✅ Updated: MauiDevFlow Packages

| Package | Old Version | New Version |
|---------|-------------|-------------|
| `Microsoft.Maui.DevFlow.Agent` | `0.1.0-preview.4.26202.3` | `0.1.0-preview.5.26217.12` |
| `Microsoft.Maui.DevFlow.Blazor` | `0.1.0-preview.4.26202.3` | `0.1.0-preview.5.26217.12` |
| `Microsoft.Maui.DevFlow.Agent.Gtk` | `0.1.0-preview.4.26202.3` | `0.1.0-preview.5.26217.12` |
| `Microsoft.Maui.DevFlow.Blazor.Gtk` | `0.1.0-preview.4.26202.3` | `0.1.0-preview.5.26217.12` |
| `microsoft.maui.cli` (dotnet-tools.json) | `0.1.0-preview.4.26202.3` | `0.1.0-preview.5.26217.12` |

### ❌ Not Updated: GitHub.Copilot.SDK

`GitHub.Copilot.SDK` `0.2.2` has a **breaking API change** and was reverted to the previous versions (`0.2.1` / `0.2.0`).

**Build error:**
```
BackgroundTasksIdleTests.cs(14,46): error CS0246: The type or namespace name 'SessionIdleDataBackgroundTasks' could not be found
```

`SessionIdleDataBackgroundTasks` was removed or renamed in `0.2.2`. Requires a dedicated PR to migrate the affected code.




> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `192.0.2.1`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "192.0.2.1"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Update NuGet Dependencies](https://github.com/PureWeen/PolyPilot/actions/runs/24615531206) · [◷](https://github.com/search?q=repo%3APureWeen%2FPolyPilot+%22gh-aw-workflow-id%3A+dep-update%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Update NuGet Dependencies, engine: copilot, id: 24615531206, workflow_id: dep-update, run: https://github.com/PureWeen/PolyPilot/actions/runs/24615531206 -->

<!-- gh-aw-workflow-id: dep-update -->

---

> [!NOTE]
> This was originally intended as a pull request, but GitHub Actions is not permitted to create or approve pull requests in this repository.
> The changes have been pushed to branch `chore/update-nuget-dependencies-d2d77061cdf4fe69`.
>
> **[Click here to create the pull request](https://github.com/PureWeen/PolyPilot/compare/main...chore/update-nuget-dependencies-d2d77061cdf4fe69?expand=1&title=chore%3A%20update%20NuGet%20dependencies)**

To fix the permissions issue, go to **Settings** → **Actions** → **General** and enable **Allow GitHub Actions to create and approve pull requests**. See also: [gh-aw FAQ](https://github.github.com/gh-aw/reference/faq/#why-is-my-create-pull-request-workflow-failing-with-github-actions-is-not-permitted-to-create-or-approve-pull-requests)

<details><summary>Show patch preview (73 of 73 lines)</summary>

```diff
From dff6ce24e6c0ca84a183f3ea41b2bf4e9dede668 Mon Sep 17 00:00:00 2001
From: "github-actions[bot]" <github-actions[bot]@users.noreply.github.com>
Date: Sat, 18 Apr 2026 22:51:40 +0000
Subject: [PATCH] chore: update NuGet dependencies
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit

- Microsoft.Maui.DevFlow.Agent: 0.1.0-preview.4.26202.3 → 0.1.0-preview.5.26217.12
- Microsoft.Maui.DevFlow.Blazor: 0.1.0-preview.4.26202.3 → 0.1.0-preview.5.26217.12
- Microsoft.Maui.DevFlow.Agent.Gtk: 0.1.0-preview.4.26202.3 → 0.1.0-preview.5.26217.12
- Microsoft.Maui.DevFlow.Blazor.Gtk: 0.1.0-preview.4.26202.3 → 0.1.0-preview.5.26217.12
- microsoft.maui.cli (dotnet-tools.json): 0.1.0-preview.4.26202.3 → 0.1.0-preview.5.26217.12

GitHub.Copilot.SDK 0.2.2 was NOT updated: build failed with breaking change
  BackgroundTasksIdleTests.cs(14): error CS0246: The type or namespace name
  'SessionIdleDataBackgroundTasks' could not be found.
  SDK reverted to previous versions (0.2.1/0.2.0). Requires dedicated PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
---
 PolyPilot.Gtk/PolyPilot.Gtk.csproj | 4 ++--
 PolyPilot/PolyPilot.csproj         | 4 ++--
 dotnet-tools.json                  | 2 +-
 3 files changed, 5 insertions(+), 5 deletions(-)

diff --git a/PolyPilot.Gtk/PolyPilot.Gtk.csproj b/PolyPilot.Gtk/PolyPilot.Gtk.csproj
index 661c65a..9114e89 100644
--- a/PolyPilot.Gtk/PolyPilot.Gtk.csproj
+++ b/PolyPilot.Gtk/PolyPilot.Gtk.csproj
@@ -68,8 +68,8 @@
 
   <!-- MauiDevFlow is a dev-time inspection tool — exclude from Release builds. -->
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-    <PackageReference Include="Microsoft.Maui.DevFlow.Agent.Gtk" Version="0.1.0-preview.4.26202.3" />
-    <PackageReference Include="Microsoft.Maui.DevFlow.Blazor.Gtk" Version="0.1.0-preview.4.26202.3" />
+    <PackageReference Include="Microsoft.Maui.DevFlow.Agent.Gtk" Version="0.1.0-preview.5.26217.12" />
+    <PackageReference Include
... (truncated)
```

</details>