### PR TITLE
feat: expand dep-update to all NuGet packages + skill updates

### DIFF
--- a/.github/workflows/dep-update.md
+++ b/.github/workflows/dep-update.md
@@ -26,72 +26,111 @@ safe-outputs:
 
 # Update NuGet Dependencies
 
-Update all NuGet package references and the MauiDevFlow CLI tool to their latest available versions, then open a PR with the changes.
+Update all NuGet package references, dotnet tools, and the MauiDevFlow skill to their latest available versions, then open a PR with the changes.
 
-## Packages to Update
+## Package Groups
 
-### GitHub Copilot SDK (nuget.org)
+### Group 1: GitHub Copilot SDK (nuget.org)
 
 Package: `GitHub.Copilot.SDK`
 
-Query the latest version from nuget.org:
 ```bash
 curl -s 'https://api.nuget.org/v3-flatcontainer/github.copilot.sdk/index.json' | jq -r '.versions[-1]'
 ```
 
-This package appears in multiple csproj files — update ALL of them to the same version:
+Update ALL of these to the **same** version:
 - `PolyPilot/PolyPilot.csproj`
 - `PolyPilot.Console/PolyPilot.csproj`
-- `PolyPilot.Gtk/PolyPilot.csproj`
+- `PolyPilot.Gtk/PolyPilot.Gtk.csproj`
 - `PolyPilot.Tests/PolyPilot.Tests.csproj`
 - `PolyPilot.Provider.Abstractions/PolyPilot.Provider.Abstractions.csproj`
 
-### MauiDevFlow Packages (Azure DevOps dotnet10 feed)
+### Group 2: MauiDevFlow Packages + CLI Tool (Azure DevOps dotnet10 feed)
 
-These are prerelease packages. Query the latest version from the ADO feed:
+Query the latest versions:
 ```bash
 curl -s 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/flat2/microsoft.maui.devflow.agent/index.json' | jq -r '.versions[-1]'
-```
-
-All four MauiDevFlow packages must use the same version:
-- `Microsoft.Maui.DevFlow.Agent` — in `PolyPilot/PolyPilot.csproj`
-- `Microsoft.Maui.DevFlow.Blazor` — in `PolyPilot/PolyPilot.csproj`
-- `Microsoft.Maui.DevFlow.Agent.Gtk` — in `PolyPilot.Gtk/PolyPilot.csproj`
-- `Microsoft.Maui.DevFlow.Blazor.Gtk` — in `PolyPilot.Gtk/PolyPilot.csproj`
-
-### MauiDevFlow CLI Tool
-
-The `microsoft.maui.cli` tool version in `dotnet-tools.json` should match the MauiDevFlow packages:
-```bash
 curl -s 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/flat2/microsoft.maui.cli/index.json' | jq -r '.versions[-1]'
 ```
 
-Update the version in `dotnet-tools.json`.
+All MauiDevFlow packages and the CLI tool must use the **same** version:
+- `Microsoft.Maui.DevFlow.Agent` — in `PolyPilot/PolyPilot.csproj`
+- `Microsoft.Maui.DevFlow.Blazor` — in `PolyPilot/PolyPilot.csproj`
+- `Microsoft.Maui.DevFlow.Agent.Gtk` — in `PolyPilot.Gtk/PolyPilot.Gtk.csproj`
+- `Microsoft.Maui.DevFlow.Blazor.Gtk` — in `PolyPilot.Gtk/PolyPilot.Gtk.csproj`
+- `microsoft.maui.cli` — in `dotnet-tools.json`
+
+After updating, also run:
+```bash
+maui devflow update-skill
+```
+This updates the MauiDevFlow skill at `.claude/skills/maui-ai-debugging/`. If `maui` CLI is not installed globally, install it first:
+```bash
+dotnet tool install -g Microsoft.Maui.Cli --prerelease
+```
+
+### Group 3: Other NuGet Packages (nuget.org)
+
+Query the latest stable version for each package. Use this pattern:
+```bash
+curl -s 'https://api.nuget.org/v3-flatcontainer/PACKAGE_NAME_LOWERCASE/index.json' | jq -r '[.versions[] | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$")))] | last'
+```
+
+Note: For packages with a `$(MauiVersion)` variable (like `Microsoft.Maui.Controls` and `Microsoft.AspNetCore.Components.WebView.Maui`), do NOT update them — they are pinned to the MAUI workload version.
+
+Update each package in ALL csproj files where it appears to the **same** latest stable version:
+
+| Package | Locations |
+|---------|-----------|
+| `CommunityToolkit.Maui` | `PolyPilot/PolyPilot.csproj`, `PolyPilot.Gtk/PolyPilot.Gtk.csproj` |
+| `Markdig` | `PolyPilot/PolyPilot.csproj`, `PolyPilot.Gtk/PolyPilot.Gtk.csproj`, `PolyPilot.Tests/PolyPilot.Tests.csproj` |
+| `sqlite-net-pcl` | `PolyPilot/PolyPilot.csproj`, `PolyPilot.Gtk/PolyPilot.Gtk.csproj`, `PolyPilot.Tests/PolyPilot.Tests.csproj` |
+| `SQLitePCLRaw.bundle_green` | `PolyPilot/PolyPilot.csproj`, `PolyPilot.Gtk/PolyPilot.Gtk.csproj`, `PolyPilot.Tests/PolyPilot.Tests.csproj` |
+| `QRCoder` | `PolyPilot/PolyPilot.csproj` |
+| `ZXing.Net.Maui.Controls` | `PolyPilot/PolyPilot.csproj` |
+| `Spectre.Console` | `PolyPilot.Console/PolyPilot.csproj` |
+| `coverlet.collector` | `PolyPilot.Tests/PolyPilot.Tests.csproj` |
+| `Microsoft.NET.Test.Sdk` | `PolyPilot.Tests/PolyPilot.Tests.csproj` |
+| `xunit` | `PolyPilot.Tests/PolyPilot.Tests.csproj` |
+| `xunit.runner.visualstudio` | `PolyPilot.Tests/PolyPilot.Tests.csproj` |
+
+Skip these — they track the .NET SDK version or use variables:
+- `Microsoft.Maui.Controls` (uses `$(MauiVersion)`)
+- `Microsoft.AspNetCore.Components.WebView.Maui` (uses `$(MauiVersion)`)
+- `Microsoft.AspNetCore.Components.WebView` (tied to .NET SDK)
+- `Microsoft.Extensions.Logging.Debug` (tied to .NET SDK)
+- `Microsoft.Extensions.DependencyInjection` (tied to .NET SDK)
+- `Microsoft.Extensions.DependencyInjection.Abstractions` (tied to .NET SDK)
+- `Microsoft.Maui.Essentials.AI` (experimental CI build)
+- `Platform.Maui.Linux.Gtk4*` (third-party GTK platform, update carefully)
 
 ## Important Constraints
 
 - This workflow runs on **ubuntu** — the MAUI workload is NOT installed. Do NOT try to build the full solution (`PolyPilot.slnx`) or any MAUI project. Only the test project can be built.
 - Do NOT attempt to fix breaking API changes. If a version bump causes build errors, **revert that specific package** to its current version and proceed with the other updates.
-- Each package group (SDK, DevFlow, CLI tool) is independent — update whichever ones build cleanly.
+- Each package group is independent — update whichever ones build cleanly.
+- Always ensure the same package uses the **same version** across all csproj files where it appears.
 
 ## Steps
 
-1. **Query latest versions** for all three package groups using the curl commands above.
+1. **Query latest versions** for all package groups.
 
-2. **Compare with current versions** in the csproj files and `dotnet-tools.json`. If everything is already up to date, stop and do not create a PR.
+2. **Compare with current versions** across all csproj files and `dotnet-tools.json`. If everything is already up to date, stop and do not create a PR.
 
-3. **Update MauiDevFlow packages first** — update all four `Microsoft.Maui.DevFlow.*` PackageReference versions and the `microsoft.maui.cli` version in `dotnet-tools.json`. These are Debug-only conditional references and do not affect the test build, so no build verification is needed for them.
+3. **Update MauiDevFlow packages + CLI tool** — update all four `Microsoft.Maui.DevFlow.*` PackageReference versions and the `microsoft.maui.cli` version in `dotnet-tools.json`. These are Debug-only conditional references, so no build verification is needed. Then run `maui devflow update-skill` to update the AI skill files.
 
-4. **Update GitHub.Copilot.SDK** — update ALL csproj files to the same latest version. Then build the test project to verify:
+4. **Update other NuGet packages** (Group 3) — update all packages to their latest stable versions, ensuring consistency across projects.
+
+5. **Update GitHub.Copilot.SDK** — update ALL csproj files to the same latest version. Then build to verify:
    ```bash
    dotnet build PolyPilot.Tests/PolyPilot.Tests.csproj -c Debug --nologo
    ```
-   If the build fails with API/type errors (breaking changes), **revert the SDK version** back to what it was before in ALL csproj files. Do NOT try to fix breaking API changes — that requires a separate, dedicated PR. Log which version had breaking changes in the PR body.
+   If the build fails with API/type errors (breaking changes), **revert the SDK version** back to what it was before in ALL csproj files. Do NOT try to fix breaking API changes. Log which version had breaking changes in the PR body.
 
-5. **Run tests** (only if SDK was updated successfully):
+6. **Run tests** — build and run all tests to verify nothing is broken:
    ```bash
    dotnet test PolyPilot.Tests/PolyPilot.Tests.csproj --configuration Debug --nologo
    ```
-   If tests fail, revert the SDK update.
+   If tests fail due to a specific package update, revert only that package and re-run tests.
 
-6. **Create a PR** — if ANY packages were updated, create a PR with title `chore: update NuGet dependencies` and a body that lists each package updated with old → new versions. If the SDK was reverted, note it in the body with the error summary.
+7. **Create a PR** — if ANY packages were updated, create a PR with title `chore: update NuGet dependencies` and a body that lists each package updated with old → new versions. If any packages were reverted, note them in the body with the error summary.


### PR DESCRIPTION
Expands the nightly dep-update agent to cover **all** NuGet packages, not just SDK and DevFlow.

## What's new
- **Group 3: All other NuGet packages** — CommunityToolkit.Maui, Markdig, sqlite-net-pcl, QRCoder, ZXing, Spectre.Console, xunit, coverlet, etc.
- **`maui devflow update-skill`** — updates the maui-ai-debugging skill files from maui-labs after DevFlow package updates
- **Version consistency enforcement** — same package = same version across all projects
- **Explicit skip list** — $(MauiVersion) packages, .NET SDK-tied packages, and Platform.Maui.Linux.Gtk4 are left alone
- **Package location table** — documents exactly which csproj files each package appears in