### PR TITLE
fix: update Xcode requirement from 26.2 to 26.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
 
       - name: Select Xcode
         run: |
-          if [ -d "/Applications/Xcode_26.2.app" ]; then
-            XCODE_PATH="/Applications/Xcode_26.2.app"
-          elif [ -d "/Applications/Xcode_26.2.0.app" ]; then
-            XCODE_PATH="/Applications/Xcode_26.2.0.app"
+          if [ -d "/Applications/Xcode_26.3.app" ]; then
+            XCODE_PATH="/Applications/Xcode_26.3.app"
+          elif [ -d "/Applications/Xcode_26.3.0.app" ]; then
+            XCODE_PATH="/Applications/Xcode_26.3.0.app"
           else
             XCODE_PATH=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -rV | head -1)
           fi

--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.2'
+          xcode-version: '26.3'
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -466,7 +466,7 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.2'
+          xcode-version: '26.3'
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5


### PR DESCRIPTION
## Problem

All Mac Catalyst CI builds fail with:
```
This version of .NET for MacCatalyst (26.2.10233) requires Xcode 26.3.
The current version of Xcode is 26.2.
```

## Root Cause

The .NET MacCatalyst SDK was updated to 26.2.10233 which requires Xcode 26.3. The `macos-26` runner has Xcode 26.3 installed at `/Applications/Xcode_26.3.app`, but our workflows explicitly selected 26.2.

## Fix

- `release-apps.yml`: Both Mac Catalyst jobs updated from `xcode-version: '26.2'` to `'26.3'`
- `build.yml`: Xcode selection fallback updated from 26.2 to 26.3