### PR TITLE
fix: update Mac Catalyst publish job to Xcode 26.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,10 +75,10 @@ jobs:
       - name: Select Xcode
         run: |
           ls -d /Applications/Xcode*.app 2>/dev/null
-          if [ -d "/Applications/Xcode_26.2.app" ]; then
-            XCODE_PATH="/Applications/Xcode_26.2.app"
-          elif [ -d "/Applications/Xcode_26.2.0.app" ]; then
-            XCODE_PATH="/Applications/Xcode_26.2.0.app"
+          if [ -d "/Applications/Xcode_26.3.app" ]; then
+            XCODE_PATH="/Applications/Xcode_26.3.app"
+          elif [ -d "/Applications/Xcode_26.3.0.app" ]; then
+            XCODE_PATH="/Applications/Xcode_26.3.0.app"
           else
             XCODE_PATH=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -rV | head -1)
           fi


### PR DESCRIPTION
PR #649 updated the Build & Test job to Xcode 26.3, but missed the **Publish Mac Catalyst App** job which still hardcoded Xcode 26.2. The .NET MacCatalyst SDK 26.2.10233 requires Xcode 26.3, causing all Mac Catalyst publish builds to fail since #649 landed.

This is a one-line fix — 26.2 → 26.3 in the publish job's Xcode selection block.

**Fixes:** Mac Catalyst artifact missing from v1.0.20 release.