### PR TITLE
fix: prevent duplicate PRs and fix DevFlow version sort

### DIFF
--- a/.github/workflows/dep-update.lock.yml
+++ b/.github/workflows/dep-update.lock.yml
@@ -21,7 +21,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ee7169a27bb5408e4b1e19ce7105a47c1e38cfeafd703ad9fc69b70cfe607c35","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"fdd69a0d294386f2adce924c31a111de8f78ddbdce34fae0a96179809be62f78","compiler_version":"v0.62.2","strict":true}
 
 name: "Update NuGet Dependencies"
 "on":
@@ -127,7 +127,7 @@ jobs:
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
           cat << 'GH_AW_PROMPT_EOF'
           <safe-output-tools>
-          Tools: create_pull_request, missing_tool, missing_data, noop
+          Tools: create_pull_request, close_pull_request, missing_tool, missing_data, noop
           GH_AW_PROMPT_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat << 'GH_AW_PROMPT_EOF'
@@ -324,13 +324,14 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"create_pull_request":{"auto_merge":true,"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"close_pull_request":{"max":5},"create_pull_request":{"auto_merge":true,"expires":24,"max":1,"preserve_branch_name":true},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
       - name: Write Safe Outputs Tools
         run: |
           cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_EOF'
           {
             "description_suffixes": {
+              "close_pull_request": " CONSTRAINTS: Maximum 5 pull request(s) can be closed.",
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created."
             },
             "repo_params": {},
@@ -339,6 +340,24 @@ jobs:
           GH_AW_SAFE_OUTPUTS_TOOLS_META_EOF
           cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_EOF'
           {
+            "close_pull_request": {
+              "defaultMax": 1,
+              "fields": {
+                "body": {
+                  "required": true,
+                  "type": "string",
+                  "sanitize": true,
+                  "maxLength": 65000
+                },
+                "pull_request_number": {
+                  "optionalPositiveInteger": true
+                },
+                "repo": {
+                  "type": "string",
+                  "maxLength": 256
+                }
+              }
+            },
             "create_pull_request": {
               "defaultMax": 1,
               "fields": {
@@ -1050,7 +1069,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dist.nuget.org,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"auto_merge\":true,\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"AGENTS.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"protected_path_prefixes\":[\".github/\",\".agents/\"]},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"close_pull_request\":{\"max\":5},\"create_pull_request\":{\"auto_merge\":true,\"expires\":24,\"max\":1,\"max_patch_size\":1024,\"preserve_branch_name\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"AGENTS.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"protected_path_prefixes\":[\".github/\",\".agents/\"]},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dep-update.md
+++ b/.github/workflows/dep-update.md
@@ -21,7 +21,11 @@ tools:
 safe-outputs:
   create-pull-request:
     auto-merge: true
+    expires: 1
+    preserve-branch-name: true
     protected-files: fallback-to-issue
+  close-pull-request:
+    max: 5
 
 timeout-minutes: 45
 
@@ -51,9 +55,13 @@ Update ALL of these to the **same** version:
 
 ### Group 2: MauiDevFlow Packages + CLI Tool (Azure DevOps dotnet10 feed)
 
-Query the latest version — the ADO feed does NOT sort versions correctly, so use `sort -t. -k4,4n -k5,5n -k6,6n` to sort by preview number then build:
+Query the latest version — the ADO feed does NOT sort versions semantically. Versions have mixed formats (`preview.N.BUILD.SUB` and `preview.BUILD.SUB`). Use `dotnet nuget` to find the latest:
 ```bash
-DEVFLOW_LATEST=$(curl -s 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/flat2/microsoft.maui.devflow.agent/index.json' | jq -r '.versions[]' | sort -t. -k4,4n -k5,5n -k6,6n | tail -1)
+DEVFLOW_LATEST=$(dotnet package search Microsoft.Maui.DevFlow.Agent --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json --prerelease --take 1 --format json 2>/dev/null | jq -r '.searchResult[0].packages[0].latestVersion // empty')
+if [ -z "$DEVFLOW_LATEST" ]; then
+  # Fallback: query flat2 API and pick the version with the highest preview number
+  DEVFLOW_LATEST=$(curl -s 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/flat2/microsoft.maui.devflow.agent/index.json' | jq -r '.versions[]' | grep -E 'preview\.[0-9]+\.[0-9]{5}\.' | sort -t. -k4,4n -k5,5n -k6,6n | tail -1)
+fi
 echo "Latest DevFlow: $DEVFLOW_LATEST"
 ```
 
@@ -117,9 +125,11 @@ Skip these — they track the .NET SDK version or use variables:
 
 ## Steps
 
-1. **Query latest versions** for all package groups.
+1. **Close previous dep-update PRs** — before doing anything, close any open PRs from previous runs of this workflow so we don't accumulate stale PRs. Use the `close_pull_request` safe output tool for any open PRs with title containing "update NuGet dependencies" that were created by this workflow.
 
-2. **Compare with current versions** across all csproj files and `dotnet-tools.json`. If everything is already up to date, stop and do not create a PR.
+2. **Query latest versions** for all package groups.
+
+3. **Compare with current versions** across all csproj files and `dotnet-tools.json`. If everything is already up to date, stop and do not create a PR.
 
 3. **Update MauiDevFlow packages + CLI tool** — query the latest DevFlow version from the ADO feed. If it differs from the current version in the csproj files, update all four `Microsoft.Maui.DevFlow.*` PackageReference versions AND the `microsoft.maui.cli` version in `dotnet-tools.json`. Then install the maui CLI and run `maui devflow update-skill`. Include any changed files under `.claude/skills/maui-ai-debugging/` in the commit.
 


### PR DESCRIPTION
Three fixes for the dep-update workflow:

1. **Duplicate PRs** — adds `close-pull-request` safe output + `expires: 1` day + `preserve-branch-name` so each run closes old PRs and reuses the same branch
2. **DevFlow version sort** — the ADO flat2 API returns versions in alphabetical order, and versions have mixed formats (`preview.N.BUILD.SUB` vs `preview.BUILD.SUB`). Now uses `dotnet package search` for correct semver with a grep+sort fallback that filters only 3-part preview versions
3. **Step 1: cleanup** — agent closes previous dep-update PRs before creating a new one