### PR TITLE
fix: pass drift data via step outputs — agent can't access activation filesystem

### DIFF
--- a/.github/workflows/instruction-drift.agent.lock.yml
+++ b/.github/workflows/instruction-drift.agent.lock.yml
@@ -22,7 +22,7 @@
 #
 # Weekly check for stale gh-aw instructions. If drift is detected, scans upstream commits and creates a PR updating the skills.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"66e5a436a85e6168c8d4d7d28e33e6cda68662d30938710d4621ff87a52a82f1","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"7a27e452df82d72be6792fdf5a727a11c01a24f16ad9d35ee00013105372572f","compiler_version":"v0.62.2","strict":true}
 
 name: "Instruction Drift Check"
 "on":
@@ -117,6 +117,9 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_STEPS_STALENESS_OUTPUTS_CHANGES_DETECTED: ${{ steps.staleness.outputs.changes_detected }}
+          GH_AW_STEPS_STALENESS_OUTPUTS_REPORT: ${{ steps.staleness.outputs.report }}
+          GH_AW_STEPS_UPSTREAM_OUTPUTS_REPORT: ${{ steps.upstream.outputs.report }}
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
@@ -175,6 +178,9 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
+          GH_AW_STEPS_STALENESS_OUTPUTS_CHANGES_DETECTED: ${{ steps.staleness.outputs.changes_detected }}
+          GH_AW_STEPS_STALENESS_OUTPUTS_REPORT: ${{ steps.staleness.outputs.report }}
+          GH_AW_STEPS_UPSTREAM_OUTPUTS_REPORT: ${{ steps.upstream.outputs.report }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -193,6 +199,9 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_STEPS_STALENESS_OUTPUTS_CHANGES_DETECTED: ${{ steps.staleness.outputs.changes_detected }}
+          GH_AW_STEPS_STALENESS_OUTPUTS_REPORT: ${{ steps.staleness.outputs.report }}
+          GH_AW_STEPS_UPSTREAM_OUTPUTS_REPORT: ${{ steps.upstream.outputs.report }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -211,7 +220,10 @@ jobs:
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
-                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE
+                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
+                GH_AW_STEPS_STALENESS_OUTPUTS_CHANGES_DETECTED: process.env.GH_AW_STEPS_STALENESS_OUTPUTS_CHANGES_DETECTED,
+                GH_AW_STEPS_STALENESS_OUTPUTS_REPORT: process.env.GH_AW_STEPS_STALENESS_OUTPUTS_REPORT,
+                GH_AW_STEPS_UPSTREAM_OUTPUTS_REPORT: process.env.GH_AW_STEPS_UPSTREAM_OUTPUTS_REPORT
               }
             });
       - name: Validate prompt placeholders
@@ -270,6 +282,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
       - name: Create gh-aw temp directory
         run: bash ${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh
       - name: Configure gh CLI for GitHub Enterprise
@@ -278,12 +294,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - env:
           GH_TOKEN: ${{ github.token }}
+        id: staleness
         name: Run staleness check
-        run: "echo \"::group::Check-Staleness.ps1\"\npwsh .github/skills/instruction-drift/scripts/Check-Staleness.ps1 \\\n  -OutputFile staleness-report.json\necho \"::endgroup::\"\n"
+        run: "RESULT=$(pwsh .github/skills/instruction-drift/scripts/Check-Staleness.ps1 \\\n  -SyncManifest .github/instructions/gh-aw-workflows.sync.yaml 2>/dev/null \\\n  || echo '{\"changes_detected\":false,\"error\":\"script failed\"}')\nCHANGES=$(echo \"$RESULT\" | python3 -c \"import json,sys; d=json.load(sys.stdin); print(str(d.get('changes_detected',False)).lower())\" 2>/dev/null || echo \"false\")\necho \"changes_detected=$CHANGES\" >> \"$GITHUB_OUTPUT\"\necho \"report<<REPORT_EOF\" >> \"$GITHUB_OUTPUT\"\necho \"$RESULT\" | head -c 60000 >> \"$GITHUB_OUTPUT\"\necho \"\" >> \"$GITHUB_OUTPUT\"\necho \"REPORT_EOF\" >> \"$GITHUB_OUTPUT\"\n"
       - env:
           GH_TOKEN: ${{ github.token }}
-        name: Scan upstream knowledge (only when drift detected)
-        run: "CHANGES=$(jq -r '.changes_detected // false' staleness-report.json 2>/dev/null || echo \"false\")\nif [ \"$CHANGES\" = \"true\" ]; then\n  echo \"::group::Scan-GhAwUpdates.ps1\"\n  pwsh .github/skills/instruction-drift/scripts/Scan-GhAwUpdates.ps1 \\\n    -MaxCommits 50 \\\n    -OutputFile scan-report.json || true\n  echo \"::endgroup::\"\nelse\n  echo '{\"changes_detected\":false,\"new_features\":[],\"feature_summary\":{}}' > scan-report.json\n  echo \"Skipping upstream scan — no drift detected.\"\nfi\n"
+        id: upstream
+        if: steps.staleness.outputs.changes_detected == 'true'
+        name: Run upstream scan (if stale)
+        run: "RESULT=$(pwsh .github/skills/instruction-drift/scripts/Scan-GhAwUpdates.ps1 \\\n  -MaxCommits 50 2>/dev/null \\\n  || echo '{\"changes_detected\":false,\"error\":\"script failed\"}')\necho \"report<<SCAN_EOF\" >> \"$GITHUB_OUTPUT\"\necho \"$RESULT\" | head -c 60000 >> \"$GITHUB_OUTPUT\"\necho \"\" >> \"$GITHUB_OUTPUT\"\necho \"SCAN_EOF\" >> \"$GITHUB_OUTPUT\"\n"
 
       - name: Configure Git credentials
         env:

--- a/.github/workflows/instruction-drift.agent.md
+++ b/.github/workflows/instruction-drift.agent.md
@@ -9,7 +9,38 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  issues: write
+
+# Run scripts in steps: where GH_TOKEN is available.
+# Pass results via $GITHUB_OUTPUT so the prompt gets them via template substitution.
+steps:
+  - name: Run staleness check
+    id: staleness
+    env:
+      GH_TOKEN: ${{ github.token }}
+    run: |
+      RESULT=$(pwsh .github/skills/instruction-drift/scripts/Check-Staleness.ps1 \
+        -SyncManifest .github/instructions/gh-aw-workflows.sync.yaml 2>/dev/null \
+        || echo '{"changes_detected":false,"error":"script failed"}')
+      CHANGES=$(echo "$RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(str(d.get('changes_detected',False)).lower())" 2>/dev/null || echo "false")
+      echo "changes_detected=$CHANGES" >> "$GITHUB_OUTPUT"
+      echo "report<<REPORT_EOF" >> "$GITHUB_OUTPUT"
+      echo "$RESULT" | head -c 60000 >> "$GITHUB_OUTPUT"
+      echo "" >> "$GITHUB_OUTPUT"
+      echo "REPORT_EOF" >> "$GITHUB_OUTPUT"
+
+  - name: Run upstream scan (if stale)
+    id: upstream
+    if: steps.staleness.outputs.changes_detected == 'true'
+    env:
+      GH_TOKEN: ${{ github.token }}
+    run: |
+      RESULT=$(pwsh .github/skills/instruction-drift/scripts/Scan-GhAwUpdates.ps1 \
+        -MaxCommits 50 2>/dev/null \
+        || echo '{"changes_detected":false,"error":"script failed"}')
+      echo "report<<SCAN_EOF" >> "$GITHUB_OUTPUT"
+      echo "$RESULT" | head -c 60000 >> "$GITHUB_OUTPUT"
+      echo "" >> "$GITHUB_OUTPUT"
+      echo "SCAN_EOF" >> "$GITHUB_OUTPUT"
 
 engine:
   id: copilot
@@ -23,41 +54,6 @@ network:
 tools:
   github:
     toolsets: [repos, pull_requests]
-
-# Both Check-Staleness.ps1 and Scan-GhAwUpdates.ps1 call `gh api` and `gh issue view`.
-# Inside the agent container, gh CLI credentials are scrubbed — all those calls return
-# "authentication required" errors, producing a report where every source has
-# status:"error". The agent can't distinguish "sources clean" from "couldn't check",
-# so it can't call noop (doesn't know if things are fresh) and can't create an issue
-# (no actionable finding), causing the workflow to exit without calling any safe-output tool.
-#
-# Fix: run both scripts in `steps:` (runs before the agent, with gh authenticated).
-# The agent reads pre-computed staleness-report.json and scan-report.json.
-steps:
-  - name: Run staleness check
-    env:
-      GH_TOKEN: ${{ github.token }}
-    run: |
-      echo "::group::Check-Staleness.ps1"
-      pwsh .github/skills/instruction-drift/scripts/Check-Staleness.ps1 \
-        -OutputFile staleness-report.json
-      echo "::endgroup::"
-
-  - name: Scan upstream knowledge (only when drift detected)
-    env:
-      GH_TOKEN: ${{ github.token }}
-    run: |
-      CHANGES=$(jq -r '.changes_detected // false' staleness-report.json 2>/dev/null || echo "false")
-      if [ "$CHANGES" = "true" ]; then
-        echo "::group::Scan-GhAwUpdates.ps1"
-        pwsh .github/skills/instruction-drift/scripts/Scan-GhAwUpdates.ps1 \
-          -MaxCommits 50 \
-          -OutputFile scan-report.json || true
-        echo "::endgroup::"
-      else
-        echo '{"changes_detected":false,"new_features":[],"feature_summary":{}}' > scan-report.json
-        echo "Skipping upstream scan — no drift detected."
-      fi
 
 safe-outputs:
   create-pull-request:
@@ -83,126 +79,65 @@ timeout-minutes: 30
 
 # Instruction Drift — Detect & Update
 
-Check whether gh-aw skill files are stale relative to upstream documentation, and if so, create a PR with updates.
+> **🚨 No test messages.** Never call any safe-output tool with placeholder or test content.
 
-> **🚨 No test messages.** Never call any safe-output tool with placeholder or test content. Every call posts permanently.
+## Pre-computed Data
 
-> **🚨 Security:** This workflow has `protected-files: allowed` because it intentionally updates `.github/skills/` files. Review the generated PR carefully before merging.
+The staleness check ran in `steps:` (before you started) with authenticated `gh` CLI.
+**Do NOT run Check-Staleness.ps1 or Scan-GhAwUpdates.ps1 yourself** — `gh` CLI is not authenticated in this container.
 
-## Step 1: Read the pre-computed staleness report
+### Staleness Report
 
-The staleness check already ran in the `steps:` phase with an authenticated `gh` CLI.
-Read the output file:
-
-```bash
-cat staleness-report.json
-```
-
-> **If `staleness-report.json` is missing or empty:** The pre-agent step failed.
-> Call `noop` with reason `"Pre-agent staleness check failed — see workflow logs."` and stop.
->
-> **Do NOT attempt to run `Check-Staleness.ps1` yourself.** It calls `gh api` and `gh issue view`
-> which require `gh` CLI authentication that is not available inside the agent container.
-> The `steps:` phase is the only place these scripts run correctly.
-
-The report has this structure:
+**Changes detected: `${{ steps.staleness.outputs.changes_detected }}`**
 
 ```json
-{
-  "checked_at": "...",
-  "changes_detected": true | false,
-  "manifests": [
-    {
-      "manifest": ".github/instructions/gh-aw-workflows.sync.yaml",
-      "target": "../skills/gh-aw-guide/SKILL.md",
-      "sources": [
-        { "type": "web",      "url": "...",  "result": { "status": "ok", "content_hash": "..." } },
-        { "type": "issue",    "ref": "...",  "resolution_expected": true, "result": { "status": "ok", "state": "closed" } },
-        { "type": "releases", "repo": "...", "result": { "status": "ok", "latest": { "tag": "...", "release_notes": "..." } } }
-      ],
-      "untracked_pages": [...],
-      "untracked_closed_issues": [...]
-    }
-  ]
-}
+${{ steps.staleness.outputs.report }}
 ```
 
-**`changes_detected: false`** — All sources fetched successfully and no actionable signals found.
-**`changes_detected: true`** — At least one source has a stale or actionable signal.
+### Upstream Scan (only if changes detected)
 
-## 🚨 CRITICAL — Step 2: Decide based on `changes_detected`
+```json
+${{ steps.upstream.outputs.report }}
+```
 
-### If `changes_detected` is `false` → call `noop` IMMEDIATELY
+## 🚨 CRITICAL — Decision
 
-Call the `noop` safe-output tool right now:
+### If changes_detected is `false` → call `noop` IMMEDIATELY
+
+Call the `noop` safe-output tool now:
 
 ```json
 {"noop": {"message": "All instruction files are fresh — no drift detected."}}
 ```
 
-**Do not** create issues, PRs, or comments. **Do not** do any further analysis. Call `noop` and stop.
+Do not create issues, PRs, or comments. Call `noop` and stop.
 
-### If `changes_detected` is `true` → continue to Step 3
+### If changes_detected is `true` → continue below
 
 ---
 
-## Step 3: Read the upstream scan report (only when drift detected)
+## Analyze and Update
 
-```bash
-cat scan-report.json
-```
-
-The scan report contains `new_features` (categorized by type: safe-output, trigger, compiler, security, engine, breaking) and `safe_output_samples` from real-world shared/ configs.
-
-## Step 4: Analyze and classify
-
-Read the current skill files:
-- `.github/skills/gh-aw-guide/SKILL.md`
-- `.github/skills/gh-aw-guide/references/architecture.md`
-- `.github/instructions/gh-aw-workflows.instructions.md`
-- `.github/instructions/gh-aw-workflows.sync.yaml`
-
-For each staleness signal, cross-reference with the upstream scan to determine what needs updating.
+Read the current skill files and cross-reference with the staleness/upstream data above.
 
 ### Update Rules
 
-1. **Respect `divergence` sections** declared in the sync manifest — NEVER remove or rewrite these:
-   - "Security Boundaries"
-   - "Safe Pattern: Checkout + Restore"
-   - "Common Patterns"
-
-2. **Classify using P0-P3 before editing:**
-   - **P0 (factually wrong)** — Fix immediately. Example: issue referenced as open but now closed.
-   - **P1 (security-relevant)** — Fix immediately. Example: new anti-pattern or protection mechanism.
-   - **P2 (new features)** — Add if straightforward. Example: new safe-output type, new frontmatter field.
-   - **P3 (nice-to-have)** — Skip. Example: doc reorganization, new examples.
-
-3. **Only make P0 and P1 changes automatically.** For P2, add a note to the PR description.
-
-4. **Update the sync manifest** — Update `resolution_expected` fields to `true` for any issues that closed since last check, and add newly discovered issues.
-
-5. **Match existing style** — Read the `style:` field in the sync manifest.
+1. **Respect `divergence` sections** — NEVER remove: "Security Boundaries", "Safe Pattern: Checkout + Restore", "Common Patterns"
+2. **Classify P0-P3:** P0=factually wrong, P1=security, P2=new features, P3=nice-to-have
+3. **Only auto-fix P0 and P1.** Note P2 in PR description. Skip P3.
+4. **Update sync manifest** — `resolution_expected`, `last_reviewed`, new issues
+5. **Match existing style**
 
 ### Making Edits
 
-Use the `edit` tool. Make surgical changes — don't rewrite entire sections.
-
-Commit each logical change separately:
+Use the `edit` tool. One commit per finding:
 ```bash
 git add <specific-files>
-git commit -m "docs: update <what changed>
-
-Source: <upstream commit SHA or issue URL>
+git commit -m "docs: update <what>
 
 Co-authored-by: copilot-agentic-workflow[bot] <224017+copilot-agentic-workflow[bot]@users.noreply.github.com>"
 ```
 
-## Step 5: Create PR
+## Create PR
 
-After all edits are committed, the `create-pull-request` safe output packages the changes into a draft PR.
-
-The PR description should include:
-- Which staleness signals triggered the update
-- Which upstream changes were detected (with commit SHAs or issue URLs)
-- What P0/P1 changes were made
-- What P2 features were noted but NOT added (for human review)
+The `create-pull-request` safe output packages changes into a draft PR. Include staleness signals, upstream changes, and P0/P1 fixes in the PR description.


### PR DESCRIPTION
Third iteration fixing the instruction-drift workflow.

**Problem chain:**
1. PR #653: Scripts ran inside agent container → gh CLI not authenticated → scripts failed
2. PR #662: Moved to `steps:` (activation job) → scripts ran with GH_TOKEN ✅ but files written to activation filesystem aren't available in agent job (different runner)
3. **This PR:** Pass data via `$GITHUB_OUTPUT` → template substitution inlines JSON directly into the agent prompt

**How it works now:**
```
activation job (steps:, has GH_TOKEN):
  ├── Check-Staleness.ps1 → $GITHUB_OUTPUT (changes_detected + report JSON)
  └── Scan-GhAwUpdates.ps1 → $GITHUB_OUTPUT (upstream JSON, only if stale)
      ↓ template substitution
agent prompt (data inlined, no file I/O):
  ├── changes_detected: false → call noop immediately
  └── changes_detected: true → analyze + create PR
```

The agent sees the actual JSON data right in its prompt — no `cat` commands, no file paths, no filesystem dependency.