### PR TITLE
feat: wire integration tests into /fix workflow

### DIFF
--- a/.github/workflows/fix.agent.lock.yml
+++ b/.github/workflows/fix.agent.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/fix-shared.md
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"19d9ceffa877205bfa28c7a882c485145010e7b620907314cad1ea79aeb1e969","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"31c83a4886177cbb70cdca0cf0461a3359ed10dd413706e5aef08ff09f9455c9","compiler_version":"v0.62.2","strict":true}
 
 name: "Review & Fix"
 "on":
@@ -401,7 +401,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":5,"target":"*"},"create_pull_request_review_comment":{"max":30},"dispatch_workflow":{"max":1,"workflow_files":{"verify-build":".yml"},"workflows":["verify-build"]},"missing_data":{},"missing_tool":{},"noop":{"max":1},"push_to_pull_request_branch":{"max":1},"submit_pull_request_review":{"max":1}}
+          {"add_comment":{"max":5,"target":"*"},"create_pull_request_review_comment":{"max":30},"dispatch_workflow":{"max":1,"workflow_files":{"polypilot-integration":".yml","verify-build":".yml"},"workflows":["verify-build","polypilot-integration"]},"missing_data":{},"missing_tool":{},"noop":{"max":1},"push_to_pull_request_branch":{"max":1},"submit_pull_request_review":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
       - name: Write Safe Outputs Tools
         run: |
@@ -437,6 +437,34 @@ jobs:
                   "type": "object"
                 },
                 "name": "verify_build"
+              },
+              {
+                "_workflow_name": "polypilot-integration",
+                "description": "Dispatch the 'polypilot-integration' workflow with workflow_dispatch trigger. This workflow must support workflow_dispatch and be in .github/workflows/ directory in the same repository.",
+                "inputSchema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "pr_number": {
+                      "description": "PR number to test (optional — posts results as comment)",
+                      "type": "number"
+                    },
+                    "ref": {
+                      "default": "",
+                      "description": "Git ref to build (branch or SHA). Defaults to main.",
+                      "type": "string"
+                    },
+                    "scenario": {
+                      "description": "Test scenario to run (smoke, full)",
+                      "enum": [
+                        "smoke",
+                        "full"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "name": "polypilot_integration"
               }
             ]
           }
@@ -1133,7 +1161,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dist.nuget.org,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":5,\"target\":\"*\"},\"create_pull_request_review_comment\":{\"max\":30,\"side\":\"RIGHT\"},\"dispatch_workflow\":{\"max\":1,\"workflow_files\":{\"verify-build\":\".yml\"},\"workflows\":[\"verify-build\"]},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"AGENTS.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"protected_path_prefixes\":[\".github/\",\".agents/\"]},\"submit_pull_request_review\":{\"max\":1}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":5,\"target\":\"*\"},\"create_pull_request_review_comment\":{\"max\":30,\"side\":\"RIGHT\"},\"dispatch_workflow\":{\"max\":1,\"workflow_files\":{\"polypilot-integration\":\".yml\",\"verify-build\":\".yml\"},\"workflows\":[\"verify-build\",\"polypilot-integration\"]},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"AGENTS.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"protected_path_prefixes\":[\".github/\",\".agents/\"]},\"submit_pull_request_review\":{\"max\":1}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/polypilot-integration.yml
+++ b/.github/workflows/polypilot-integration.yml
@@ -3,10 +3,15 @@ name: "PolyPilot Integration Test"
 on:
   workflow_dispatch:
     inputs:
-      issue_number:
-        description: 'Issue number to analyze (optional)'
+      pr_number:
+        description: 'PR number to test (optional — posts results as comment)'
         required: false
         type: number
+      ref:
+        description: 'Git ref to build (branch or SHA). Defaults to main.'
+        required: false
+        type: string
+        default: ''
       scenario:
         description: 'Test scenario to run (smoke, full)'
         required: false
@@ -32,6 +37,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v5
@@ -279,6 +286,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v5
@@ -555,6 +564,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v5
@@ -661,4 +672,42 @@ jobs:
         run: |
           $appPid = $env:APP_PID
           if ($appPid) { Stop-Process -Id $appPid -Force -ErrorAction SilentlyContinue }
-# CI trigger
+
+  # ─── Report Results to PR ────────────────────────────────────
+  report:
+    name: Report Integration Results
+    runs-on: ubuntu-latest
+    needs: [integration-linux, integration-maccatalyst, integration-windows]
+    if: always() && inputs.pr_number
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post results to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LINUX: ${{ needs.integration-linux.result }}
+          CATALYST: ${{ needs.integration-maccatalyst.result }}
+          WINDOWS: ${{ needs.integration-windows.result }}
+          PR: ${{ inputs.pr_number }}
+        run: |
+          if [ "$LINUX" = "success" ] && [ "$CATALYST" = "success" ] && [ "$WINDOWS" = "success" ]; then
+            STATUS="✅ All platforms passed"
+          else
+            STATUS="❌ Integration test failures"
+          fi
+
+          cat > /tmp/report.md << EOF
+          ## 🧪 Integration Test Report — PR #${PR}
+
+          | Platform | Build | Launch | DevFlow | Smoke |
+          |----------|-------|--------|---------|-------|
+          | Linux/GTK (xvfb) | $([ "$LINUX" = "success" ] && echo "✅" || echo "❌") | $([ "$LINUX" = "success" ] && echo "✅" || echo "❌") | $([ "$LINUX" = "success" ] && echo "✅" || echo "⚠️") | $([ "$LINUX" = "success" ] && echo "✅" || echo "❌") |
+          | Mac Catalyst | $([ "$CATALYST" = "success" ] && echo "✅" || echo "❌") | — | — | — |
+          | Windows | $([ "$WINDOWS" = "success" ] && echo "✅" || echo "❌") | $([ "$WINDOWS" = "success" ] && echo "✅" || echo "❌") | $([ "$WINDOWS" = "success" ] && echo "⚠️" || echo "❌") | $([ "$WINDOWS" = "success" ] && echo "⚠️" || echo "❌") |
+
+          **${STATUS}**
+
+          [View full run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          EOF
+
+          gh pr comment "$PR" --body "$(cat /tmp/report.md)"

--- a/.github/workflows/shared/fix-shared.md
+++ b/.github/workflows/shared/fix-shared.md
@@ -19,7 +19,7 @@ safe-outputs:
     max: 1
     protected-files: fallback-to-issue
   dispatch-workflow:
-    workflows: [verify-build]
+    workflows: [verify-build, polypilot-integration]
     max: 1
   create-pull-request-review-comment:
     max: 30
@@ -219,9 +219,9 @@ If the initial review (Round 1) found **zero findings** and no fix commits were 
 
 **🚨 CRITICAL:** You MUST call at least one safe-output tool before finishing — either `add_comment` (if findings exist), `push-to-pull-request-branch` (if fixes were made), or `noop` (if clean). Failing to call any safe-output tool causes the workflow to report as failed.
 
-## Step 5: Cross-Platform Verification
+## Step 5: Cross-Platform Verification & Integration Tests
 
-After fixes are pushed, dispatch the `verify-build` workflow to build and test on macOS and Windows:
+After fixes are pushed, dispatch **both** verification workflows:
 
 ```
 dispatch_workflow({
@@ -231,7 +231,19 @@ dispatch_workflow({
     "ref": "<PR branch name>"
   }
 })
+
+dispatch_workflow({
+  "workflow": "polypilot-integration.yml",
+  "inputs": {
+    "pr_number": "<PR number>",
+    "ref": "<PR branch name>",
+    "scenario": "smoke"
+  }
+})
 ```
+
+- **verify-build** — compiles Mac Catalyst + Windows + runs unit tests
+- **polypilot-integration** — builds and launches the GTK app under xvfb, connects MauiDevFlow, runs UI smoke tests (visual tree, screenshots), and validates on Windows too. Posts results back to the PR.
 
 **Only dispatch if fixes were pushed.** If the review found zero findings and no changes were made, skip this step.
 


### PR DESCRIPTION
The `/fix` workflow now dispatches both `verify-build` AND `polypilot-integration` after pushing fixes.

**polypilot-integration** now accepts `pr_number` and `ref` inputs, checks out the PR branch, and posts a results table back to the PR:
- Linux/GTK: build → launch under xvfb → MauiDevFlow agent → smoke tests
- Mac Catalyst: build verification
- Windows: build → launch → DevFlow → smoke tests

Testing this against PR #587 (scheduled task integration tests).