### PR TITLE
fix: Xcode beta exclusion + Linux binary find

### DIFF
--- a/.github/workflows/polypilot-integration.yml
+++ b/.github/workflows/polypilot-integration.yml
@@ -91,8 +91,6 @@ jobs:
             find PolyPilot.Gtk/bin/Debug -type f 2>/dev/null | head -20
             exit 1
           fi
-            exit 1
-          fi
           echo "binary=$BINARY" >> $GITHUB_OUTPUT
           echo "Found binary: $BINARY"
 

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -43,12 +43,14 @@ jobs:
 
       - name: Select Xcode
         run: |
-          XCODE_PATH=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -rV | head -1)
+          # Prefer stable Xcode 26.x, exclude beta
+          XCODE_PATH=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | grep -v beta | sort -rV | head -1)
           if [ -z "$XCODE_PATH" ]; then
-            XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -rV | head -1)
+            XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | grep -v beta | sort -rV | head -1)
           fi
           echo "Selected Xcode: $XCODE_PATH"
           sudo xcode-select -s "$XCODE_PATH"
+          xcodebuild -version
 
       - uses: actions/setup-dotnet@v5
         with:


### PR DESCRIPTION
macos-26 runner has Xcode 26.5_beta which has broken SDK paths. Exclude beta from selection. Also fix duplicate exit/fi in integration workflow.