### PR TITLE
Fix background task continuations silently dropped after reconnects

### DIFF
--- a/PolyPilot.Tests/ChatExperienceSafetyTests.cs
+++ b/PolyPilot.Tests/ChatExperienceSafetyTests.cs
@@ -1732,6 +1732,47 @@ public class ChatExperienceSafetyTests
     }
 
     /// <summary>
+    /// PR #712 re-review: STEER-ERROR clears IsProcessing without ClearProcessingState.
+    /// It must stamp ProcessingClearedAtTicks to prevent stale freshness-based re-arm.
+    /// </summary>
+    [Fact]
+    public void SteerError_StampsProcessingClearedAtTicks()
+    {
+        var svcPath = Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.cs");
+        var source = File.ReadAllText(svcPath);
+
+        var tagIdx = source.IndexOf("[STEER-ERROR]", StringComparison.Ordinal);
+        Assert.True(tagIdx >= 0, "STEER-ERROR diagnostic tag must exist");
+        var block = source.Substring(tagIdx, Math.Min(1000, source.Length - tagIdx));
+
+        Assert.True(block.Contains("ProcessingClearedAtTicks", StringComparison.Ordinal),
+            "STEER-ERROR must stamp ProcessingClearedAtTicks — prevents stale freshness re-arm after soft steer failure");
+    }
+
+    /// <summary>
+    /// PR #712 re-review: MCP-reload abort block clears IsProcessing without ClearProcessingState.
+    /// It must stamp ProcessingClearedAtTicks to prevent stale freshness-based re-arm.
+    /// </summary>
+    [Fact]
+    public void McpReloadAbort_StampsProcessingClearedAtTicks()
+    {
+        var svcPath = Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.cs");
+        var source = File.ReadAllText(svcPath);
+
+        var tagIdx = source.IndexOf("[MCP-RELOAD]", StringComparison.Ordinal);
+        Assert.True(tagIdx >= 0, "MCP-RELOAD tag must exist");
+        // Find the abort block that clears IsProcessing (the InvokeOnUIAsync block)
+        var abortIdx = source.IndexOf("IsProcessing = false", tagIdx, StringComparison.Ordinal);
+        Assert.True(abortIdx >= 0, "MCP-RELOAD must clear IsProcessing");
+        // Grab ~200 chars around the clearing — should include the stamp
+        var start = Math.Max(0, abortIdx - 100);
+        var block = source.Substring(start, Math.Min(300, source.Length - start));
+
+        Assert.True(block.Contains("ProcessingClearedAtTicks", StringComparison.Ordinal),
+            "MCP-RELOAD abort block must stamp ProcessingClearedAtTicks — prevents stale freshness re-arm during session replacement");
+    }
+
+    /// <summary>
     /// PR #531 review finding: _consecutiveWatchdogTimeouts reset must NOT be in
     /// ClearProcessingState. It is a success-only signal (healthy server) — resetting it
     /// on error/abort paths defeats the server-recovery detection threshold.

--- a/PolyPilot.Tests/ChatExperienceSafetyTests.cs
+++ b/PolyPilot.Tests/ChatExperienceSafetyTests.cs
@@ -467,6 +467,47 @@ public class ChatExperienceSafetyTests
     }
 
     /// <summary>
+    /// Boundary test: exactly at the threshold (>= 5s) should re-arm.
+    /// Uses a timestamp slightly beyond 5s to avoid timing-dependent flakes.
+    /// </summary>
+    [Fact]
+    public void TurnStartRearmGuard_ExactBoundary_ReturnsTrue()
+    {
+        // 5.1s to avoid sub-millisecond timing flakes while testing the >= boundary
+        var clearedAt = DateTime.UtcNow.AddSeconds(-5.1).Ticks;
+
+        var result = CopilotService.ShouldRearmOnTurnStart(
+            isProcessing: false,
+            isCurrentState: true,
+            isOrphaned: false,
+            wasUserAborted: false,
+            allowTurnStartRearm: false,
+            processingClearedAtTicks: clearedAt);
+
+        Assert.True(result, "TurnStart arriving at >= 5s threshold should re-arm");
+    }
+
+    /// <summary>
+    /// Future timestamp safety: if ProcessingClearedAtTicks is in the future
+    /// (clock skew or bug), elapsed is negative, so re-arm should NOT fire.
+    /// </summary>
+    [Fact]
+    public void TurnStartRearmGuard_FutureTimestamp_ReturnsFalse()
+    {
+        var futureTimestamp = DateTime.UtcNow.AddMinutes(5).Ticks;
+
+        var result = CopilotService.ShouldRearmOnTurnStart(
+            isProcessing: false,
+            isCurrentState: true,
+            isOrphaned: false,
+            wasUserAborted: false,
+            allowTurnStartRearm: false,
+            processingClearedAtTicks: futureTimestamp);
+
+        Assert.False(result, "Future ProcessingClearedAtTicks should not trigger freshness re-arm");
+    }
+
+    /// <summary>
     /// CompleteResponse with null generation always executes (used by error/watchdog paths).
     /// </summary>
     [Fact]
@@ -1634,6 +1675,8 @@ public class ChatExperienceSafetyTests
     /// processing, so background task continuations (agent/shell completions) can trigger
     /// re-arm after reconnects. Without this, 91% of background continuations are silently
     /// dropped (695 EVT-REARM-SKIP vs 68 EVT-REARM in production diagnostics).
+    /// The RESUME-REARM must be in the else branch of HasInterruptedToolExecution to avoid
+    /// racing with the InvokeOnUI that sets IsProcessing=true.
     /// </summary>
     [Fact]
     public void EnsureSessionConnected_SetsAllowTurnStartRearm_AfterResume()
@@ -1645,6 +1688,47 @@ public class ChatExperienceSafetyTests
             "EnsureSessionConnectedAsync must set AllowTurnStartRearm=true after resume when not processing");
         Assert.True(source.Contains("RESUME-REARM", StringComparison.Ordinal),
             "Resume re-arm must have diagnostic log tag [RESUME-REARM]");
+    }
+
+    /// <summary>
+    /// SessionErrorEvent must stamp ProcessingClearedAtTicks when clearing IsProcessing,
+    /// so the freshness-based TurnStart re-arm doesn't use a stale timestamp from a prior
+    /// turn's ClearProcessingState call. Without this, error → stale timestamp → freshness
+    /// check passes → spurious re-arm shows "Thinking..." instead of error message.
+    /// </summary>
+    [Fact]
+    public void SessionErrorEvent_StampsProcessingClearedAtTicks()
+    {
+        var eventsPath = Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.Events.cs");
+        var source = File.ReadAllText(eventsPath);
+
+        // Find the SessionErrorEvent case block
+        var caseIdx = source.IndexOf("case SessionErrorEvent err:", StringComparison.Ordinal);
+        Assert.True(caseIdx >= 0, "SessionErrorEvent handler must exist");
+        var nextBreak = source.IndexOf("break;", caseIdx, StringComparison.Ordinal);
+        var caseBody = source.Substring(caseIdx, nextBreak - caseIdx);
+
+        Assert.True(caseBody.Contains("ProcessingClearedAtTicks", StringComparison.Ordinal),
+            "SessionErrorEvent must stamp ProcessingClearedAtTicks — required to prevent stale freshness-based re-arm after errors");
+    }
+
+    /// <summary>
+    /// ClearProcessingStateForRecoveryFailure must stamp ProcessingClearedAtTicks when
+    /// clearing IsProcessing, same rationale as SessionErrorEvent above.
+    /// </summary>
+    [Fact]
+    public void ClearProcessingStateForRecoveryFailure_StampsProcessingClearedAtTicks()
+    {
+        var eventsPath = Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.Events.cs");
+        var source = File.ReadAllText(eventsPath);
+
+        var methodIdx = source.IndexOf("private void ClearProcessingStateForRecoveryFailure(", StringComparison.Ordinal);
+        Assert.True(methodIdx >= 0, "ClearProcessingStateForRecoveryFailure must exist");
+        var methodEnd = source.IndexOf("\n    }", methodIdx + 1, StringComparison.Ordinal);
+        var methodBody = source.Substring(methodIdx, methodEnd - methodIdx);
+
+        Assert.True(methodBody.Contains("ProcessingClearedAtTicks", StringComparison.Ordinal),
+            "ClearProcessingStateForRecoveryFailure must stamp ProcessingClearedAtTicks — prevents stale freshness re-arm after recovery failure");
     }
 
     /// <summary>

--- a/PolyPilot.Tests/ChatExperienceSafetyTests.cs
+++ b/PolyPilot.Tests/ChatExperienceSafetyTests.cs
@@ -368,17 +368,18 @@ public class ChatExperienceSafetyTests
     /// by stale SDK TurnStart replays.
     /// </summary>
     [Theory]
-    [InlineData(false, true, false, false, true,  true)]
-    [InlineData(false, true, false, false, false, false)]
-    [InlineData(false, true, false, true,  true,  false)]
-    [InlineData(false, true, true,  false, true,  false)]
-    [InlineData(true,  true, false, false, true,  false)]
+    [InlineData(false, true, false, false, true,  0L, true)]   // AllowTurnStartRearm=true → rearm
+    [InlineData(false, true, false, false, false, 0L, false)]  // AllowTurnStartRearm=false, no timestamp → skip
+    [InlineData(false, true, false, true,  true,  0L, false)]  // WasUserAborted → skip
+    [InlineData(false, true, true,  false, true,  0L, false)]  // IsOrphaned → skip
+    [InlineData(true,  true, false, false, true,  0L, false)]  // IsProcessing → skip
     public void TurnStartRearmGuard_OnlyAllowsSpeculativeCompletion(
         bool isProcessing,
         bool isCurrentState,
         bool isOrphaned,
         bool wasUserAborted,
         bool allowTurnStartRearm,
+        long processingClearedAtTicks,
         bool expected)
     {
         var result = CopilotService.ShouldRearmOnTurnStart(
@@ -386,9 +387,83 @@ public class ChatExperienceSafetyTests
             isCurrentState,
             isOrphaned,
             wasUserAborted,
-            allowTurnStartRearm);
+            allowTurnStartRearm,
+            processingClearedAtTicks);
 
         Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// Freshness-based re-arm: if AllowTurnStartRearm is false but processing was cleared
+    /// more than 5 seconds ago, the TurnStart is from a genuine new turn (background task
+    /// completion) and should be re-armed. This prevents the "agent says I'll get back to
+    /// you but never does" bug after reconnects that reset AllowTurnStartRearm to false.
+    /// </summary>
+    [Fact]
+    public void TurnStartRearmGuard_FreshnessBasedFallback_ReturnsTrue()
+    {
+        // Processing was cleared 10 seconds ago — well past the 5s threshold
+        var clearedAt = DateTime.UtcNow.AddSeconds(-10).Ticks;
+
+        var result = CopilotService.ShouldRearmOnTurnStart(
+            isProcessing: false,
+            isCurrentState: true,
+            isOrphaned: false,
+            wasUserAborted: false,
+            allowTurnStartRearm: false,
+            processingClearedAtTicks: clearedAt);
+
+        Assert.True(result, "TurnStart arriving >5s after processing cleared should be treated as a genuine new turn");
+    }
+
+    /// <summary>
+    /// Freshness-based re-arm: if processing was cleared very recently (&lt;5s), the TurnStart
+    /// is likely stale replay from the just-completed turn and should NOT be re-armed.
+    /// </summary>
+    [Fact]
+    public void TurnStartRearmGuard_RecentClearing_ReturnsFalse()
+    {
+        // Processing was cleared 1 second ago — within the 5s threshold
+        var clearedAt = DateTime.UtcNow.AddSeconds(-1).Ticks;
+
+        var result = CopilotService.ShouldRearmOnTurnStart(
+            isProcessing: false,
+            isCurrentState: true,
+            isOrphaned: false,
+            wasUserAborted: false,
+            allowTurnStartRearm: false,
+            processingClearedAtTicks: clearedAt);
+
+        Assert.False(result, "TurnStart arriving <5s after processing cleared is likely stale replay");
+    }
+
+    /// <summary>
+    /// Freshness-based re-arm must NOT override WasUserAborted — if the user
+    /// explicitly clicked Stop, background task continuations must be suppressed.
+    /// </summary>
+    [Fact]
+    public void TurnStartRearmGuard_FreshButAborted_ReturnsFalse()
+    {
+        var clearedAt = DateTime.UtcNow.AddSeconds(-30).Ticks;
+
+        var result = CopilotService.ShouldRearmOnTurnStart(
+            isProcessing: false,
+            isCurrentState: true,
+            isOrphaned: false,
+            wasUserAborted: true,
+            allowTurnStartRearm: false,
+            processingClearedAtTicks: clearedAt);
+
+        Assert.False(result, "User abort must suppress all re-arms regardless of freshness");
+    }
+
+    /// <summary>
+    /// The freshness threshold constant should be accessible for test verification.
+    /// </summary>
+    [Fact]
+    public void TurnStartFreshnessThreshold_IsFiveSeconds()
+    {
+        Assert.Equal(5, CopilotService.TurnStartFreshnessThresholdSeconds);
     }
 
     /// <summary>
@@ -1533,6 +1608,43 @@ public class ChatExperienceSafetyTests
         Assert.False(codeOnly.Contains("AllowTurnStartRearm = true", StringComparison.Ordinal),
             "ClearProcessingState must NOT set AllowTurnStartRearm=true — only CompleteResponse should, " +
             "to avoid a race where error/abort paths get it briefly set before they can override to false.");
+    }
+
+    /// <summary>
+    /// ClearProcessingState must set ProcessingClearedAtTicks so the freshness-based
+    /// TurnStart re-arm can distinguish genuine new turns from stale replays.
+    /// </summary>
+    [Fact]
+    public void ClearProcessingState_SetsProcessingClearedAtTicks()
+    {
+        var svcPath = Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.cs");
+        var source = File.ReadAllText(svcPath);
+
+        var methodIdx = source.IndexOf("private void ClearProcessingState(", StringComparison.Ordinal);
+        Assert.True(methodIdx >= 0, "ClearProcessingState must exist");
+        var methodEnd = source.IndexOf("\n    }", methodIdx + 1, StringComparison.Ordinal);
+        var methodBody = source.Substring(methodIdx, methodEnd - methodIdx);
+
+        Assert.True(methodBody.Contains("ProcessingClearedAtTicks", StringComparison.Ordinal),
+            "ClearProcessingState must set ProcessingClearedAtTicks — required for freshness-based TurnStart re-arm");
+    }
+
+    /// <summary>
+    /// EnsureSessionConnectedAsync must set AllowTurnStartRearm=true after resume when not
+    /// processing, so background task continuations (agent/shell completions) can trigger
+    /// re-arm after reconnects. Without this, 91% of background continuations are silently
+    /// dropped (695 EVT-REARM-SKIP vs 68 EVT-REARM in production diagnostics).
+    /// </summary>
+    [Fact]
+    public void EnsureSessionConnected_SetsAllowTurnStartRearm_AfterResume()
+    {
+        var persistencePath = Path.Combine(GetRepoRoot(), "PolyPilot", "Services", "CopilotService.Persistence.cs");
+        var source = File.ReadAllText(persistencePath);
+
+        Assert.True(source.Contains("AllowTurnStartRearm = true", StringComparison.Ordinal),
+            "EnsureSessionConnectedAsync must set AllowTurnStartRearm=true after resume when not processing");
+        Assert.True(source.Contains("RESUME-REARM", StringComparison.Ordinal),
+            "Resume re-arm must have diagnostic log tag [RESUME-REARM]");
     }
 
     /// <summary>

--- a/PolyPilot/Services/CopilotService.Events.cs
+++ b/PolyPilot/Services/CopilotService.Events.cs
@@ -787,9 +787,13 @@ public partial class CopilotService
                         isCurrentState,
                         state.IsOrphaned,
                         state.WasUserAborted,
-                        state.AllowTurnStartRearm))
+                        state.AllowTurnStartRearm,
+                        Interlocked.Read(ref state.ProcessingClearedAtTicks)))
                 {
-                    Debug($"[EVT-REARM] '{sessionName}' TurnStartEvent arrived after premature session.idle — re-arming IsProcessing");
+                    var rearmReason = state.AllowTurnStartRearm
+                        ? "premature session.idle"
+                        : "background task continuation (freshness-based)";
+                    Debug($"[EVT-REARM] '{sessionName}' TurnStartEvent arrived after {rearmReason} — re-arming IsProcessing");
                     state.PrematureIdleSignal.Set(); // Signal to ExecuteWorkerAsync that TCS result was truncated
                     state.AllowTurnStartRearm = false; // One-shot guard for this completion cycle
                     Invoke(() =>
@@ -1562,18 +1566,39 @@ public partial class CopilotService
         return string.Equals(state.LastFlushedResponseSegment, text, StringComparison.Ordinal);
     }
 
+    /// <summary>Minimum elapsed time (seconds) since processing was cleared before a TurnStart
+    /// is considered a genuinely new turn rather than stale replay. Background task completions
+    /// arrive seconds-to-hours after the prior turn; stale replays arrive within milliseconds.</summary>
+    internal const int TurnStartFreshnessThresholdSeconds = 5;
+
     internal static bool ShouldRearmOnTurnStart(
         bool isProcessing,
         bool isCurrentState,
         bool isOrphaned,
         bool wasUserAborted,
-        bool allowTurnStartRearm)
+        bool allowTurnStartRearm,
+        long processingClearedAtTicks = 0)
     {
-        return !isProcessing
-               && isCurrentState
-               && !isOrphaned
-               && !wasUserAborted
-               && allowTurnStartRearm;
+        if (isProcessing || !isCurrentState || isOrphaned || wasUserAborted)
+            return false;
+
+        // Fast path: explicit permission from CompleteResponse (premature idle recovery)
+        if (allowTurnStartRearm)
+            return true;
+
+        // Freshness-based fallback: if processing was cleared more than N seconds ago,
+        // this TurnStart is from a genuinely new turn (background task completion),
+        // not a stale replay from the just-completed turn. This handles the case where
+        // AllowTurnStartRearm was reset by a reconnect/restart but the CLI agent
+        // continued processing background tasks and eventually started a new turn.
+        if (processingClearedAtTicks > 0)
+        {
+            var elapsed = TimeSpan.FromTicks(DateTime.UtcNow.Ticks - processingClearedAtTicks);
+            if (elapsed.TotalSeconds >= TurnStartFreshnessThresholdSeconds)
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>Flush accumulated assistant text to history without ending the turn.</summary>

--- a/PolyPilot/Services/CopilotService.Events.cs
+++ b/PolyPilot/Services/CopilotService.Events.cs
@@ -790,7 +790,9 @@ public partial class CopilotService
                         state.AllowTurnStartRearm,
                         Interlocked.Read(ref state.ProcessingClearedAtTicks)))
                 {
-                    var rearmReason = state.AllowTurnStartRearm
+                    // Capture before consuming the one-shot guard to avoid volatile re-read TOCTOU
+                    var wasExplicitRearm = state.AllowTurnStartRearm;
+                    var rearmReason = wasExplicitRearm
                         ? "premature session.idle"
                         : "background task continuation (freshness-based)";
                     Debug($"[EVT-REARM] '{sessionName}' TurnStartEvent arrived after {rearmReason} — re-arming IsProcessing");
@@ -1270,6 +1272,7 @@ public partial class CopilotService
                     // (Matches CompleteResponse ordering per INV-O3)
                     state.Info.IsProcessing = false;
                     state.AllowTurnStartRearm = false; // Errors are terminal for this turn; late TurnStart events are stale
+                    Interlocked.Exchange(ref state.ProcessingClearedAtTicks, DateTime.UtcNow.Ticks); // Stamp freshness so ShouldRearmOnTurnStart doesn't use stale timestamp from prior turn
                     state.Info.IsResumed = false;
                     state.IsReconnectedSend = false; // INV-1: clear all per-turn flags on termination
                     Interlocked.Exchange(ref state.SendingFlag, 0); // Release atomic send lock (INV-1)
@@ -3274,6 +3277,7 @@ public partial class CopilotService
             Interlocked.Exchange(ref state.ToolHealthStaleChecks, 0);
             Interlocked.Exchange(ref state.EventCountThisTurn, 0);
             Interlocked.Exchange(ref state.TurnEndReceivedAtTicks, 0);
+            Interlocked.Exchange(ref state.ProcessingClearedAtTicks, DateTime.UtcNow.Ticks); // Stamp freshness so ShouldRearmOnTurnStart doesn't use stale timestamp from prior turn
             state.Info.ProcessingStartedAt = null;
             state.Info.ToolCallCount = 0;
             state.Info.ProcessingPhase = 0;

--- a/PolyPilot/Services/CopilotService.Persistence.cs
+++ b/PolyPilot/Services/CopilotService.Persistence.cs
@@ -564,6 +564,16 @@ public partial class CopilotService
             }
 
             Debug($"Lazy-resume complete: '{sessionName}'");
+            // If the session is NOT processing after resume (common case: session completed
+            // before the reconnect), enable re-arm so background task continuations
+            // (agent/shell completions that trigger a new CLI turn) are properly detected.
+            // Without this, AllowTurnStartRearm defaults to false on new SessionState objects,
+            // causing EVT-REARM-SKIP to silently drop genuine new turns after reconnects.
+            if (!state.Info.IsProcessing)
+            {
+                state.AllowTurnStartRearm = true;
+                Debug($"[RESUME-REARM] '{sessionName}' not processing after resume — enabling AllowTurnStartRearm for background task continuations");
+            }
         }
         finally
         {

--- a/PolyPilot/Services/CopilotService.Persistence.cs
+++ b/PolyPilot/Services/CopilotService.Persistence.cs
@@ -562,18 +562,21 @@ public partial class CopilotService
                     });
                 }
             }
-
-            Debug($"Lazy-resume complete: '{sessionName}'");
-            // If the session is NOT processing after resume (common case: session completed
-            // before the reconnect), enable re-arm so background task continuations
-            // (agent/shell completions that trigger a new CLI turn) are properly detected.
-            // Without this, AllowTurnStartRearm defaults to false on new SessionState objects,
-            // causing EVT-REARM-SKIP to silently drop genuine new turns after reconnects.
-            if (!state.Info.IsProcessing)
+            else
             {
+                // Session is NOT processing after resume (common case: session completed
+                // before the reconnect). Enable re-arm so background task continuations
+                // (agent/shell completions that trigger a new CLI turn) are properly detected.
+                // Without this, AllowTurnStartRearm defaults to false on new SessionState objects,
+                // causing EVT-REARM-SKIP to silently drop genuine new turns after reconnects.
+                // NOTE: This is in the `else` branch to avoid a race with InvokeOnUI above —
+                // if HasInterruptedToolExecution is true, IsProcessing=true is queued async
+                // and reading it synchronously here would see stale false.
                 state.AllowTurnStartRearm = true;
                 Debug($"[RESUME-REARM] '{sessionName}' not processing after resume — enabling AllowTurnStartRearm for background task continuations");
             }
+
+            Debug($"Lazy-resume complete: '{sessionName}'");
         }
         finally
         {

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -3820,6 +3820,16 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
                                                         siblingState.Info.ProcessingStartedAt ??= DateTime.UtcNow;
                                                         siblingState.ResponseCompletion = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
                                                     }
+                                                    // If the sibling was NOT processing, enable re-arm for background
+                                                    // task continuations BEFORE handler registration so there's no
+                                                    // window where TurnStart arrives with AllowTurnStartRearm=false.
+                                                    if (!siblingWasProcessing)
+                                                    {
+                                                        siblingState.AllowTurnStartRearm = true;
+                                                        // Seed ProcessingClearedAtTicks so the freshness fallback works
+                                                        // even if AllowTurnStartRearm gets consumed before the next TurnStart.
+                                                        Interlocked.Exchange(ref siblingState.ProcessingClearedAtTicks, DateTime.UtcNow.Ticks);
+                                                    }
                                                     // Register handler BEFORE publishing to dictionary —
                                                     // no window where events arrive with no handler.
                                                     resumed.On(evt => HandleSessionEvent(siblingState, evt));
@@ -3835,13 +3845,6 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
                                                     }
                                                     DisposePrematureIdleSignal(capturedOtherState);
                                                     Debug($"[RECONNECT] Re-resumed sibling session '{capturedKey}' after client recreation");
-                                                    // If the sibling was NOT processing, enable re-arm for background
-                                                    // task continuations (same rationale as RESUME-REARM above).
-                                                    if (!siblingWasProcessing)
-                                                    {
-                                                        siblingState.AllowTurnStartRearm = true;
-                                                        Debug($"[RECONNECT-REARM] Sibling '{capturedKey}' not processing — enabling AllowTurnStartRearm");
-                                                    }
                                                     // Start watchdog on UI thread — IsProcessing and companion fields
                                                     // were already set before handler registration (above), so this
                                                     // just needs to start the timer and notify the UI.

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -722,6 +722,15 @@ public partial class CopilotService : IAsyncDisposable
         /// </summary>
         public volatile bool AllowTurnStartRearm;
         /// <summary>
+        /// UTC ticks when IsProcessing was last cleared (via ClearProcessingState).
+        /// Used by ShouldRearmOnTurnStart as a freshness-based fallback: if enough time
+        /// has elapsed since processing was cleared (&gt;5s), a TurnStartEvent is treated
+        /// as a genuinely new turn (background task completion) rather than stale replay.
+        /// This prevents the "agent says I'll get back to you but never does" bug caused
+        /// by AllowTurnStartRearm being reset to false after reconnects.
+        /// </summary>
+        public long ProcessingClearedAtTicks;
+        /// <summary>
         /// Stable identity of the most recently reported background task set (agent IDs + shell IDs).
         /// Preserved across SendPromptAsync so the same orphaned background shells keep aging instead
         /// of resetting the zombie timeout every time the user sends another prompt.
@@ -813,6 +822,10 @@ public partial class CopilotService : IAsyncDisposable
         state.IsReconnectedSend = false;
         CancelTurnEndFallback(state);
         CancelToolHealthCheck(state);
+        // Record when processing was cleared — used by ShouldRearmOnTurnStart freshness check
+        // to distinguish genuinely new turns (background task completion after seconds/hours)
+        // from stale replays (same turn, < 1 second gap).
+        Interlocked.Exchange(ref state.ProcessingClearedAtTicks, DateTime.UtcNow.Ticks);
         // NOTE: AllowTurnStartRearm, _consecutiveWatchdogTimeouts, and ConsecutiveStuckCount
         // are NOT reset here. All three are cross-turn health accumulators:
         // - AllowTurnStartRearm = true only belongs on the normal-completion path (CompleteResponse)
@@ -3822,6 +3835,13 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
                                                     }
                                                     DisposePrematureIdleSignal(capturedOtherState);
                                                     Debug($"[RECONNECT] Re-resumed sibling session '{capturedKey}' after client recreation");
+                                                    // If the sibling was NOT processing, enable re-arm for background
+                                                    // task continuations (same rationale as RESUME-REARM above).
+                                                    if (!siblingWasProcessing)
+                                                    {
+                                                        siblingState.AllowTurnStartRearm = true;
+                                                        Debug($"[RECONNECT-REARM] Sibling '{capturedKey}' not processing — enabling AllowTurnStartRearm");
+                                                    }
                                                     // Start watchdog on UI thread — IsProcessing and companion fields
                                                     // were already set before handler registration (above), so this
                                                     // just needs to start the timer and notify the UI.

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -4509,6 +4509,7 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
                 // No MaxValue guard needed: STEER-ERROR only reaches non-orphaned sessions
                 Interlocked.Increment(ref state.ProcessingGeneration); // Invalidate stale callbacks
                 state.Info.IsProcessing = false;
+                Interlocked.Exchange(ref state.ProcessingClearedAtTicks, DateTime.UtcNow.Ticks);
                 if (state.Info.ProcessingStartedAt is { } steerStarted)
                     state.Info.TotalApiTimeSeconds += (DateTime.UtcNow - steerStarted).TotalSeconds;
                 state.Info.ProcessingStartedAt = null;
@@ -4790,6 +4791,7 @@ ALWAYS run the relaunch script as the final step after making changes to this pr
                     // No MaxValue guard needed: MCP-reload only reaches non-orphaned sessions
                     Interlocked.Increment(ref state.ProcessingGeneration); // Invalidate stale callbacks
                     state.Info.IsProcessing = false;
+                    Interlocked.Exchange(ref state.ProcessingClearedAtTicks, DateTime.UtcNow.Ticks);
                     state.Info.IsResumed = false;
                     state.HasUsedToolsThisTurn = false;
                     ClearDeferredIdleTracking(state);


### PR DESCRIPTION
## Problem

When the CLI agent says "I'll monitor and get back to you," it starts background tasks (shells/agents). When those complete, the CLI auto-starts a new turn via `AssistantTurnStartEvent`. PolyPilot's `EVT-REARM` logic should detect this and re-arm `IsProcessing`, but `AllowTurnStartRearm` (the one-shot guard) defaults to `false` and is only set to `true` by `CompleteResponse`.

After reconnects (2,219 observed in production diagnostics), session state is rebuilt and `AllowTurnStartRearm` resets to `false`. **91% of background task continuations were silently dropped** (695 `EVT-REARM-SKIP` vs 68 `EVT-REARM`).

## Root Cause

`AllowTurnStartRearm` is a volatile bool that defaults to `false` on new `SessionState` objects. It's designed as a one-shot guard for premature `session.idle` recovery:
- Set `true` only in `CompleteResponse` (normal completion)
- Set `false` in `SendPromptAsync`, `AbortSessionAsync`, error handlers, watchdog
- After reconnects: session state rebuilt → flag reverts to `false` → `EVT-REARM-SKIP`

## Fix (two-part)

### 1. Set `AllowTurnStartRearm=true` after session resume when not processing

In `EnsureSessionConnectedAsync` and the sibling re-resume path: after `ResumeSessionAsync` returns and the session is not processing, set `AllowTurnStartRearm = true`. This enables re-arm for background task continuations.

### 2. Freshness-based re-arm fallback

Added `ProcessingClearedAtTicks` field to `SessionState`, set in `ClearProcessingState`. If `AllowTurnStartRearm` is `false` but >5 seconds have elapsed since processing was cleared, treat the `TurnStart` as a genuinely new turn and allow re-arm.

The 5-second threshold cleanly separates:
- **Stale replays**: arrive <100ms after completion (same turn, should be skipped)
- **Background task continuations**: arrive seconds to hours later (new turn, should re-arm)

## Changes

| File | Change |
|------|--------|
| `CopilotService.cs` | Add `ProcessingClearedAtTicks` field; set it in `ClearProcessingState`; set `AllowTurnStartRearm=true` in sibling re-resume |
| `CopilotService.Events.cs` | Add `TurnStartFreshnessThresholdSeconds` constant; update `ShouldRearmOnTurnStart` with freshness fallback; update call site with new param + descriptive log |
| `CopilotService.Persistence.cs` | Set `AllowTurnStartRearm=true` after resume when not processing |
| `ChatExperienceSafetyTests.cs` | Update existing `TurnStartRearmGuard` tests; add 4 new behavioral tests for freshness-based re-arm; add 2 structural invariant tests |

## Tests

All 3,516 tests pass (6 new tests added).