### PR TITLE
fix: scanner false positive on cancel-in-progress in comments

### DIFF
--- a/.github/skills/gh-aw-guide/scripts/Check-WorkflowSecurity.ps1
+++ b/.github/skills/gh-aw-guide/scripts/Check-WorkflowSecurity.ps1
@@ -52,14 +52,18 @@ function Test-Workflow {
         $frontmatter = $Matches[1]
     }
 
+    # Strip full-line comments once — prevents false positives (matching comment text)
+    # and false negatives (-notmatch skipping because a comment contains the keyword)
+    $fm = ($frontmatter -split "`n" | Where-Object { $_ -notmatch '^\s*#' }) -join "`n"
+
     # --- Trigger checks ---
 
     # pull_request_target without safety gates
-    if ($frontmatter -match 'pull_request_target') {
+    if ($fm -match 'pull_request_target') {
         # Note: Do NOT check for min-integrity — compiler v0.62.2 emits incomplete
         # guard policy when min-integrity is hardcoded. The runtime determine-automatic-lockdown
         # step handles integrity filtering automatically for pull_request_target events.
-        if ($frontmatter -match 'roles:\s*all') {
+        if ($fm -match 'roles:\s*all') {
             $findings += @{
                 file     = $name
                 severity = "CRITICAL"
@@ -71,8 +75,8 @@ function Test-Workflow {
     }
 
     # workflow_run without branch restrictions
-    if ($frontmatter -match 'workflow_run') {
-        if ($frontmatter -notmatch 'branches:') {
+    if ($fm -match 'workflow_run') {
+        if ($fm -notmatch 'branches:') {
             $findings += @{
                 file     = $name
                 severity = "MODERATE"
@@ -84,8 +88,8 @@ function Test-Workflow {
     }
 
     # push with broad patterns
-    if ($frontmatter -match 'push:') {
-        if ($frontmatter -match 'branches:\s*\[\s*[''"]?\*\*[''"]?\s*\]') {
+    if ($fm -match 'push:') {
+        if ($fm -match 'branches:\s*\[\s*[''"]?\*\*[''"]?\s*\]') {
             $findings += @{
                 file     = $name
                 severity = "HIGH"
@@ -97,7 +101,7 @@ function Test-Workflow {
     }
 
     # roles: all on PR-processing workflows
-    if ($frontmatter -match 'roles:\s*all' -and $frontmatter -match '(pull_request|issue_comment|slash_command)') {
+    if ($fm -match 'roles:\s*all' -and $fm -match '(pull_request|issue_comment|slash_command)') {
         $findings += @{
             file     = $name
             severity = "HIGH"
@@ -110,20 +114,22 @@ function Test-Workflow {
     # --- Concurrency checks ---
 
     # slash_command with cancel-in-progress: true
-    if ($frontmatter -match 'slash_command' -and $frontmatter -match 'cancel-in-progress:\s*true') {
-        $findings += @{
-            file     = $name
-            severity = "MODERATE"
-            rule     = "slash-command-cancel-in-progress"
-            message  = "slash_command with cancel-in-progress: true. Non-matching comments can kill in-progress agent runs."
-            fix      = "Use cancel-in-progress: false for slash_command workflows"
+    if ($fm -match 'slash_command') {
+        if ($fm -match 'cancel-in-progress:\s*true') {
+            $findings += @{
+                file     = $name
+                severity = "MODERATE"
+                rule     = "slash-command-cancel-in-progress"
+                message  = "slash_command with cancel-in-progress: true. Non-matching comments can kill in-progress agent runs."
+                fix      = "Use cancel-in-progress: false for slash_command workflows"
+            }
         }
     }
 
     # --- Safe output checks ---
 
     # submit-pull-request-review without allowed-events
-    if ($frontmatter -match 'submit-pull-request-review' -and $frontmatter -notmatch 'allowed-events') {
+    if ($fm -match 'submit-pull-request-review' -and $fm -notmatch 'allowed-events') {
         $findings += @{
             file     = $name
             severity = "HIGH"
@@ -134,7 +140,7 @@ function Test-Workflow {
     }
 
     # create-pull-request or push-to-pull-request-branch without protected-files
-    if ($frontmatter -match '(create-pull-request|push-to-pull-request-branch)' -and $frontmatter -notmatch 'protected-files') {
+    if ($fm -match '(create-pull-request|push-to-pull-request-branch)' -and $fm -notmatch 'protected-files') {
         $findings += @{
             file     = $name
             severity = "LOW"
@@ -148,12 +154,12 @@ function Test-Workflow {
 
     # Check for script execution patterns in steps/pre-agent-steps
     $stepsSection = ""
-    if ($frontmatter -match '(?s)((?:pre-agent-)?steps:\s*\n(?:\s+-.*\n?)+)') {
+    if ($fm -match '(?s)((?:pre-agent-)?steps:\s*\n(?:\s+-.*\n?)+)') {
         $stepsSection = $Matches[1]
     }
 
     if ($stepsSection -match '(run:|pwsh|bash|python|node)\s.*\.(ps1|sh|py|js)') {
-        if ($frontmatter -match '(pull_request_target|pull_request|issue_comment|slash_command)') {
+        if ($fm -match '(pull_request_target|pull_request|issue_comment|slash_command)') {
             $findings += @{
                 file     = $name
                 severity = "HIGH"


### PR DESCRIPTION
The security scanner matched `cancel-in-progress: true` inside a YAML comment. Fixed by filtering comment lines before regex match.