### PR TITLE
feat: run scheduled-tasks integration test on Mac Catalyst

### DIFF
--- a/.github/workflows/polypilot-integration.yml
+++ b/.github/workflows/polypilot-integration.yml
@@ -543,6 +543,13 @@ jobs:
           curl -s http://localhost:$PORT/api/screenshot -o /tmp/polypilot-after-session.png
           echo "✅ Final screenshot: $(wc -c < /tmp/polypilot-after-session.png) bytes"
 
+      - name: "Feature Test: Scheduled Tasks (Mac Catalyst)"
+        if: steps.devflow.outputs.agent_port != '' && (inputs.scenario == 'scheduled-tasks' || inputs.scenario == 'full')
+        run: |
+          PORT=${{ steps.devflow.outputs.agent_port }}
+          echo "Running scheduled tasks integration tests against port $PORT"
+          bash .github/integration-tests/scheduled-tasks.sh "$PORT"
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -555,6 +562,7 @@ jobs:
             /tmp/polypilot-after-create.png
             /tmp/polypilot-after-fill.png
             /tmp/polypilot-after-session.png
+            /tmp/polypilot-scheduled-tasks-*.png
             /tmp/polypilot-stdout.log
             /tmp/polypilot-stderr.log
           if-no-files-found: ignore


### PR DESCRIPTION
Wires the scheduled-tasks CDP test script to the Mac Catalyst job in polypilot-integration. This is the most reliable platform for DevFlow integration.