### PR TITLE
fix: awaitPromise for async CDP eval

### DIFF
--- a/PolyPilot.IntegrationTests/ClipboardCopyTests.cs
+++ b/PolyPilot.IntegrationTests/ClipboardCopyTests.cs
@@ -38,6 +38,72 @@ public class ClipboardCopyTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task CopyButton_ActuallyCopiesTextToClipboard()
+    {
+        await WaitForCdpReadyAsync();
+
+        // Find a copy button
+        var hasCopyBtn = await ExistsAsync(".copy-icon-btn");
+        if (!hasCopyBtn)
+        {
+            var sessionExists = await ExistsAsync(".session-item, .session-list-item");
+            if (sessionExists)
+            {
+                await ClickAsync(".session-item, .session-list-item");
+                await Task.Delay(2000);
+                hasCopyBtn = await ExistsAsync(".copy-icon-btn");
+            }
+        }
+
+        if (!hasCopyBtn)
+        {
+            Output.WriteLine("No messages with copy buttons found — skipping clipboard verification");
+            return;
+        }
+
+        // Click the copy button
+        await ClickAsync(".copy-icon-btn");
+        await Task.Delay(500);
+
+        // Wait for the copied indicator
+        for (var i = 0; i < 5; i++)
+        {
+            if (await ExistsAsync(".copy-icon-btn.copied"))
+                break;
+            await Task.Delay(200);
+        }
+
+        // Read clipboard via JSInvokable static method — this calls MAUI Clipboard.GetTextAsync()
+        // DotNet.invokeMethodAsync returns a Promise — must use awaitPromise in CDP
+        var clipboardText = "";
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            clipboardText = await CdpEvalAsync(
+                "DotNet.invokeMethodAsync('PolyPilot', 'GetClipboardText')",
+                awaitPromise: true);
+            Output.WriteLine($"Clipboard read attempt {attempt}: '{clipboardText}'");
+            if (!string.IsNullOrWhiteSpace(clipboardText))
+                break;
+            await Task.Delay(500);
+        }
+
+        // If JSInvokable didn't work, try the Clipboard API check as fallback
+        if (string.IsNullOrWhiteSpace(clipboardText))
+        {
+            var hasText = await CdpEvalAsync(
+                "DotNet.invokeMethodAsync('PolyPilot', 'GetClipboardText').then(t => 'GOT:' + t).catch(e => 'ERR:' + e)",
+                awaitPromise: true);
+            Output.WriteLine($"Clipboard fallback: '{hasText}'");
+        }
+
+        Output.WriteLine($"Final clipboard content: '{clipboardText}'");
+
+        Assert.False(string.IsNullOrWhiteSpace(clipboardText),
+            "Clipboard should contain text after clicking Copy — " +
+            "proves MAUI Clipboard.SetTextAsync() actually wrote to system clipboard");
+    }
+
+    [Fact]
     public async Task CopyButton_ClickShowsSuccessIndicator()
     {
         await WaitForCdpReadyAsync();

--- a/PolyPilot.IntegrationTests/Fixtures/IntegrationTestBase.cs
+++ b/PolyPilot.IntegrationTests/Fixtures/IntegrationTestBase.cs
@@ -37,18 +37,22 @@ public abstract class IntegrationTestBase
     }
 
     /// <summary>Evaluate JavaScript in the Blazor WebView via CDP.</summary>
-    protected async Task<string> CdpEvalAsync(string expression)
+    protected async Task<string> CdpEvalAsync(string expression, bool awaitPromise = false)
     {
         // Use direct HTTP POST to /api/cdp — the Driver's SendCdpCommandAsync
         // uses a different route that may not be available on all agent versions.
+        var paramsObj = new JsonObject
+        {
+            ["expression"] = expression,
+            ["returnByValue"] = true,
+        };
+        if (awaitPromise)
+            paramsObj["awaitPromise"] = true;
+
         var payload = new JsonObject
         {
             ["method"] = "Runtime.evaluate",
-            ["params"] = new JsonObject
-            {
-                ["expression"] = expression,
-                ["returnByValue"] = true,
-            }
+            ["params"] = paramsObj,
         };
 
         var response = await Http.PostAsync("/api/cdp",


### PR DESCRIPTION
CDP needs awaitPromise:true for DotNet.invokeMethodAsync (Promise). Also adds diagnostics to clipboard readback test.