### PR TITLE
fix: integration workflow — correct binary name and report job

### DIFF
--- a/.github/workflows/polypilot-integration.yml
+++ b/.github/workflows/polypilot-integration.yml
@@ -78,10 +78,11 @@ jobs:
         run: |
           echo "=== Build output ==="
           ls -la PolyPilot.Gtk/bin/Debug/net10.0/ 2>/dev/null | head -20 || true
-          BINARY=$(find PolyPilot.Gtk/bin/Debug -name "PolyPilot.Gtk" -type f -executable 2>/dev/null | head -1)
+          # AssemblyName in PolyPilot.Gtk.csproj is "PolyPilot" (not "PolyPilot.Gtk")
+          BINARY=$(find PolyPilot.Gtk/bin/Debug -name "PolyPilot" -type f -executable 2>/dev/null | head -1)
           if [ -z "$BINARY" ]; then
             # On Linux, the native executable may not exist — use dotnet exec with the DLL
-            DLL=$(find PolyPilot.Gtk/bin/Debug -name "PolyPilot.Gtk.dll" -type f 2>/dev/null | head -1)
+            DLL=$(find PolyPilot.Gtk/bin/Debug -name "PolyPilot.dll" -type f 2>/dev/null | head -1)
             if [ -n "$DLL" ]; then
               echo "No native executable found, using dotnet exec: $DLL"
               BINARY="dotnet $DLL"
@@ -764,4 +765,4 @@ jobs:
           [View full run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
           EOF
 
-          gh pr comment "$PR" --body "$(cat /tmp/report.md)"
+          gh pr comment "$PR" --repo "${{ github.repository }}" --body "$(cat /tmp/report.md)"


### PR DESCRIPTION
## Summary

Fixes two bugs in `polypilot-integration.yml` that caused the integration test run dispatched by PR #745 to fail:

### Bug 1: Linux/GTK binary not found
The `find-binary` step searched for `PolyPilot.Gtk` / `PolyPilot.Gtk.dll`, but the GTK csproj has `<AssemblyName>PolyPilot</AssemblyName>`. The build output is named `PolyPilot` / `PolyPilot.dll`, so the search always failed.

### Bug 2: Report job — 'not a git repository'
The report job runs `gh pr comment` without an `actions/checkout` step. The `gh` CLI can't determine the repo without a git context. Fixed by adding `--repo ${{ github.repository }}`.

### Evidence
Integration test run [#24815950280](https://github.com/PureWeen/PolyPilot/actions/runs/24815950280) — dispatched by agent-fix for PR #745 — failed on both of these.