### PR TITLE
fix: auto-fix-on-failure never triggers for workflow_dispatch runs

### DIFF
--- a/.github/workflows/auto-fix-on-failure.yml
+++ b/.github/workflows/auto-fix-on-failure.yml
@@ -10,8 +10,6 @@ on:
       - "Verify Build (Cross-Platform)"
       - "PolyPilot Integration Test"
     types: [completed]
-    branches-ignore:
-      - main
 
 env:
   GH_TOKEN: ${{ github.token }}
@@ -23,7 +21,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'failure'
     permissions:
       actions: write
-      pull-requests: read
+      pull-requests: write
 
     steps:
       - name: Find associated PR
@@ -36,21 +34,32 @@ jobs:
           echo "Failed workflow: $FAILED_WORKFLOW"
           echo "Failed run: $FAILED_RUN"
 
-          # Find open PR for this branch
-          PR_NUMBER=$(gh pr list --repo ${{ github.repository }} \
-            --head "$BRANCH" --state open \
-            --json number --jq '.[0].number // empty')
+          # workflow_dispatch runs execute on main but carry the PR number
+          # in their inputs. Try reading it from the API first.
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/actions/runs/$FAILED_RUN" \
+            --jq '.inputs.pr_number // empty' 2>/dev/null || true)
+
+          # Fall back to branch-based lookup for push/PR-triggered runs
+          if [ -z "$PR_NUMBER" ]; then
+            PR_NUMBER=$(gh pr list --repo ${{ github.repository }} \
+              --head "$BRANCH" --state open \
+              --json number --jq '.[0].number // empty')
+          fi
 
           if [ -z "$PR_NUMBER" ]; then
-            echo "No open PR found for branch $BRANCH — skipping"
+            echo "No associated PR found — skipping"
             echo "has_pr=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          echo "Found PR #$PR_NUMBER"
+          # Resolve the PR's head branch for the comment
+          PR_BRANCH=$(gh pr view "$PR_NUMBER" --repo ${{ github.repository }} \
+            --json headRefName --jq '.headRefName' 2>/dev/null || echo "$BRANCH")
+
+          echo "Found PR #$PR_NUMBER (branch: $PR_BRANCH)"
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "has_pr=true" >> $GITHUB_OUTPUT
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
           echo "failed_workflow=$FAILED_WORKFLOW" >> $GITHUB_OUTPUT
           echo "failed_run=$FAILED_RUN" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary

The auto-fix feedback loop (`auto-fix-on-failure.yml`) has **never triggered** (0 runs) because two bugs prevented it from working with `workflow_dispatch`-based integration tests.

### Bug 1: `branches-ignore: main`
Integration tests dispatched by the agent-fix workflow use `workflow_dispatch`, which always runs on `main` (the `ref` input only controls which code is checked out). The `branches-ignore: main` filter excluded all such runs.

### Bug 2: PR lookup by `head_branch`  
For `workflow_dispatch` runs, `head_branch` is `main`, not the PR branch. The original code searched for a PR with `--head main`, finding nothing.

**Fix:** Read `pr_number` from the failed run's inputs via the API first, fall back to branch-based lookup for push/PR-triggered runs. Also resolve the actual PR branch name for the comment.

### Bug 3: Insufficient permissions
`pull-requests: read` → `pull-requests: write` (needed for `gh pr comment`).

### Testing
This was discovered while validating the end-to-end agent-fix pipeline for PR #745. The agent correctly dispatched integration tests, but when they failed (due to workflow YAML bugs fixed in #755), the auto-fix loop never fired.