### PR TITLE
fix: auto-fix PR discovery via run-name embedding

### DIFF
--- a/.github/workflows/auto-fix-on-failure.yml
+++ b/.github/workflows/auto-fix-on-failure.yml
@@ -30,14 +30,15 @@ jobs:
           BRANCH="${{ github.event.workflow_run.head_branch }}"
           FAILED_WORKFLOW="${{ github.event.workflow_run.name }}"
           FAILED_RUN="${{ github.event.workflow_run.id }}"
+          DISPLAY_TITLE="${{ github.event.workflow_run.display_title }}"
           echo "Branch: $BRANCH"
           echo "Failed workflow: $FAILED_WORKFLOW"
           echo "Failed run: $FAILED_RUN"
+          echo "Display title: $DISPLAY_TITLE"
 
-          # workflow_dispatch runs execute on main but carry the PR number
-          # in their inputs. Try reading it from the API first.
-          PR_NUMBER=$(gh api "repos/${{ github.repository }}/actions/runs/$FAILED_RUN" \
-            --jq '.inputs.pr_number // empty' 2>/dev/null || true)
+          # The dispatching workflow embeds "PR #NNN" in run-name.
+          # Parse it from the display title first.
+          PR_NUMBER=$(echo "$DISPLAY_TITLE" | grep -oP 'PR #\K[0-9]+' || true)
 
           # Fall back to branch-based lookup for push/PR-triggered runs
           if [ -z "$PR_NUMBER" ]; then

--- a/.github/workflows/polypilot-integration.yml
+++ b/.github/workflows/polypilot-integration.yml
@@ -1,4 +1,5 @@
 name: "PolyPilot Integration Test"
+run-name: "PolyPilot Integration Test${{ inputs.pr_number && format(' — PR #{0}', inputs.pr_number) || '' }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -1,4 +1,5 @@
 name: Verify Build (Cross-Platform)
+run-name: "Verify Build${{ inputs.pr_number && format(' — PR #{0}', inputs.pr_number) || '' }}"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Problem

PR #756 fixed the `branches-ignore: main` blocker and added API-based input reading, but the GitHub API returns `inputs: null` for completed `workflow_dispatch` runs. The auto-fix-on-failure workflow still can't find the PR number.

## Fix

1. **`polypilot-integration.yml`** and **`verify-build.yml`**: Add `run-name` that embeds `PR #NNN` in the display title when `pr_number` input is provided
2. **`auto-fix-on-failure.yml`**: Parse PR number from `github.event.workflow_run.display_title` instead of trying to read inputs from the API

This completes the auto-fix feedback loop: agent-fix dispatches tests → tests fail → auto-fix-on-failure finds the PR from the run name → dispatches `/fix`.