### PR TITLE
feat: make agent-fix pipeline fully autonomous (end-to-end)

### DIFF
--- a/.github/workflows/agent-fix.lock.yml
+++ b/.github/workflows/agent-fix.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"faa2bf3ff67734b7c837563a43fd538972113c0c92a8445999f97937210c3d85","compiler_version":"v0.69.3","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7c28eddce0ffd2c32ecf0ffc9a3ce735435a78ee4077be9e01bc053c8c774630","compiler_version":"v0.69.3","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"006ffd856b868b71df342dbe0ba082a963249b31","version":"v0.69.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.26"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.26"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.26"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.26"},{"image":"ghcr.io/github/github-mcp-server:v1.0.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -230,19 +230,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_4f800411f4637140_EOF'
+          cat << 'GH_AW_PROMPT_1f516a78ed60a889_EOF'
           <system>
-          GH_AW_PROMPT_4f800411f4637140_EOF
+          GH_AW_PROMPT_1f516a78ed60a889_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4f800411f4637140_EOF'
+          cat << 'GH_AW_PROMPT_1f516a78ed60a889_EOF'
           <safe-output-tools>
-          Tools: add_comment(max:3), create_pull_request, dispatch_workflow(max:2), missing_tool, missing_data, noop
-          GH_AW_PROMPT_4f800411f4637140_EOF
+          Tools: add_comment(max:3), create_pull_request, dispatch_workflow(max:3), missing_tool, missing_data, noop
+          GH_AW_PROMPT_1f516a78ed60a889_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_4f800411f4637140_EOF'
+          cat << 'GH_AW_PROMPT_1f516a78ed60a889_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -272,12 +272,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_4f800411f4637140_EOF
+          GH_AW_PROMPT_1f516a78ed60a889_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4f800411f4637140_EOF'
+          cat << 'GH_AW_PROMPT_1f516a78ed60a889_EOF'
           </system>
           {{#runtime-import .github/workflows/agent-fix.md}}
-          GH_AW_PROMPT_4f800411f4637140_EOF
+          GH_AW_PROMPT_1f516a78ed60a889_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -452,16 +452,16 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a3518ceb05c9ec12_EOF'
-          {"add_comment":{"max":3,"target":"*"},"create_pull_request":{"auto_merge":false,"draft":true,"max":1,"max_patch_size":1024,"preserve_branch_name":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","protected_path_prefixes":[".github/",".agents/"]},"create_report_incomplete_issue":{},"dispatch_workflow":{"max":2,"workflow_files":{"polypilot-integration":".yml","verify-build":".yml"},"workflows":["polypilot-integration","verify-build"]},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a3518ceb05c9ec12_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a441522289813da5_EOF'
+          {"add_comment":{"max":3,"target":"*"},"create_pull_request":{"auto_merge":false,"draft":false,"max":1,"max_patch_size":1024,"preserve_branch_name":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","protected_path_prefixes":[".github/",".agents/"]},"create_report_incomplete_issue":{},"dispatch_workflow":{"aw_context_workflows":["review.agent"],"max":3,"workflow_files":{"polypilot-integration":".yml","review.agent":".lock.yml","verify-build":".yml"},"workflows":["polypilot-integration","verify-build","review.agent"]},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_a441522289813da5_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 3 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. PRs will be created as drafts."
+                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created."
               },
               "repo_params": {},
               "dynamic_tools": [
@@ -517,6 +517,29 @@ jobs:
                     "type": "object"
                   },
                   "name": "verify_build"
+                },
+                {
+                  "_workflow_name": "review.agent",
+                  "description": "Dispatch the 'review.agent' workflow with workflow_dispatch trigger. This workflow must support workflow_dispatch and be in .github/workflows/ directory in the same repository.",
+                  "inputSchema": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "aw_context": {
+                        "default": "",
+                        "description": "Agent caller context (used internally by Agentic Workflows).",
+                        "type": "string"
+                      },
+                      "pr_number": {
+                        "description": "PR number to review",
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "pr_number"
+                    ],
+                    "type": "object"
+                  },
+                  "name": "review_agent"
                 }
               ]
             }
@@ -738,7 +761,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_a58630e41044a115_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_ef5369e1f56c862b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -779,7 +802,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a58630e41044a115_EOF
+          GH_AW_MCP_CONFIG_ef5369e1f56c862b_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1423,7 +1446,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dist.nuget.org,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":3,\"target\":\"*\"},\"create_pull_request\":{\"auto_merge\":false,\"draft\":true,\"max\":1,\"max_patch_size\":1024,\"preserve_branch_name\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"protected_path_prefixes\":[\".github/\",\".agents/\"]},\"create_report_incomplete_issue\":{},\"dispatch_workflow\":{\"max\":2,\"workflow_files\":{\"polypilot-integration\":\".yml\",\"verify-build\":\".yml\"},\"workflows\":[\"polypilot-integration\",\"verify-build\"]},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":3,\"target\":\"*\"},\"create_pull_request\":{\"auto_merge\":false,\"draft\":false,\"max\":1,\"max_patch_size\":1024,\"preserve_branch_name\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"protected_path_prefixes\":[\".github/\",\".agents/\"]},\"create_report_incomplete_issue\":{},\"dispatch_workflow\":{\"aw_context_workflows\":[\"review.agent\"],\"max\":3,\"workflow_files\":{\"polypilot-integration\":\".yml\",\"review.agent\":\".lock.yml\",\"verify-build\":\".yml\"},\"workflows\":[\"polypilot-integration\",\"verify-build\",\"review.agent\"]},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/agent-fix.md
+++ b/.github/workflows/agent-fix.md
@@ -35,15 +35,15 @@ tools:
 safe-outputs:
   create-pull-request:
     auto-merge: false
-    draft: true
+    draft: false
     preserve-branch-name: true
     protected-files: fallback-to-issue
   add-comment:
     max: 3
     target: "*"
   dispatch-workflow:
-    workflows: [polypilot-integration, verify-build]
-    max: 2
+    workflows: [polypilot-integration, verify-build, review.agent]
+    max: 3
 
 timeout-minutes: 90
 
@@ -171,9 +171,9 @@ For each finding from the self-review:
 
 Repeat Steps 6-7 up to **3 times** (max 3 review rounds).
 
-## Step 8: Dispatch Integration Tests
+## Step 8: Dispatch Integration Tests and Review
 
-After all fixes are committed, dispatch the integration test workflows.
+After all fixes are committed, dispatch the integration test workflows AND the expert code review.
 
 **Important:** Use the exact branch name from the PR. If you named your branch `fix/issue-N`, the safe-outputs job will use that name without modification (because `preserve-branch-name: true` is set). If you're unsure, use `get_pull_request` to read the PR and get the `headRefName` field.
 
@@ -194,7 +194,16 @@ dispatch_workflow({
     "scenario": "smoke"
   }
 })
+
+dispatch_workflow({
+  "workflow": "review.agent",
+  "inputs": {
+    "pr_number": "<PR number>"
+  }
+})
 ```
+
+The review workflow runs a multi-model expert code review on the PR. This is dispatched via `workflow_dispatch` to bypass the approval gate that blocks `pull_request`-triggered workflows for bot-created PRs.
 
 ## Step 9: Post Summary
 
@@ -204,6 +213,7 @@ Post an `add_comment` on issue #${{ github.event.issue.number || inputs.issue_nu
 - Test results (unit tests passed/failed count)
 - Review summary (findings found and fixed)
 - Integration test dispatch status
+- Expert review dispatch status
 - **For visual changes:** note that screenshots are available in the integration test CI artifacts (link to the workflow run)
 
 ## Rules


### PR DESCRIPTION
## Summary

Closes the last gaps in the agent-fix pipeline so it runs **fully end-to-end** without human intervention:

**label issue → agent implements fix → self-review → non-draft PR → integration tests + expert review dispatched → auto-fix if tests fail**

## Changes

1. **`draft: false`** — PRs are now created as non-draft, so `review-on-open.agent` can trigger on `ready_for_review`
2. **Dispatch `review.agent` directly** — bypasses the `action_required` approval gate that blocks `pull_request`-triggered workflows for bot-created PRs
3. **Increase dispatch max** from 2 → 3 (verify-build + integration + review)
4. **Updated Step 8** — instructions now include dispatching the expert review with `pr_number`
5. **Recompiled lock file** — `gh aw compile` auto-detected `review.agent` as a gh-aw workflow and added `.lock.yml` extension mapping

## Pipeline Flow (after this PR)

```
Issue labeled 'agent-fix'
  → Agent reads issue, explores code, implements fix
  → 3-model self-review (Opus 4.6, Sonnet 4.6, GPT-5.3-Codex)
  → Non-draft PR created
  → Dispatches: verify-build + polypilot-integration + review.agent
  → If tests fail: auto-fix-on-failure dispatches /fix
  → Result: fully reviewed, tested PR ready for merge
```

## Context

This is the final piece of the pipeline work started across PRs #755 (integration test fixes), #756 (auto-fix-on-failure), and #757 (run-name embedding for PR discovery). Those PRs fixed bugs that prevented the existing pipeline from completing.