### PR TITLE
fix: remove hallucinated rate-limit: frontmatter feature

### DIFF
--- a/.claude/skills/gh-aw-guide/SKILL.md
+++ b/.claude/skills/gh-aw-guide/SKILL.md
@@ -397,10 +397,6 @@ resources:                                                       # Companion fil
 labels: ["automation", "ci"]                                     # For gh aw status --label filtering
 checkout: false                                                  # Skip repo checkout (for workflows that only use MCP/API, no source needed)
 
-rate-limit:                  # Throttle slash commands to prevent abuse
-  max: 5                     # Max invocations per window
-  window: 60                 # Window in seconds
-
 runtimes:                    # Override default runtime versions
   dotnet:
     version: "9.0"
@@ -431,8 +427,6 @@ tools:
 **Claude engine (v0.71.0+)** — The deprecated `bypassPermissions` flag is replaced by `acceptEdits`. If you maintain Claude-engine workflows, ensure you're on a compiler version that emits `acceptEdits` in the lock file (v0.71.0+). Older compiler versions generate non-functional Claude workflows.
 
 **`checkout: false`** — Skip the default repository checkout when the workflow doesn't need source code (e.g., ChatOps commands that only call APIs via `web-fetch`). Saves ~10-30s of runner time.
-
-**`rate-limit:`** — Throttle slash command invocations to prevent abuse or accidental spam. The `max` field limits invocations per `window` seconds. Useful for commands that call external APIs or create issues.
 
 **Available tools:** `web-fetch` (fetch URLs), `bash` (shell commands), GitHub MCP toolsets (`pull_requests`, `repos`, `issues`, etc.). Use `tools: [web-fetch]` for workflows that call external APIs.
 


### PR DESCRIPTION
Removes `rate-limit:` from SKILL.md — it doesn't exist in gh-aw. Verified against official frontmatter and command-triggers references.