### PR TITLE
Extract shared JsonSerializerOptions to eliminate duplicate allocations

### DIFF
--- a/PolyPilot.Tests/PolyPilot.Tests.csproj
+++ b/PolyPilot.Tests/PolyPilot.Tests.csproj
@@ -34,6 +34,7 @@
     <Compile Include="../PolyPilot/Models/AuditLogEntry.cs" Link="Shared/AuditLogEntry.cs" />
     <Compile Include="../PolyPilot/Models/BridgeMessages.cs" Link="Shared/BridgeMessages.cs" />
     <Compile Include="../PolyPilot/Models/ConnectionSettings.cs" Link="Shared/ConnectionSettings.cs" />
+    <Compile Include="../PolyPilot/Models/JsonDefaults.cs" Link="Shared/JsonDefaults.cs" />
     <Compile Include="../PolyPilot/Models/PlatformHelper.cs" Link="Shared/PlatformHelper.cs" />
     <Compile Include="../PolyPilot/Models/PlatformPaths.cs" Link="Shared/PlatformPaths.cs" />
     <Compile Include="../PolyPilot/Models/SessionOrganization.cs" Link="Shared/SessionOrganization.cs" />

--- a/PolyPilot/Models/ConnectionSettings.cs
+++ b/PolyPilot/Models/ConnectionSettings.cs
@@ -331,9 +331,9 @@ public class ConnectionSettings
             Directory.CreateDirectory(dir);
 #if IOS || ANDROID
             SaveMobileSecretsIfDirty();
-            var json = JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(this, JsonDefaults.Indented);
 #else
-            var json = JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(this, JsonDefaults.Indented);
 #endif
             File.WriteAllText(SettingsPath, json);
         }

--- a/PolyPilot/Models/JsonDefaults.cs
+++ b/PolyPilot/Models/JsonDefaults.cs
@@ -1,0 +1,8 @@
+using System.Text.Json;
+
+namespace PolyPilot.Models;
+
+internal static class JsonDefaults
+{
+    internal static readonly JsonSerializerOptions Indented = new() { WriteIndented = true };
+}

--- a/PolyPilot/Services/CopilotService.Events.cs
+++ b/PolyPilot/Services/CopilotService.Events.cs
@@ -1493,7 +1493,7 @@ public partial class CopilotService
                     if (!string.IsNullOrEmpty(val)) return val;
                 }
             }
-            var json = JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(result, JsonDefaults.Indented);
             if (json != "{}" && json != "null") return json;
         }
         catch { }

--- a/PolyPilot/Services/CopilotService.Organization.cs
+++ b/PolyPilot/Services/CopilotService.Organization.cs
@@ -455,7 +455,7 @@ public partial class CopilotService
                     DeletedRepoGroupRepoIds = new HashSet<string>(Organization.DeletedRepoGroupRepoIds)
                 };
             }
-            var json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(snapshot, JsonDefaults.Indented);
             WriteOrgFile(json);
         }
         catch (Exception ex)
@@ -3056,7 +3056,7 @@ public partial class CopilotService
         try
         {
             Directory.CreateDirectory(PolyPilotBaseDir);
-            var json = JsonSerializer.Serialize(pending, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(pending, JsonDefaults.Indented);
             var tmp = PendingOrchestrationFile + ".tmp";
             File.WriteAllText(tmp, json);
             File.Move(tmp, PendingOrchestrationFile, overwrite: true);

--- a/PolyPilot/Services/CopilotService.Persistence.cs
+++ b/PolyPilot/Services/CopilotService.Persistence.cs
@@ -156,7 +156,7 @@ public partial class CopilotService
                 Debug($"Failed to merge existing sessions: {ex.Message}");
             }
             
-            var json = JsonSerializer.Serialize(entries, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(entries, JsonDefaults.Indented);
             // Atomic write: write to temp file then rename to prevent corruption on crash
             var tempFile = ActiveSessionsFile + ".tmp";
             File.WriteAllText(tempFile, json);
@@ -1458,7 +1458,7 @@ public partial class CopilotService
         {
             // Ensure directory exists (required on iOS where it may not exist by default)
             Directory.CreateDirectory(PolyPilotBaseDir);
-            var json = JsonSerializer.Serialize(aliases, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(aliases, JsonDefaults.Indented);
             File.WriteAllText(SessionAliasesFile, json);
         }
         catch { }
@@ -1554,7 +1554,7 @@ public partial class CopilotService
                     .ToList();
                 if (kept.Count != entries.Count)
                 {
-                    var updatedJson = JsonSerializer.Serialize(kept, new JsonSerializerOptions { WriteIndented = true });
+                    var updatedJson = JsonSerializer.Serialize(kept, JsonDefaults.Indented);
                     var tempFile = ActiveSessionsFile + ".tmp";
                     File.WriteAllText(tempFile, updatedJson);
                     File.Move(tempFile, ActiveSessionsFile, overwrite: true);

--- a/PolyPilot/Services/CopilotService.cs
+++ b/PolyPilot/Services/CopilotService.cs
@@ -1963,7 +1963,7 @@ public partial class CopilotService : IAsyncDisposable
             // Write merged config back to mcp-config.json so the CLI auto-reads it.
             // This is more reliable than --additional-mcp-config for persistent servers.
             var merged = new Dictionary<string, object> { ["mcpServers"] = allServers };
-            var json = JsonSerializer.Serialize(merged, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(merged, JsonDefaults.Indented);
             File.WriteAllText(configPath, json);
         }
         catch (Exception ex)

--- a/PolyPilot/Services/RepoManager.cs
+++ b/PolyPilot/Services/RepoManager.cs
@@ -356,7 +356,7 @@ public class RepoManager
         {
             var stateFile = StateFile; // resolve once
             Directory.CreateDirectory(Path.GetDirectoryName(stateFile)!);
-            var json = JsonSerializer.Serialize(_state, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(_state, JsonDefaults.Indented);
             // Atomic write: write to .tmp then rename, so a crash during write
             // doesn't leave repos.json truncated/corrupt.
             var tmp = stateFile + ".tmp";

--- a/PolyPilot/Services/ScheduledTaskService.cs
+++ b/PolyPilot/Services/ScheduledTaskService.cs
@@ -490,7 +490,7 @@ public class ScheduledTaskService : IDisposable
             {
                 var dir = Path.GetDirectoryName(TasksFilePath)!;
                 Directory.CreateDirectory(dir);
-                var json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true });
+                var json = JsonSerializer.Serialize(snapshot, JsonDefaults.Indented);
                 var tempPath = TasksFilePath + "." + Guid.NewGuid().ToString("N") + ".tmp";
                 File.WriteAllText(tempPath, json);
                 File.Move(tempPath, TasksFilePath, overwrite: true);


### PR DESCRIPTION
Replace 11 inline `new JsonSerializerOptions { WriteIndented = true }` allocations across 7 files with a shared `JsonDefaults.Indented` static readonly field.

Each inline call allocated a new `JsonSerializerOptions` instance on every invocation, bypassing System.Text.Json's internal caching. The shared `static readonly` field is safe here — `JsonSerializerOptions` is a pure BCL type with no platform API dependencies.

## Changes
- **New**: `PolyPilot/Models/JsonDefaults.cs` — `internal static class` with `Indented` field
- **Modified** (11 call sites across 7 files):
  - `CopilotService.Events.cs` (line 1496)
  - `CopilotService.Organization.cs` (lines 458, 3059)
  - `CopilotService.Persistence.cs` (lines 159, 1461, 1557)
  - `CopilotService.cs` (line 1966)
  - `RepoManager.cs` (line 359)
  - `ScheduledTaskService.cs` (line 493)
  - `ConnectionSettings.cs` (lines 334, 336)
- **Test project**: added `<Compile Include>` for `JsonDefaults.cs`

## Verification
- `dotnet build PolyPilot/PolyPilot.csproj -f net10.0-maccatalyst` ✅ 0 errors
- `dotnet test PolyPilot.Tests/PolyPilot.Tests.csproj` ✅ 3565 passed, 0 failed

Zero behavioral change — pure mechanical refactor.