### PR TITLE
fix: skip Report Results when pr_number is 0

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -94,7 +94,7 @@ jobs:
     name: Report Results
     runs-on: ubuntu-latest
     needs: [test, build-catalyst, build-windows]
-    if: always()
+    if: always() && inputs.pr_number > 0
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
When dispatched by agent-fix safe-outputs, `pr_number` defaults to 0 (the PR hasn't been created yet). The Report Results job tried to `gh pr comment 0` which fails.

Add `inputs.pr_number > 0` guard, matching what `polypilot-integration.yml` already does.