### PR TITLE
docs: fill 10 P2 gaps from exhaustive v0.68.4–v0.71.1 audit

### DIFF
--- a/.claude/skills/gh-aw-guide/SKILL.md
+++ b/.claude/skills/gh-aw-guide/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 
 This skill provides a complete reference for building, securing, and maintaining GitHub Agentic Workflows. It covers the gh-aw platform's architecture, security model, and all available features.
 
-> **Version baseline:** This guide targets **v0.68.3** (the default version installed with `gh extension install github/gh-aw`). Features from later versions are marked with their minimum version (e.g., `(v0.70.0+)`). When using a feature marked with a version tag, verify your compiler version with `gh aw --version` and upgrade if needed: `gh extension install github/gh-aw --pin <version>`.
+> **Version baseline:** This guide covers features through **v0.71.1**. A fresh `gh extension install github/gh-aw` gets the latest release. Features introduced after v0.68.3 are marked with their minimum version (e.g., `(v0.70.0+)`). Verify your compiler version with `gh aw --version` and upgrade if needed: `gh extension install github/gh-aw --pin <version>`.
 
 ## Quick Start
 
@@ -79,8 +79,9 @@ gh aw upgrade                 # Upgrade gh-aw CLI extension
 | Triggering CI on agent-created PRs | `github-token-for-extra-empty-commit:` on `create-pull-request` | [Triggering CI](https://github.github.com/gh-aw/reference/triggering-ci/) |
 | No guard against agent approving PRs | `allowed-events: [COMMENT]` on `submit-pull-request-review`; or `[COMMENT, REQUEST_CHANGES]` with `supersede-older-reviews: true` to auto-dismiss stale blocking reviews | [Safe Outputs](https://github.github.com/gh-aw/reference/safe-outputs-pull-requests/) |
 | Stale blocking reviews from previous `/review` runs | `supersede-older-reviews: true` on `submit-pull-request-review` — dismisses older same-workflow `REQUEST_CHANGES` reviews after posting replacement | [Safe Outputs](https://github.github.com/gh-aw/reference/safe-outputs-pull-requests/) |
-| Merging PRs via shell `gh pr merge` in post-steps | Use `push-to-pull-request-branch` + branch protection auto-merge, or `dispatch-workflow` to trigger a merge workflow | [Safe Outputs](https://github.github.com/gh-aw/reference/safe-outputs/) |
+| Merging PRs via shell `gh pr merge` in post-steps | `merge-pull-request` safe output (v0.70.0+) — executes in the safe-outputs job with proper permissions | [Safe Outputs](https://github.github.com/gh-aw/reference/safe-outputs/) |
 | Manually updating existing bot comments (delete + repost) | `hide-older-comments: true` on `add-comment` — collapses previous comments before posting new | [Safe Outputs](https://github.github.com/gh-aw/reference/safe-outputs/) |
+| Keeping PR branch up-to-date with base manually | `update-branch: true` on `update-pull-request` (v0.69.0+) — merges latest base into PR branch | [Safe Outputs](https://github.github.com/gh-aw/reference/safe-outputs-pull-requests/) |
 | Replying to inline review comments manually | `reply-to-pull-request-review-comment` safe output — threads replies under existing review comments | [Safe Outputs](https://github.github.com/gh-aw/reference/safe-outputs-pull-requests/) |
 | Resolving review threads manually | `resolve-pull-request-review-thread` safe output — marks review threads as resolved | [Safe Outputs](https://github.github.com/gh-aw/reference/safe-outputs-pull-requests/) |
 | Configuring the GitHub CLI proxy mode | `tools.github.mode: gh-proxy` (v0.70.0+) — official config; old `cli-proxy` feature flag is deprecated | [Engines](https://github.github.com/gh-aw/reference/engines/) |
@@ -472,7 +473,9 @@ on:
 
 **`comment_memory` safe output (v0.69.2+)** — Agents can persist structured memory in a managed issue/PR comment. Memory files are materialized under `/tmp/gh-aw/comment-memory/` before the agent runs and synced back after. Enables stateful agents across runs without external storage.
 
-**`on.needs:` (v0.70.0+)** — Express dependencies on custom `pre_activation`/`activation` jobs, enabling GitHub App credentials to be sourced from upstream job outputs.
+**`on.needs:` (v0.70.0+)** — Express dependencies on custom `pre_activation`/`activation` jobs, enabling GitHub App credentials to be sourced from upstream job outputs. See also `safe-outputs.needs` (v0.69.1+) for credential-supply dependencies in the safe-outputs job.
+
+**`merge-pull-request` safe output (v0.70.0+)** — Merge a PR directly as a safe output. Executes in the safe-outputs job with proper write permissions, not inside the agent container.
 
 **`tools.github.mode: gh-proxy` (v0.70.0+)** — Configure the GitHub CLI proxy feature. The deprecated `cli-proxy` feature flag is scheduled for removal; migrate to this form:
 
@@ -486,7 +489,19 @@ tools:
 
 **`checkout: false`** — Skip the default repository checkout when the workflow doesn't need source code (e.g., ChatOps commands that only call APIs via `web-fetch`). Saves ~10-30s of runner time.
 
+**`engine.max-turns`** — Limit the number of turns the agent can take. Set in the engine block: `engine: { id: copilot, max-turns: 15 }`. Preserved through shared imports (fixed in v0.68.3).
+
+**Available engines:** `copilot` (default), `claude`, `codex`, `crush` (v0.69.0+, replaces OpenCode), `gemini`. See [Engines reference](https://github.github.com/gh-aw/reference/engines/).
+
 **Available tools:** `web-fetch` (fetch URLs), `bash` (shell commands), GitHub MCP toolsets (`pull_requests`, `repos`, `issues`, etc.). Use `tools: [web-fetch]` for workflows that call external APIs.
+
+**MCP config location:** `.github/mcp.json` (v0.68.5+ — previously `.mcp.json` at repo root). Migrate existing configs manually.
+
+**`vulnerability-alerts` permission (v0.69.3+)** — Available as a `GITHUB_TOKEN` permission scope for workflows that need to read security alerts.
+
+### Breaking Changes
+
+**`network.firewall` removed (v0.69.2)** — This deprecated frontmatter key is now rejected by the compiler. Migrate with: `gh aw fix --write`.
 
 Supported runtimes: `node`, `python`, `go`, `uv`, `bun`, `deno`, `ruby`, `java`, `dotnet`, `elixir`.
 

--- a/.claude/skills/gh-aw-guide/SKILL.md
+++ b/.claude/skills/gh-aw-guide/SKILL.md
@@ -291,7 +291,7 @@ safe-outputs:
 
 > **`supersede-older-reviews: true`** — When using `REQUEST_CHANGES`, set this to automatically dismiss older blocking reviews from the same workflow after posting a replacement. This solves the stale-review problem: without it, a `REQUEST_CHANGES` review persists even after the author fixes everything and re-runs `/review`, because gh-aw has no `dismiss-pull-request-review` safe output and the compiler rejects `pull-requests: write`. With `supersede-older-reviews`, the new review replaces the old one (best-effort). This makes `[COMMENT, REQUEST_CHANGES]` a viable option alongside `[COMMENT]`-only.
 
-**3. Integrity filtering** — controls what content the agent can **see** (vs. `roles:` which controls who can **trigger**). The MCP gateway filters content by author trust level:
+**3. Integrity filtering** — controls what content the agent can **see** (vs. `roles:` which controls who can **trigger**). The MCP gateway intercepts GitHub tool calls and filters content by author trust level before the AI engine sees it. Filtered items are logged as `DIFC_FILTERED` events — inspect them with `gh aw logs --filtered-integrity`.
 
 | Level | Who qualifies |
 |-------|--------------|
@@ -301,14 +301,44 @@ safe-outputs:
 | `none` | All content including `FIRST_TIMER` and users with no association |
 | `blocked` | Users in `blocked-users` — always denied, cannot be promoted |
 
+**Defaults:** Public repos default to `min-integrity: approved` when unconfigured. Private repos default to `min-integrity: none`.
+
 ```yaml
 tools:
   github:
     min-integrity: approved        # Default for public repos — only trusted author content
+    allowed-repos: "myorg/*"       # Scope to specific repos (optional; default "all")
     toolsets: [pull_requests, repos]
-    # trusted-users: [contractor-1]   # Elevate specific users to 'approved'
-    # blocked-users: [spam-bot]       # Unconditionally block specific users
-    # approval-labels: [human-reviewed]  # Labels that promote items to 'approved'
+    trusted-users: [contractor-1]  # Elevate specific users to 'approved'
+    blocked-users: [spam-bot]      # Unconditionally block specific users (always denied)
+    approval-labels: [human-reviewed]  # Labels on issues/PRs that promote items to 'approved'
+    integrity-proxy: true          # Set false to disable DIFC proxy for pre-agent gh CLI calls (default true)
+```
+
+**`allowed-repos` scoping:** Restricts which repositories' content the agent can see. Accepts `"all"` (default), `"public"`, or an array of patterns: `["myorg/*", "partner/repo"]`. When specified alongside `min-integrity`, both fields must be present.
+
+**`approval-labels`:** Label names that promote an issue or PR to `approved` integrity regardless of author association. Useful as a human-review gate: a maintainer applies the label, and the agent can then see and act on it. Accepts a static list or a GitHub Actions expression.
+
+**`trusted-users` / `blocked-users` / `approval-labels` — GitHub Actions expressions:** All three fields accept GitHub Actions expressions (e.g., `${{ vars.TRUSTED_CONTRACTORS }}`) in addition to static arrays. This enables centralized management via repository variables or environment variables (`GH_AW_GITHUB_*`).
+
+**Centralized management via `GH_AW_GITHUB_*` environment variables:** Organization-wide integrity settings can be distributed via Actions environment variables prefixed with `GH_AW_GITHUB_` (e.g., `GH_AW_GITHUB_TRUSTED_USERS`). These are merged with per-workflow frontmatter.
+
+**`integrity-proxy: false`:** Disables the DIFC proxy for pre-agent `gh` CLI calls in workflow steps. Only use when you deliberately want to bypass integrity checks for a non-agentic step. Does not affect the MCP gateway filtering.
+
+**Effective integrity computation order:** An item's final integrity level is determined by (highest wins): `blocked-users` (forced deny) → `trusted-users` (forced `approved`) → `approval-labels` (promote to `approved`) → endorsement/disapproval reactions (see below) → author association default.
+
+**Reaction-based integrity (v0.68.2+, `features.integrity-reactions: true`):** Reactions on issues/PRs/comments can dynamically promote or demote integrity:
+
+```yaml
+features:
+  integrity-reactions: true
+tools:
+  github:
+    min-integrity: approved
+    endorsement-reactions: [THUMBS_UP, HEART]   # Promote item to 'approved' (default when feature enabled)
+    disapproval-reactions: [THUMBS_DOWN, CONFUSED]  # Demote item integrity (default when feature enabled)
+    endorser-min-integrity: approved            # Reactor's own integrity required for reaction to count (default: approved)
+    disapproval-integrity: none                 # Integrity level assigned on qualifying disapproval (default: none)
 ```
 
 **Interaction with `roles:`:**

--- a/.github/instructions/gh-aw-workflows.sync.yaml
+++ b/.github/instructions/gh-aw-workflows.sync.yaml
@@ -29,16 +29,6 @@ sources:
     sections: ["Safe Outputs Quick Reference"]
   - url: https://github.github.com/gh-aw/reference/integrity/
     sections: ["Security Boundaries"]
-    coverage_gaps:
-      - "endorsement-reactions / disapproval-reactions (v0.68.2+)"
-      - "approval-labels for promoting items"
-      - "allowed-repos scoping"
-      - "integrity-proxy: false opt-out"
-      - "centralized management via GH_AW_GITHUB_* variables"
-      - "effective integrity computation order"
-      - "DIFC_FILTERED logging and gh aw logs --filtered-integrity"
-      - "public repos auto-apply min-integrity: approved when unconfigured"
-      - "GitHub Actions expressions for blocked-users/trusted-users/approval-labels"
   - url: https://github.github.com/gh-aw/reference/custom-safe-outputs/
     sections: ["Anti-Patterns", "Safe Outputs Quick Reference"]
   - url: https://github.github.com/gh-aw/reference/triggering-ci/


### PR DESCRIPTION
Opus audit of all 11 releases found 10 undocumented author-facing features:

- `merge-pull-request` safe output (v0.70.0) — re-added after confirming in official docs
- `update-branch` on `update-pull-request` (v0.69.0)
- `safe-outputs.needs` for credential supply (v0.69.1)
- `engine.max-turns` tuning knob
- Available engines: copilot, claude, codex, crush (v0.69.0 — replaces OpenCode), gemini
- MCP config at `.github/mcp.json` (v0.68.5, was `.mcp.json`)
- `vulnerability-alerts` permission scope (v0.69.3)
- `network.firewall` breaking removal (v0.69.2) + migration guide
- Version baseline updated to v0.71.1

Also: drift workflow (PR #794) independently found 9 integrity filtering coverage gaps.